### PR TITLE
Generate code action to ignore certain compiler issues.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ExternalFileChange.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ExternalFileChange.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal;
+
+import java.net.URI;
+
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.ltk.core.refactoring.DocumentChange;
+
+public class ExternalFileChange extends DocumentChange {
+
+	private URI file;
+
+	public ExternalFileChange(String name, IDocument document, URI file) {
+		super(name, document);
+		this.file = file;
+	}
+
+	public URI getURI() {
+		return file;
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ResourceUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ResourceUtils.java
@@ -47,6 +47,8 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.jdt.core.IJavaModelMarker;
 import org.eclipse.jdt.core.compiler.IProblem;
+import org.eclipse.lsp4j.RelativePattern;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 import com.google.common.io.CharStreams;
 
@@ -288,7 +290,7 @@ public final class ResourceUtils {
 	 *            the path to convert
 	 * @return a glob pattern prefixed with the path
 	 */
-	public static String toGlobPattern(IPath path) {
+	public static Either<String, RelativePattern> toGlobPattern(IPath path) {
 		if (path == null) {
 			return null;
 		}
@@ -306,9 +308,13 @@ public final class ResourceUtils {
 	 *            whether to end the glob with "/**"
 	 * @return a glob pattern prefixed with the path
 	 */
-	public static String toGlobPattern(IPath path, boolean recursive) {
+	public static Either<String, RelativePattern> toGlobPattern(IPath path, boolean recursive) {
 		if (path == null) {
 			return null;
+		}
+
+		if (path.isAbsolute() && !recursive) {
+			return Either.forRight(new RelativePattern(Either.forRight(path.removeLastSegments(1).toPortableString()), path.lastSegment()));
 		}
 
 		String globPattern = path.toPortableString();
@@ -328,7 +334,7 @@ public final class ResourceUtils {
 			}
 		}
 
-		return globPattern;
+		return Either.forLeft(globPattern);
 	}
 
 	public static String dos2Unix(String str) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/CorrectionMessages.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/CorrectionMessages.java
@@ -434,4 +434,5 @@ public final class CorrectionMessages extends NLS {
 	public static String VarargsWarningsSubProcessor_remove_safevarargs_label;
 	public static String NullAnnotationsCorrectionProcessor_change_local_variable_to_nonNull;
 	public static String QuickAssistProcessor_convert_to_try_with_resource;
+	public static String CodeActionHandler_ignore_compiler_problems;
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/CorrectionMessages.properties
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/CorrectionMessages.properties
@@ -469,3 +469,5 @@ VarargsWarningsSubProcessor_remove_safevarargs_label=Remove @SafeVarargs
 NullAnnotationsCorrectionProcessor_change_local_variable_to_nonNull=Declare ''{0}'' as ''@{1}'' to see the root problem
 
 QuickAssistProcessor_convert_to_try_with_resource=Surround with try-with-resources
+
+CodeActionHandler_ignore_compiler_problems=Ignore compiler problem(s)

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/syntaxserver/SyntaxProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/syntaxserver/SyntaxProjectsManager.java
@@ -54,17 +54,18 @@ import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
 import org.eclipse.lsp4j.DidChangeWatchedFilesRegistrationOptions;
 import org.eclipse.lsp4j.FileSystemWatcher;
+import org.eclipse.lsp4j.RelativePattern;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 public class SyntaxProjectsManager extends ProjectsManager {
 	//@formatter:off
-	private static final List<String> basicWatchers = Arrays.asList(
-			"**/*.java"
+	private static final List<Either<String, RelativePattern>> basicWatchers = Arrays.asList(
+			Either.forLeft("**/*.java")
 			// "**/src/**"
 	);
 	//@formatter:on
 
-	private final Set<String> watchers = new LinkedHashSet<>();
+	private final Set<Either<String, RelativePattern>> watchers = new LinkedHashSet<>();
 
 	private Job registerWatcherJob = new Job("Register Watchers") {
 
@@ -137,14 +138,14 @@ public class SyntaxProjectsManager extends ProjectsManager {
 				JavaLanguageServerPlugin.logException(e.getMessage(), e);
 			}
 			List<FileSystemWatcher> fileWatchers = new ArrayList<>();
-			Set<String> patterns = new LinkedHashSet<>(basicWatchers);
+			Set<Either<String, RelativePattern>> patterns = new LinkedHashSet<>(basicWatchers);
 			patterns.addAll(Stream.of(sources).map(ResourceUtils::toGlobPattern).collect(Collectors.toList()));
 
-			for (String pattern : patterns) {
-				FileSystemWatcher watcher = new FileSystemWatcher(Either.forLeft(pattern));
+			for (Either<String, RelativePattern> pattern : patterns) {
+				FileSystemWatcher watcher = new FileSystemWatcher(pattern);
 				fileWatchers.add(watcher);
 			}
-	
+
 			if (!patterns.equals(watchers)) {
 				JavaLanguageServerPlugin.logInfo(">> registerFeature 'workspace/didChangeWatchedFiles'");
 				DidChangeWatchedFilesRegistrationOptions didChangeWatchedFilesRegistrationOptions = new DidChangeWatchedFilesRegistrationOptions(fileWatchers);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ResourceUtilsTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ResourceUtilsTest.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertTrue;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.lsp4j.RelativePattern;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.junit.Test;
 
 public class ResourceUtilsTest {
@@ -28,11 +30,11 @@ public class ResourceUtilsTest {
 	@Test
 	public void testToGlobPattern() {
 		assertNull(toGlobPattern(null));
-		assertEquals("/foo/bar/**", toGlobPattern(Path.forPosix("/foo/bar")));
-		assertEquals("/foo/bar/**", toGlobPattern(Path.forPosix("/foo/bar/")));
-		assertEquals("**/foo/bar/**", toGlobPattern(Path.forWindows("c:/foo/bar/")));
-		assertEquals("**/foo/bar/**", toGlobPattern(Path.forWindows("c:\\foo\\bar")));
-		assertEquals("/foo/bar/foo.jar", toGlobPattern(Path.forPosix("/foo/bar/foo.jar")));
+		assertEquals(Either.forLeft("/foo/bar/**"), toGlobPattern(Path.forPosix("/foo/bar")));
+		assertEquals(Either.forLeft("/foo/bar/**"), toGlobPattern(Path.forPosix("/foo/bar/")));
+		assertEquals(Either.forLeft("**/foo/bar/**"), toGlobPattern(Path.forWindows("c:/foo/bar/")));
+		assertEquals(Either.forLeft("**/foo/bar/**"), toGlobPattern(Path.forWindows("c:\\foo\\bar")));
+		assertEquals(Either.forRight(new RelativePattern(Either.forRight("/foo/bar"), "foo.jar")), toGlobPattern(Path.forPosix("/foo/bar/foo.jar")));
 	}
 
 	@Test

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandlerTest.java
@@ -326,10 +326,10 @@ public class InitHandlerTest extends AbstractProjectsManagerBasedTest {
 		// 8 basic + 3 project roots
 		assertEquals("Unexpected watchers:\n" + toString(watchers), 12, watchers.size());
 		List<FileSystemWatcher> projectWatchers = watchers.subList(9, 12);
-		assertTrue(projectWatchers.get(0).getGlobPattern().map(Function.identity(), RelativePattern::getPattern).endsWith("/TestProject"));
+		assertTrue(projectWatchers.get(0).getGlobPattern().map(Function.identity(), RelativePattern::getPattern).endsWith("TestProject"));
 		assertTrue(WatchKind.Delete == projectWatchers.get(0).getKind());
-		assertTrue(projectWatchers.get(1).getGlobPattern().map(Function.identity(), RelativePattern::getPattern).endsWith("/maven/salut"));
-		assertTrue(projectWatchers.get(2).getGlobPattern().map(Function.identity(), RelativePattern::getPattern).endsWith("/gradle/simple-gradle"));
+		assertTrue(projectWatchers.get(1).getGlobPattern().map(Function.identity(), RelativePattern::getPattern).endsWith("salut"));
+		assertTrue(projectWatchers.get(2).getGlobPattern().map(Function.identity(), RelativePattern::getPattern).endsWith("simple-gradle"));
 
 		watchers = watchers.subList(0, 9);
 		Collections.sort(watchers, Comparator.comparing(fileSystemWatcher -> fileSystemWatcher.getGlobPattern().map(Function.identity(), RelativePattern::getPattern)));
@@ -373,9 +373,9 @@ public class InitHandlerTest extends AbstractProjectsManagerBasedTest {
 		verify(client, times(1)).registerCapability(any());
 		assertEquals("Unexpected watchers:\n" + toString(watchers), 12, newWatchers.size());
 		projectWatchers = newWatchers.subList(9, 12);
-		assertTrue(projectWatchers.get(0).getGlobPattern().map(Function.identity(), RelativePattern::getPattern).endsWith("/TestProject"));
-		assertTrue(projectWatchers.get(1).getGlobPattern().map(Function.identity(), RelativePattern::getPattern).endsWith("/maven/salut"));
-		assertTrue(projectWatchers.get(2).getGlobPattern().map(Function.identity(), RelativePattern::getPattern).endsWith("/gradle/simple-gradle"));
+		assertTrue(projectWatchers.get(0).getGlobPattern().map(Function.identity(), RelativePattern::getPattern).endsWith("TestProject"));
+		assertTrue(projectWatchers.get(1).getGlobPattern().map(Function.identity(), RelativePattern::getPattern).endsWith("salut"));
+		assertTrue(projectWatchers.get(2).getGlobPattern().map(Function.identity(), RelativePattern::getPattern).endsWith("simple-gradle"));
 
 		newWatchers = watchers.subList(0, 9);
 		Collections.sort(newWatchers, Comparator.comparing(fileSystemWatcher -> fileSystemWatcher.getGlobPattern().map(Function.identity(), RelativePattern::getPattern)));


### PR DESCRIPTION
Generate code action to ignore certain compiler issues.
    
- Fixes redhat-developer/vscode-java#1791
- Some JDT core compiler problems can be ignored using JDT compiler
  settings so offer a code action, "Ignore compiler problem(s)" to do
  this for a given error/warning
- This respects (writes to) `java.settings.url` (if present) on the
  local filesystem and otherwise writes to the project metadata location
- Add testcase