### PR TITLE
Add ability to skip Gradle checksum packaging.

### DIFF
--- a/org.eclipse.jdt.ls.core/pom.xml
+++ b/org.eclipse.jdt.ls.core/pom.xml
@@ -46,6 +46,13 @@
 								import groovy.json.JsonSlurper
 								import groovy.json.JsonOutput
 
+
+								def checksumsFile = new File(project.basedir.absolutePath, "gradle/checksums/checksums.json")
+								if (System.getProperty("eclipse.jdt.ls.skipGradleChecksums") != null &amp;&amp; checksumsFile.exists()) {
+									println "Skipping gradle wrapper validation checksums ..."
+									return
+								}
+
 								def versionUrl = new URL("https://services.gradle.org/versions/all")
 								def versionStr = versionUrl.text;
 								def versionsFile = new File(project.basedir.absolutePath, "gradle/checksums/versions.json")
@@ -71,7 +78,6 @@
 									}
 								}
 								def json = JsonOutput.toJson(checksums)
-								def checksumsFile = new File(project.basedir.absolutePath, "gradle/checksums/checksums.json")
 								checksumsFile.write(JsonOutput.prettyPrint(json))
 								println "Wrote to ${checksumsFile}"
 							</source>

--- a/org.eclipse.jdt.ls.product/pom.xml
+++ b/org.eclipse.jdt.ls.product/pom.xml
@@ -256,34 +256,5 @@
 				</plugins>
 			</build>
 		</profile>
-		<profile>
-			<id>fast</id>
-			<!-- 
-			Enable faster builds by targeting a single TP environment.
-			Run the Maven command with specific environment properties:
-			- On MacOS : mvn clean verify -Pfast -Denvironment.os=macosx -Denvironment.ws=cocoa -Denvironment.arch=x86_64
-			- On Win32 : mvn clean verify -Pfast -Denvironment.os=win32 -Denvironment.ws=win32 -Denvironment.arch=x86
-			- On Win64 : mvn clean verify -Pfast -Denvironment.os=win32 -Denvironment.ws=win32 -Denvironment.arch=x86_64
-			- On Linux : mvn clean verify -Pfast -Denvironment.os=linux -Denvironment.ws=gtk -Denvironment.arch=x86_64
-			
-			 -->
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.eclipse.tycho</groupId>
-						<artifactId>target-platform-configuration</artifactId>
-						<configuration>
-							<environments>
-								<environment>
-									<os>${environment.os}</os>
-									<ws>${environment.ws}</ws>
-									<arch>${environment.arch}</arch>
-								</environment>
-							</environments>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
 	</profiles>
 </project>


### PR DESCRIPTION
- For developer build workflows it can be useful to be able to build the
  JDT-LS core bundle faster

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>