### PR TITLE
Add "Surround With Try-With" code assist proposal.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/CorrectionMessages.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/CorrectionMessages.java
@@ -427,4 +427,5 @@ public final class CorrectionMessages extends NLS {
 	public static String VarargsWarningsSubProcessor_add_safevarargs_to_method_label;
 	public static String VarargsWarningsSubProcessor_remove_safevarargs_label;
 	public static String NullAnnotationsCorrectionProcessor_change_local_variable_to_nonNull;
+	public static String QuickAssistProcessor_convert_to_try_with_resource;
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/CorrectionMessages.properties
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/CorrectionMessages.properties
@@ -460,3 +460,5 @@ VarargsWarningsSubProcessor_add_safevarargs_to_method_label=Add @SafeVarargs to 
 VarargsWarningsSubProcessor_remove_safevarargs_label=Remove @SafeVarargs
 
 NullAnnotationsCorrectionProcessor_change_local_variable_to_nonNull=Declare ''{0}'' as ''@{1}'' to see the root problem
+
+QuickAssistProcessor_convert_to_try_with_resource=Surround with try-with-resources

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
@@ -518,6 +518,10 @@ public class QuickFixProcessor {
 				LocalCorrectionsSubProcessor.getMissingEnumConstantCaseProposals(context, problem, proposals);
 				LocalCorrectionsSubProcessor.addCasesOmittedProposals(context, problem, proposals);
 				break;
+			case IProblem.UnclosedCloseable:
+			case IProblem.PotentiallyUnclosedCloseable:
+				LocalCorrectionsSubProcessor.getTryWithResourceProposals(context, problem, proposals);
+				break;
 			// case IProblem.MissingSynchronizedModifierInInheritedMethod:
 			// ModifierCorrectionSubProcessor.addSynchronizedMethodProposal(context,
 			// problem, proposals);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/LocalCorrectionsSubProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/LocalCorrectionsSubProcessor.java
@@ -169,6 +169,9 @@ public class LocalCorrectionsSubProcessor {
 			}
 		}
 
+		//Surround with try-with
+		getTryWithResourceProposals(context, problem, proposals);
+
 		//Catch exception
 		BodyDeclaration decl = ASTResolving.findParentBodyDeclaration(selectedNode);
 		if (decl == null) {
@@ -1039,6 +1042,18 @@ public class LocalCorrectionsSubProcessor {
 					proposals.add(proposal);
 					break;
 				}
+			}
+		}
+	}
+
+	public static void getTryWithResourceProposals(IInvocationContext context, IProblemLocationCore problem, Collection<ChangeCorrectionProposal> proposals) {
+		ASTNode coveringNode = problem.getCoveringNode(context.getASTRoot());
+		if (coveringNode != null) {
+			try {
+				ArrayList<ASTNode> coveredNodes = QuickAssistProcessor.getFullyCoveredNodes(context, coveringNode);
+				QuickAssistProcessor.getTryWithResourceProposals(context, coveringNode, coveredNodes, proposals);
+			} catch (IllegalArgumentException | CoreException e) {
+				JavaLanguageServerPlugin.logException(e);
 			}
 		}
 	}


### PR DESCRIPTION
- Fixes redhat-developer/vscode-java#2128
- Add it as a quick-fix for UnclosedCloseable &
  PotentiallyUnclosedCloseable as well as UnhandledException &
  UnhandledExceptionOnAutoClose as a quick-assist
- Update Target Platform to pick up newly migrated API to
  jdt.core.manipulation

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>