### PR TITLE
Adjust m2e repository due to release of 1.18.2

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -21,7 +21,7 @@
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.m2e.logback.feature.feature.group" version="0.0.0"/>
-	        <repository location="https://download.eclipse.org/technology/m2e/snapshots/1.18.2/latest/"/>
+	        <repository location="https://download.eclipse.org/technology/m2e/releases/1.18.2/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.equinox.core.feature.feature.group" version="0.0.0"/>


### PR DESCRIPTION
- Reference the m2e release repository for 1.18.2 instead of snapshots

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>