### PR TITLE
Prevent StringIndexOutOfBoundsException on textDocument/signatureHelp

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpContext.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpContext.java
@@ -123,7 +123,7 @@ public class SignatureHelpContext {
 		}
 
 		String source = unit.getSource();
-		if (source == null) {
+		if (source == null || triggerOffset >= source.length()) {
 			return;
 		}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandlerTest.java
@@ -181,6 +181,20 @@ public class SignatureHelpHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertEquals(0, help.getSignatures().size());
 	}
 
+	@Test
+	public void testSignatureHelp_endOfDoc() throws JavaModelException {
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E {\n");
+		buf.append("   public int bar(String s) {  }\n");
+		buf.append("}\n");
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+		SignatureHelp help = getSignatureHelp(cu, 3, 2);
+		assertNotNull(help);
+		assertEquals(0, help.getSignatures().size());
+	}
+
 	// See https://github.com/eclipse/eclipse.jdt.ls/pull/1015#issuecomment-487997215
 	@Test
 	public void testSignatureHelp_parameters() throws JavaModelException {


### PR DESCRIPTION
... when invoking signatureHelp at the end of the document.

Fixes #2606