### PR TITLE
"Surround with try/catch" Code Action

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/RefactorProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/RefactorProcessor.java
@@ -58,6 +58,7 @@ import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.StructuralPropertyDescriptor;
 import org.eclipse.jdt.core.dom.Type;
 import org.eclipse.jdt.core.dom.VariableDeclaration;
@@ -93,6 +94,7 @@ import org.eclipse.jdt.internal.ui.fix.LambdaExpressionsCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.MultiFixMessages;
 import org.eclipse.jdt.internal.ui.text.correction.IProblemLocationCore;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.corext.refactoring.surround.SurroundWithTryCatchRefactoring;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.ASTRewriteRemoveImportsCorrectionProposal;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.CUCorrectionProposal;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.ChangeCorrectionProposal;
@@ -154,6 +156,7 @@ public class RefactorProcessor {
 				getIntroduceParameterProposals(params, context, coveringNode, locations, proposals);
 				getExtractInterfaceProposal(params, context, proposals);
 				getChangeSignatureProposal(params, context, proposals);
+				getSurroundWithTryCatchProposal(context, proposals);
 			}
 			return proposals;
 		}
@@ -1019,5 +1022,61 @@ public class RefactorProcessor {
 
 		proposals.add(proposal);
 		return true;
+	}
+
+	private boolean getSurroundWithTryCatchProposal(IInvocationContext context, Collection<ChangeCorrectionProposal> proposals) {
+		if (proposals == null) {
+			return false;
+		}
+
+		if(context.getSelectionLength() <= 0) {
+			return false;
+		}
+
+		ICompilationUnit cu = context.getCompilationUnit();
+
+		CompilationUnit astRoot = context.getASTRoot();
+		ASTNode selectedNode = context.getCoveredNode();
+		if (selectedNode == null) {
+			return false;
+		}
+
+		while (selectedNode != null && !(selectedNode instanceof Statement) && !(selectedNode instanceof VariableDeclarationExpression) && !(selectedNode.getLocationInParent() == LambdaExpression.BODY_PROPERTY)
+				&& !(selectedNode instanceof MethodReference)) {
+			selectedNode = selectedNode.getParent();
+		}
+		if (selectedNode == null) {
+			return false;
+		}
+
+		int offset = selectedNode.getStartPosition();
+		int length = selectedNode.getLength();
+		int selectionEnd = context.getSelectionOffset() + context.getSelectionLength();
+
+		if (selectionEnd > offset + length) {
+			// extend the selection if more than one statement is selected (bug 72149)
+			length = selectionEnd - offset;
+		}
+
+		try {
+			SurroundWithTryCatchRefactoring refactoring = SurroundWithTryCatchRefactoring.create(cu, offset, length);
+
+			if (!refactoring.checkActivationBasics(astRoot).isOK()) {
+				return false;
+			}
+
+			refactoring.setLeaveDirty(true);
+
+			String label = CorrectionMessages.LocalCorrectionsSubProcessor_surroundwith_trycatch_description;
+			RefactoringCorrectionProposal proposal = new RefactoringCorrectionProposal(label, CodeActionKind.Refactor, cu, refactoring, IProposalRelevance.SURROUND_WITH_TRY_CATCH);
+			proposal.setLinkedProposalModel(refactoring.getLinkedProposalModel());
+
+			proposals.add(proposal);
+			return true;
+		} catch (CoreException e) {
+			JavaLanguageServerPlugin.log(e);
+		}
+
+		return false;
 	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/ExtractMethodTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/ExtractMethodTest.java
@@ -446,7 +446,7 @@ public class ExtractMethodTest extends AbstractSelectionTest {
 		//@formatter:on
 		Range range = new Range(new Position(4, 14), new Position(4, 32));
 		List<Either<Command, CodeAction>> codeActions = evaluateCodeActions(cu, range);
-		assertEquals(4, codeActions.size());
+		assertEquals(5, codeActions.size());
 		List<Either<Command, CodeAction>> extractMethod = codeActions.stream().filter((c) -> c.getRight().getTitle().equals("Extract to method")).collect(Collectors.toList());
 		Expected e1 = new Expected("Extract to method", expected, JavaCodeActionKind.REFACTOR_EXTRACT_METHOD);
 		assertCodeActions(extractMethod, e1);


### PR DESCRIPTION
This PR adds a "Surround with try/catch" proposal to the `RefactorProcessor`. That way, one can surround a block of code (selection range) with a try/catch block. This is especially useful when one is guarding against `RuntimeException`s.

The code in RefactorProcessor.getSurroundWithTryCatchProposal was based on `LocalCorrectionsSubProcessor.addUncaughtExceptionProposals`.