### PR TITLE
Improve chain completion by waiting for either main or context chains.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/ChainCompletionProposalComputer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/ChainCompletionProposalComputer.java
@@ -132,7 +132,7 @@ public class ChainCompletionProposalComputer {
 					// ignore
 				}
 			}, executor);
-			CompletableFuture<Void> future = CompletableFuture.allOf(mainChains, contextChains);
+			CompletableFuture<?> future = CompletableFuture.anyOf(mainChains, contextChains);
 
 			long timeout = Long.parseLong(JavaManipulation.getPreference("recommenders.chain.timeout", cu.getJavaProject()));
 			future.get(timeout, TimeUnit.SECONDS);


### PR DESCRIPTION
This will provide completions from either of the completions processing threads that finish first. Most of the time it will be the main chain completion thread. By doing this we try to minimize the chance we will not get any chain completions when there supposed to be.