### PR TITLE
Add check for workDoneProgress client capability

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -181,6 +181,10 @@ public class ClientPreferences {
 		return v3supported && capabilities.getTextDocument().getSynchronization() != null && isTrue(capabilities.getTextDocument().getSynchronization().getWillSaveWaitUntil());
 	}
 
+	public boolean isWorkDoneProgressSupported() {
+		return v3supported && capabilities.getWindow().getWorkDoneProgress();
+	}
+
 	public boolean isWorkspaceApplyEditSupported() {
 		return capabilities.getWorkspace() != null && isTrue(capabilities.getWorkspace().getApplyEdit());
 	}
@@ -188,6 +192,7 @@ public class ClientPreferences {
 	public boolean isProgressReportSupported() {
 		return Boolean.parseBoolean(extendedClientCapabilities.getOrDefault("progressReportProvider", "false").toString());
 	}
+
 
 	public boolean isClassFileContentSupported() {
 		return Boolean.parseBoolean(extendedClientCapabilities.getOrDefault("classFileContentsSupport", "false").toString());

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ProgressReporterManagerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ProgressReporterManagerTest.java
@@ -110,6 +110,7 @@ public class ProgressReporterManagerTest {
 	@Test
 	public void testJobReporting_WithNotifyProgress() throws InterruptedException {
 		when(clientPreferences.isProgressReportSupported()).thenReturn(false);
+		when(clientPreferences.isWorkDoneProgressSupported()).thenReturn(true);
 		manager.setReportThrottle(275);
 		Job job = new Job("Test Job") {
 			@Override


### PR DESCRIPTION
Adds the appropriate check for the workDoneProgress client capability according to the [spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#serverInitiatedProgress).