### PR TITLE
Fix multiline semantic highlighting for 'record'

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokensVisitor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokensVisitor.java
@@ -39,6 +39,7 @@ import org.eclipse.jdt.core.dom.PackageDeclaration;
 import org.eclipse.jdt.core.dom.ParameterizedType;
 import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.QualifiedType;
+import org.eclipse.jdt.core.dom.RecordDeclaration;
 import org.eclipse.jdt.core.dom.RequiresDirective;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.SimpleType;
@@ -430,6 +431,20 @@ public class SemanticTokensVisitor extends ASTVisitor {
 
 		acceptNodeList(node.arguments());
 		acceptNode(node.getAnonymousClassDeclaration());
+		return false;
+	}
+
+	@Override
+	public boolean visit(RecordDeclaration node) {
+		acceptNode(node.getJavadoc());
+		acceptNodeList(node.modifiers());
+		// Adds token for 'record' keyword. Token type 'MODIFIER' is used to provide the correct highlight colour.
+		addToken(node.getRestrictedIdentifierStartPosition(), 6, TokenType.MODIFIER, 0);
+		acceptNode(node.getName());
+		acceptNodeList(node.typeParameters());
+		acceptNodeList(node.recordComponents());
+		acceptNodeList(node.superInterfaceTypes());
+		acceptNodeList(node.bodyDeclarations());
 		return false;
 	}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SemanticTokensHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SemanticTokensHandlerTest.java
@@ -208,6 +208,7 @@ public class SemanticTokensHandlerTest extends AbstractProjectsManagerBasedTest 
 			.assertNextToken("string", "parameter", "declaration")
 
 			.assertNextToken("private", "modifier")
+			.assertNextToken("record", "modifier")
 			.assertNextToken("InnerRecord", "record", "private", "static", "readonly", "declaration")
 			.assertNextToken("String", "class", "public", "readonly")
 			.assertNextToken("string", "recordComponent", "declaration")


### PR DESCRIPTION
Fixes redhat-developer/vscode-java#1444

Before:
![Screenshot from 2023-08-03 15-47-17](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/f3e70dbd-bb21-4565-8ac4-296ccfba182c)

After:
![Screenshot from 2023-08-03 16-13-57](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/b5f9b2dd-9c74-4396-b527-c23a64e685c3)