### PR TITLE
Update target platform to I20230806-1800

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -29,7 +29,7 @@
             <unit id="org.eclipse.jdt.source.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
             <unit id="org.mockito.mockito-core" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.29-I-builds/I20230801-1800/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.29-I-builds/I20230806-1800/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.xtext.xbase.lib" version="0.0.0"/>


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-java/issues/3232

A related PR - https://github.com/eclipse-jdt/eclipse.jdt.core/pull/1265