### PR TITLE
Fix folding ranges for nested switch statements

### DIFF
--- a/org.eclipse.jdt.ls.tests/projects/maven/foldingRange/src/main/java/org/sample/NestedSwitchFoldingRange.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/foldingRange/src/main/java/org/sample/NestedSwitchFoldingRange.java
@@ -1,0 +1,26 @@
+package org.sample;
+
+public class NestedSwitchFoldingRange {
+    
+    void foo(){
+
+        int x = 1;
+        int y = 2;
+
+        switch(x) {
+            case 1:
+            {
+                switch(y) {
+                    case 1:
+                        System.out.println(y);
+                    case 2:
+                        System.out.println(x);
+                }
+            }
+            case 2:
+            {
+                System.out.println(x);
+            }
+        }
+    }
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/FoldingRangeHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/FoldingRangeHandlerTest.java
@@ -124,6 +124,25 @@ public class FoldingRangeHandlerTest extends AbstractProjectsManagerBasedTest {
 	}
 
 	@Test
+	public void testNestedSwitchFoldingRanges() throws Exception {
+		String className = "org.sample.NestedSwitchFoldingRange";
+		List<FoldingRange> foldingRanges = getFoldingRanges(className);
+		assertTrue(foldingRanges.size() == 8);
+		assertHasFoldingRange(2, 25, null, foldingRanges);
+		assertHasFoldingRange(4, 24, null, foldingRanges);
+
+		// First switch statement
+		assertHasFoldingRange(9, 23, null, foldingRanges);
+		assertHasFoldingRange(10, 18, null, foldingRanges);
+		assertHasFoldingRange(19, 22, null, foldingRanges);
+
+		// Nested switch statement:
+		assertHasFoldingRange(12, 17, null, foldingRanges);
+		assertHasFoldingRange(13, 14, null, foldingRanges);
+		assertHasFoldingRange(15, 16, null, foldingRanges);
+	}
+
+	@Test
 	public void testStaticBlockFoldingRange() throws Exception {
 		String className = "org.sample.StaticBlockFoldingRange";
 		List<FoldingRange> foldingRanges = getFoldingRanges(className);


### PR DESCRIPTION
Fixes redhat-developer/vscode-java#2751

Normal (not collapsed):
![Screenshot from 2023-08-10 16-06-11](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/f3fd980d-e8f6-4a15-ab7b-0fa3dad1719e)

Before fix:
![Screenshot from 2023-08-10 16-09-58](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/85d2c475-4574-453d-90b9-6594dc4ccac1)

After fix:
![Screenshot from 2023-08-10 16-06-34](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/aaebf54f-6406-4370-8326-80f84c380eb1)