### PR TITLE
Update CompletionItemKinds for annotation attributes and records

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -143,7 +143,10 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 																				CompletionItemKind.Variable,
 																				CompletionItemKind.Method,
 																				CompletionItemKind.Text,
-																				CompletionItemKind.Snippet);
+																				CompletionItemKind.Snippet,
+																				CompletionItemKind.Property,
+																				CompletionItemKind.Struct
+																				);
 	// @formatter:on
 
 	/**
@@ -456,6 +459,8 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 				return CompletionItemKind.Interface;
 			} else if (Flags.isEnum(flags)) {
 				return CompletionItemKind.Enum;
+			} else if (Flags.isRecord(flags)) {
+				return CompletionItemKind.Struct;
 			}
 			return CompletionItemKind.Class;
 		case CompletionProposal.FIELD_IMPORT:
@@ -491,6 +496,7 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 			return CompletionItemKind.Method;
 			//text
 		case CompletionProposal.ANNOTATION_ATTRIBUTE_REF:
+			return CompletionItemKind.Property;
 		case CompletionProposal.JAVADOC_BLOCK_TAG:
 		case CompletionProposal.JAVADOC_FIELD_REF:
 		case CompletionProposal.JAVADOC_INLINE_TAG:

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -3178,10 +3178,10 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertNotNull(list);
 		assertEquals(1, list.getItems().size());
 		ci = list.getItems().get(0);
-		assertEquals(CompletionItemKind.Text, ci.getKind());
+		assertEquals(CompletionItemKind.Property, ci.getKind());
 		assertEquals("someMethod : String", ci.getLabel());
 		resolvedItem = server.resolveCompletionItem(ci).join();
-		assertEquals(CompletionItemKind.Text, resolvedItem.getKind());
+		assertEquals(CompletionItemKind.Property, resolvedItem.getKind());
 		documentation = resolvedItem.getDocumentation().getLeft();
 		assertEquals("Default: \"test\"", documentation);
 	}
@@ -3834,6 +3834,52 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		} finally {
 			unit.discardWorkingCopy();
 			proj.delete(true, monitor);
+		}
+	}
+
+
+	@Test
+	public void testCompletion_record() throws Exception{
+		importProjects("eclipse/java17");
+		project = WorkspaceHelper.getProject("java17");
+		ICompilationUnit unit = getWorkingCopy("src/foo/bar/Foo.java", """
+				package foo.bar;
+
+				public class Foo() {
+
+					static record MyRecordKind(int i){}
+
+					private MyRecordKin
+				}
+				""");
+
+		CompletionList list = requestCompletions(unit, "private MyRecordKin");
+
+		assertNotNull(list);
+		assertFalse(list.getItems().isEmpty());
+		CompletionItem item = list.getItems().get(0);
+		assertEquals(CompletionItemKind.Struct, item.getKind());
+		assertEquals("MyRecordKind", item.getInsertText());
+	}
+
+	@Test
+	public void testCompletion_annotationParam() throws Exception {
+		importProjects("eclipse/java17");
+		project = WorkspaceHelper.getProject("java17");
+		ICompilationUnit unit = getWorkingCopy("src/foo/bar/Foo.java", """
+				package foo.bar;
+
+				@Deprecated()
+				public class Foo() {
+				}
+				""");
+
+		CompletionList list = requestCompletions(unit, "@Deprecated(");
+
+		assertNotNull(list);
+		assertFalse(list.getItems().isEmpty());
+		for (CompletionItem item : list.getItems()) {
+			assertEquals(CompletionItemKind.Property, item.getKind());
 		}
 	}
 


### PR DESCRIPTION
Following the remark on https://github.com/redhat-developer/vscode-java/issues/3242#issuecomment-1674583851, I'm updating the Annotation attritbutes to use the `CompletionItemKind.Property` kind.
Before:
<img width="850" alt="Screenshot 2023-08-11 at 16 02 17" src="https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/148698/0bce1cb3-9f21-4b44-980f-16aa754f7d81">

After:
<img width="852" alt="Screenshot 2023-08-11 at 15 08 53" src="https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/148698/2a7bc373-77a3-4632-8e62-ef09bffbde2e">

As well as use the more apt `CompletionItemKind.Struct` kind for records
Before:
<img width="741" alt="Screenshot 2023-08-11 at 16 05 00" src="https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/148698/74ba4e76-c707-40e2-af0d-2305fce64ef1">

After:
<img width="750" alt="Screenshot 2023-08-11 at 15 12 13" src="https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/148698/627902cb-c2eb-45ef-a0fd-6ec1fec82f8f">

