### PR TITLE
Fix multiline semantic highlighting for 'class' and 'interface'

### DIFF
--- a/org.eclipse.jdt.ls.tests/projects/maven/semantic-tokens/src/main/java/foo/Constructors.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/semantic-tokens/src/main/java/foo/Constructors.java
@@ -30,5 +30,7 @@ public class Constructors {
 			this("bar", 0);
 		}
 	}
+	
+	public interface TestInterface{}
 
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SemanticTokensHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SemanticTokensHandlerTest.java
@@ -87,6 +87,7 @@ public class SemanticTokensHandlerTest extends AbstractProjectsManagerBasedTest 
 		TokenAssertionHelper.beginAssertion(classFileUri)
 			.assertNextToken("foo", "namespace")
 			.assertNextToken("public", "modifier")
+			.assertNextToken("class", "modifier")
 			.assertNextToken("bar", "class", "public", "declaration")
 			.assertNextToken("public", "modifier")
 			.assertNextToken("static", "modifier")
@@ -138,6 +139,7 @@ public class SemanticTokensHandlerTest extends AbstractProjectsManagerBasedTest 
 		TokenAssertionHelper.beginAssertion(getURI("Constructors.java"))
 			.assertNextToken("foo", "namespace")
 			.assertNextToken("public", "modifier")
+			.assertNextToken("class", "modifier")
 			.assertNextToken("Constructors", "class", "public", "declaration")
 			.assertNextToken("private", "modifier")
 			.assertNextToken("Constructors", "class", "private", "constructor", "declaration")
@@ -191,10 +193,12 @@ public class SemanticTokensHandlerTest extends AbstractProjectsManagerBasedTest 
 			.assertNextToken("InnerRecord", "record", "protected", "constructor")
 
 			.assertNextToken("protected", "modifier")
+			.assertNextToken("class", "modifier")
 			.assertNextToken("InnerClass", "class", "protected", "generic", "declaration")
 			.assertNextToken("T", "typeParameter", "declaration")
 
 			.assertNextToken("private", "modifier")
+			.assertNextToken("class", "modifier")
 			.assertNextToken("GenericConstructor", "class", "private", "declaration")
 			.assertNextToken("protected", "modifier")
 			.assertNextToken("T", "typeParameter", "declaration")
@@ -215,6 +219,9 @@ public class SemanticTokensHandlerTest extends AbstractProjectsManagerBasedTest 
 			.assertNextToken("integer", "recordComponent", "declaration")
 			.assertNextToken("protected", "modifier")
 			.assertNextToken("InnerRecord", "record", "protected", "constructor", "declaration")
+			.assertNextToken("public", "modifier")
+			.assertNextToken("interface", "modifier")
+			.assertNextToken("TestInterface", "interface", "public", "static", "declaration")
 		.endAssertion();
 	}
 
@@ -379,6 +386,7 @@ public class SemanticTokensHandlerTest extends AbstractProjectsManagerBasedTest 
 			.assertNextToken("lang", "namespace", "documentation")
 			.assertNextToken("String", "class", "public", "readonly", "documentation")
 			.assertNextToken("public", "modifier")
+			.assertNextToken("class", "modifier")
 			.assertNextToken("Javadoc", "class", "public", "declaration")
 
 			.assertNextToken("@code", "keyword", "documentation")


### PR DESCRIPTION
Before:
![Screenshot from 2023-08-21 17-27-37](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/cfb22c2f-d3d7-4d9a-be9f-0c1a6555b3f5)

After: 
![Screenshot from 2023-08-21 17-29-22](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/54a16881-d114-4f90-9947-2bfabd22fdb5)