### PR TITLE
Support python wrapper for Windows

### DIFF
--- a/org.eclipse.jdt.ls.product/scripts/jdtls.bat
+++ b/org.eclipse.jdt.ls.product/scripts/jdtls.bat
@@ -1,0 +1,3 @@
+@echo off
+python %~dp0/jdtls
+pause

--- a/org.eclipse.jdt.ls.product/scripts/jdtls.bat
+++ b/org.eclipse.jdt.ls.product/scripts/jdtls.bat
@@ -1,3 +1,3 @@
 @echo off
-python %~dp0/jdtls
+python %~dp0/jdtls %*
 pause


### PR DESCRIPTION
Hi, after adding jdtls bin to PATH variable on windows you can't run the lsp server because they are python scripts. I know you can use the java command but then you would need to use a different command for Linux and Windows and it requires you to set the options manually.

Adding a simple batch file to the bin directory allows it to be run from path on Windows with just "jdtls". I think putting it in scripts directory would copy it there? Didn't build it myself.

This change is important for editors, particularly for https://github.com/helix-editor/helix/blob/master/languages.toml#L36 to be able to work out of the box.

Discussion about this here https://github.com/helix-editor/helix/discussions/5861.