### PR TITLE
Select suitable JDK to launch Gradle.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
@@ -199,13 +199,13 @@ public class GradleProjectImporter extends AbstractProjectImporter {
 		if (!applies(monitor)) {
 			return;
 		}
-		// run just once at the first project, assuming that all projects are using the same gradle version.
-		inferGradleJavaHome(directories.iterator().next(), monitor);
 		int projectSize = directories.size();
 		SubMonitor subMonitor = SubMonitor.convert(monitor, projectSize + 1);
 		subMonitor.setTaskName(IMPORTING_GRADLE_PROJECTS);
 		JavaLanguageServerPlugin.logInfo(IMPORTING_GRADLE_PROJECTS);
 		subMonitor.worked(1);
+		// run just once at the first project, assuming that all projects are using the same gradle version.
+		inferGradleJavaHome(directories.iterator().next(), monitor);
 		MultiStatus compatibilityStatus = new MultiStatus(IConstants.PLUGIN_ID, -1, "Compatibility issue occurs when importing Gradle projects", null);
 		MultiStatus gradleUpgradeWrapperStatus = new MultiStatus(IConstants.PLUGIN_ID, -1, "Gradle upgrade wrapper", null);
 		for (Path directory : directories) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporterTest.java
@@ -65,6 +65,7 @@ import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
 import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
 import org.eclipse.jdt.ls.core.internal.preferences.Preferences.FeatureStatus;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -79,6 +80,12 @@ import com.google.common.io.Files;
 public class GradleProjectImporterTest extends AbstractGradleBasedTest{
 
 	private static final String GRADLE1_PATTERN = "**/gradle1";
+	private String gradleJavaHome;
+
+	@Before
+	public void setUp() {
+		gradleJavaHome = JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getGradleJavaHome();
+	}
 
 	@Test
 	public void importSimpleGradleProject() throws Exception {
@@ -94,6 +101,7 @@ public class GradleProjectImporterTest extends AbstractGradleBasedTest{
 	public void cleanUp() throws Exception {
 		super.cleanUp();
 		Job.getJobManager().join(CorePlugin.GRADLE_JOB_FAMILY, new NullProgressMonitor());
+		JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setGradleJavaHome(gradleJavaHome);
 	}
 
 	@Test

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleUtilsTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleUtilsTest.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.managers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import org.junit.Test;
+
+public class GradleUtilsTest {
+	@Test
+	public void testGetJdkToLaunchDaemon() {
+		assertEquals("17", GradleUtils.getMajorJavaVersion("17.0.8"));
+		assertEquals("1.8", GradleUtils.getMajorJavaVersion("1.8.0_202"));
+	}
+
+	@Test
+	public void testGetMajorJavaVersion() {
+		File javaHome = GradleUtils.getJdkToLaunchDaemon("10");
+		assertTrue(javaHome.getAbsolutePath().contains("fakejdk" + File.separator + "10"));
+	}
+}


### PR DESCRIPTION
- When the Gradle Java home preference is not set, and the default JDK is not compatible with the project Gradle, try to find compatible JDK if there is one available.