### PR TITLE
The type declaration snippets should generate file headers.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetCompletionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetCompletionProposal.java
@@ -38,6 +38,7 @@ import org.eclipse.jdt.core.compiler.ITerminalSymbols;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.ExpressionStatement;
 import org.eclipse.jdt.core.dom.Initializer;
+import org.eclipse.jdt.core.manipulation.CodeGeneration;
 import org.eclipse.jdt.core.manipulation.CoreASTProvider;
 import org.eclipse.jdt.internal.codeassist.InternalCompletionContext;
 import org.eclipse.jdt.internal.codeassist.complete.CompletionOnFieldType;
@@ -46,6 +47,7 @@ import org.eclipse.jdt.internal.codeassist.complete.CompletionOnSingleNameRefere
 import org.eclipse.jdt.internal.compiler.ast.ASTNode;
 import org.eclipse.jdt.internal.core.manipulation.CodeTemplateContext;
 import org.eclipse.jdt.internal.core.manipulation.CodeTemplateContextType;
+import org.eclipse.jdt.internal.core.manipulation.StubUtility;
 import org.eclipse.jdt.internal.core.manipulation.util.Strings;
 import org.eclipse.jdt.internal.corext.dom.TokenScanner;
 import org.eclipse.jdt.internal.corext.refactoring.structure.ASTNodeSearchUtil;
@@ -578,6 +580,8 @@ public class SnippetCompletionProposal extends CompletionProposal {
 		}
 		CodeTemplateContext context = new CodeTemplateContext(template.getContextTypeId(), cu.getJavaProject(), scc.getRecommendedLineSeprator());
 
+		String fileComment = cu.getTypes().length == 0 ? CodeGeneration.getFileComment(cu, StubUtility.getLineDelimiterUsed(cu.getJavaProject())) : null;
+		context.setVariable(CodeTemplateContextType.FILE_COMMENT, fileComment != null ? fileComment + "\n" : "");
 		context.setVariable(PACKAGEHEADER, scc.getPackageHeader());
 		String typeName = JavaCore.removeJavaLikeExtension(cu.getElementName());
 		List<IType> types = Arrays.asList(cu.getAllTypes());

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/CodeTemplatePreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/CodeTemplatePreferences.java
@@ -119,7 +119,7 @@ public class CodeTemplatePreferences {
 	/**
 	 * Default value for new type
 	 */
-	public static final String CODETEMPLATE_NEWTYPE_DEFAULT = "${filecomment}\n${package_declaration}\n\n${typecomment}\n${type_declaration}";
+	public static final String CODETEMPLATE_NEWTYPE_DEFAULT = "${filecomment}${package_declaration}\n\n${typecomment}\n${type_declaration}";
 	/**
 	 * Default value for field comments
 	 */
@@ -193,28 +193,28 @@ public class CodeTemplatePreferences {
 	/**
 	 * Default value for class snippet body content
 	 */
-	public static final String CODETEMPLATE_CLASSSNIPPET_DEFAULT = "${package_header}class ${type_name} {\n\n\t${cursor}\n}";
+	public static final String CODETEMPLATE_CLASSSNIPPET_DEFAULT = "${filecomment}${package_header}class ${type_name} {\n\n\t${cursor}\n}";
 
 	/**
 	 * Default value for public class snippet body content
 	 */
-	public static final String CODETEMPLATE_CLASSSNIPPET_PUBLIC = "${package_header}/**\n * ${type_name}\n */\npublic class ${type_name} {\n\n\t${cursor}\n}";
+	public static final String CODETEMPLATE_CLASSSNIPPET_PUBLIC = "${filecomment}${package_header}/**\n * ${type_name}\n */\npublic class ${type_name} {\n\n\t${cursor}\n}";
 	/**
 	 * Default value for interface snippet body content
 	 */
-	public static final String CODETEMPLATE_INTERFACESNIPPET_DEFAULT = "${package_header}interface ${type_name} {\n\n\t${cursor}\n}";
+	public static final String CODETEMPLATE_INTERFACESNIPPET_DEFAULT = "${filecomment}${package_header}interface ${type_name} {\n\n\t${cursor}\n}";
 	/**
 	 * Default value for public interface snippet body content
 	 */
-	public static final String CODETEMPLATE_INTERFACESNIPPET_PUBLIC = "${package_header}/**\n * ${type_name}\n */\npublic interface ${type_name} {\n\n\t${cursor}\n}";
+	public static final String CODETEMPLATE_INTERFACESNIPPET_PUBLIC = "${filecomment}${package_header}/**\n * ${type_name}\n */\npublic interface ${type_name} {\n\n\t${cursor}\n}";
 	/**
 	 * Default value for record snippet body content
 	 */
-	public static final String CODETEMPLATE_RECORDSNIPPET_DEFAULT = "${package_header}record ${type_name}(${cursor}) {\n}";
+	public static final String CODETEMPLATE_RECORDSNIPPET_DEFAULT = "${filecomment}${package_header}record ${type_name}(${cursor}) {\n}";
 	/**
 	 * Default value for public record snippet body content
 	 */
-	public static final String CODETEMPLATE_RECORDSNIPPET_PUBLIC = "${package_header}/**\n * ${type_name}\n */\npublic record ${type_name}(${cursor}) {\n}";
+	public static final String CODETEMPLATE_RECORDSNIPPET_PUBLIC = "${filecomment}${package_header}/**\n * ${type_name}\n */\npublic record ${type_name}(${cursor}) {\n}";
 
 	public static class Month extends SimpleTemplateVariableResolver {
 		public Month() {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
@@ -37,6 +37,8 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.manipulation.CodeStyleConfiguration;
 import org.eclipse.jdt.core.manipulation.JavaManipulation;
 import org.eclipse.jdt.internal.core.manipulation.CodeTemplateContextType;
+import org.eclipse.jdt.internal.core.manipulation.CodeTemplateContextType.CodeTemplateVariableResolver;
+import org.eclipse.jdt.internal.core.manipulation.JavaManipulationMessages;
 import org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin;
 import org.eclipse.jdt.internal.core.manipulation.MembersOrderPreferenceCacheCommon;
 import org.eclipse.jdt.internal.core.manipulation.StubUtility;
@@ -111,9 +113,14 @@ public class PreferenceManager {
 		// Register standard context types from JDT
 		CodeTemplateContextType.registerContextTypes(registry);
 		// Register additional context types
-		registry.addContextType(new CodeTemplateContextType(CodeTemplatePreferences.CLASSSNIPPET_CONTEXTTYPE));
-		registry.addContextType(new CodeTemplateContextType(CodeTemplatePreferences.INTERFACESNIPPET_CONTEXTTYPE));
-		registry.addContextType(new CodeTemplateContextType(CodeTemplatePreferences.RECORDSNIPPET_CONTEXTTYPE));
+		for (String contextTypeId : List.of(
+				CodeTemplatePreferences.CLASSSNIPPET_CONTEXTTYPE,
+				CodeTemplatePreferences.INTERFACESNIPPET_CONTEXTTYPE,
+				CodeTemplatePreferences.RECORDSNIPPET_CONTEXTTYPE)) {
+			CodeTemplateContextType contextType = new CodeTemplateContextType(contextTypeId);
+			contextType.addResolver(new CodeTemplateVariableResolver(CodeTemplateContextType.FILE_COMMENT, JavaManipulationMessages.CodeTemplateContextType_variable_description_filecomment));
+			registry.addContextType(contextType);
+		}
 
 		// These should be upstreamed into CodeTemplateContextType & GlobalVariables
 		TemplateContextType tmp = registry.getContextType(CodeTemplateContextType.TYPECOMMENT_CONTEXTTYPE);


### PR DESCRIPTION
- class/interface/record snippets should generate a file header if defined

Before this change, the class/interface/record snippets ignored `java.templates.fileHeader`. Now they should respect it as seen below. This worked correctly for the quick-fixes that generated a new type declaration in a new file (eg. "Create new class '...'" since that code is a bit different. 

![class-snippet-context](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/1417342/598dd007-d985-49f6-a79b-170070fcdf2b)


- [ ] Add a simple testcase for this

@hopehadfield feel free to have a look since you've been looking into the snippets recently.