### PR TITLE
Respect client capabilities for type hierarchy.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -194,6 +194,10 @@ final public class InitHandler extends BaseInitHandler {
 			capabilities.setInlayHintProvider(Boolean.TRUE);
 		}
 
+		if (!preferenceManager.getClientPreferences().isTypeHierarchyDynamicRegistrationSupported()) {
+			capabilities.setTypeHierarchyProvider(Boolean.TRUE);
+		}
+
 		capabilities.setCallHierarchyProvider(Boolean.TRUE);
 		TextDocumentSyncOptions textDocumentSyncOptions = new TextDocumentSyncOptions();
 		textDocumentSyncOptions.setOpenClose(Boolean.TRUE);
@@ -221,7 +225,6 @@ final public class InitHandler extends BaseInitHandler {
 		semanticTokensOptions.setDocumentSelector(List.of(new DocumentFilter("java", "file", null), new DocumentFilter("java", "jdt", null)));
 		semanticTokensOptions.setLegend(SemanticTokensHandler.legend());
 		capabilities.setSemanticTokensProvider(semanticTokensOptions);
-		capabilities.setTypeHierarchyProvider(Boolean.TRUE);
 
 		initializeResult.setCapabilities(capabilities);
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -364,6 +364,10 @@ public class ClientPreferences {
 		return v3supported && isDynamicRegistrationSupported(capabilities.getTextDocument().getCallHierarchy());
 	}
 
+	public boolean isTypeHierarchyDynamicRegistrationSupported() {
+		return v3supported && isDynamicRegistrationSupported(capabilities.getTextDocument().getTypeHierarchy());
+	}
+
 	public boolean isResolveCodeActionSupported() {
 		//@formatter:off
 		return v3supported && capabilities.getTextDocument().getCodeAction() != null


### PR DESCRIPTION
This seems to fix the issue mentioned in https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/2769#issuecomment-1690887502 and it was something I noted originally as the proper approach.