### PR TITLE
documentSymbols to work for Java files that are not resources

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/DocumentAdapter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/DocumentAdapter.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,12 +24,14 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourceAttributes;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.BufferChangedEvent;
 import org.eclipse.jdt.core.IBuffer;
 import org.eclipse.jdt.core.IBufferChangedListener;
 import org.eclipse.jdt.core.IOpenable;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.WorkingCopyOwner;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.IDocument;
@@ -84,8 +87,13 @@ public class DocumentAdapter implements IBuffer, IDocumentListener {
 
 	private Object lock = new Object();
 
-	private IOpenable fOwner;
-	private IFile fFile;
+	private final IOpenable fOwner;
+	private final IFile fFile;
+	/**
+	 * The file Path: in case of a resource, the resource workspace-relative
+	 * full path; in case of a plain file, the filesystem location.
+	 */
+	public final IPath filePath;
 	private boolean fIsClosed;
 
 	private List<IBufferChangedListener> fBufferListeners;
@@ -97,13 +105,32 @@ public class DocumentAdapter implements IBuffer, IDocumentListener {
 	public DocumentAdapter(IOpenable owner, IFile file) {
 		fOwner = owner;
 		fFile = file;
+		filePath = file.getFullPath();
 		fBufferListeners = new ArrayList<>(3);
 		fIsClosed = false;
 
 		ITextFileBufferManager manager= FileBuffers.getTextFileBufferManager();
 		try {
-			manager.connect(file.getFullPath(), LocationKind.IFILE, null);
-			fTextFileBuffer= manager.getTextFileBuffer(file.getFullPath(), LocationKind.IFILE);
+			manager.connect(filePath, LocationKind.IFILE, null);
+			fTextFileBuffer= manager.getTextFileBuffer(filePath, LocationKind.IFILE);
+		} catch (CoreException e) {
+		}
+	}
+
+	public DocumentAdapter(IOpenable owner, Path path) {
+		fOwner = owner;
+		fFile = null;
+		filePath = IPath.fromPath(path);
+		fBufferListeners = new ArrayList<>(3);
+		fIsClosed = false;
+
+		ITextFileBufferManager manager= FileBuffers.getTextFileBufferManager();
+		try {
+			manager.connect(filePath, LocationKind.LOCATION, null);
+			fTextFileBuffer= manager.getTextFileBuffer(filePath, LocationKind.LOCATION);
+			if (fTextFileBuffer != null) {
+				fDocument = fTextFileBuffer.getDocument();
+			}
 		} catch (CoreException e) {
 		}
 	}
@@ -154,10 +181,10 @@ public class DocumentAdapter implements IBuffer, IDocumentListener {
 				fDocument.removeDocumentListener(this);
 			}
 
-			if (fTextFileBuffer != null && fFile != null) {
+			if (fTextFileBuffer != null) {
 				try {
 					ITextFileBufferManager manager= FileBuffers.getTextFileBufferManager();
-					manager.disconnect(fFile.getFullPath(), LocationKind.NORMALIZE, null);
+					manager.disconnect(filePath, fFile != null ? LocationKind.NORMALIZE : LocationKind.LOCATION, null);
 				} catch (CoreException x) {
 					// ignore
 				}
@@ -229,7 +256,9 @@ public class DocumentAdapter implements IBuffer, IDocumentListener {
 		if (fTextFileBuffer != null) {
 			return fTextFileBuffer.isCommitable();
 		}
-
+		if (fFile == null) {
+			return filePath.toFile().canWrite();
+		}
 		ResourceAttributes attributes = fFile.getResourceAttributes();
 		return attributes != null ? attributes.isReadOnly() : false;
 	}
@@ -272,7 +301,7 @@ public class DocumentAdapter implements IBuffer, IDocumentListener {
 					fDocument = fTextFileBuffer.getDocument();
 				} else {
 					ITextFileBufferManager manager= FileBuffers.getTextFileBufferManager();
-					fDocument =  manager.createEmptyDocument(fFile.getFullPath(), LocationKind.IFILE);
+					fDocument =  manager.createEmptyDocument(filePath, fFile != null ? LocationKind.IFILE : LocationKind.LOCATION);
 				}
 				fDocument.addDocumentListener(this);
 				((ISynchronizable)fDocument).setLockObject(lock);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
@@ -256,7 +256,21 @@ public final class JDTUtils {
 
 		IProject project = JavaLanguageServerPlugin.getProjectsManager().getDefaultProject();
 		if (project == null || !project.isAccessible()) {
-			return null;
+			String fileName = path.getFileName().toString();
+			if (fileName.endsWith(".java") || fileName.endsWith(".class")) {
+				fileName = fileName.substring(0, fileName.lastIndexOf('.'));
+			}
+			WorkingCopyOwner owner = new WorkingCopyOwner() {
+				@Override
+				public IBuffer createBuffer(ICompilationUnit workingCopy) {
+					return new DocumentAdapter(workingCopy, path);
+				}
+ 			};
+ 			try {
+ 				return owner.newWorkingCopy(fileName, new IClasspathEntry[] { JavaRuntime.getDefaultJREContainerEntry() }, monitor);
+ 			} catch (JavaModelException e) {
+				return null;
+			}
 		}
 		IJavaProject javaProject = JavaCore.create(project);
 
@@ -959,7 +973,20 @@ public final class JDTUtils {
 	 * @return
 	 */
 	public static String toURI(ICompilationUnit cu) {
-		return getFileURI(cu.getResource());
+		if (cu.getResource() != null) {
+			String uri = getFileURI(cu.getResource());
+			if (uri != null) {
+				return uri;
+			}
+		}
+		try {
+			if (cu.getBuffer() instanceof DocumentAdapter adapter) {
+				return adapter.filePath.toFile().toURI().toString();
+			}
+		} catch (JavaModelException ex) {
+			JavaLanguageServerPlugin.logException(ex);
+		} 
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
The makes that the documentSymbols (and probably some other requests) capable of processing files that are not imported in any way in the workspace.
It consists of mainly
* Adding capability to create an ICompilationUnit for those files
* Adding extra-logic to resolve an URI for ICompilationUnit that are not backed by an IFile.

Fixes https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/2809