### PR TITLE
Add new API 'onWillUpdate()' to IBuildSupport

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ProjectConfigurationUpdateHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ProjectConfigurationUpdateHandler.java
@@ -41,12 +41,9 @@ public class ProjectConfigurationUpdateHandler {
 	 */
 	public void updateConfigurations(List<TextDocumentIdentifier> identifiers) {
 		Collection<IProject> projects = ProjectUtils.getProjectsFromDocumentIdentifiers(identifiers);
-
-		for (IProject project : projects) {
-			// most likely the handler is invoked intentionally by the user, that's why
-			// we force the update despite no changes of in build descriptor being made
-			projectManager.updateProject(project, true);
-		}
+		// most likely the handler is invoked intentionally by the user, that's why
+		// we force the update despite no changes of in build descriptor being made
+		projectManager.updateProjects(projects, true);
 	}
 
 	public void updateConfiguration(TextDocumentIdentifier param) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
@@ -45,6 +45,14 @@ public interface IBuildSupport {
 	}
 
 	/**
+	 * Implementors can put preparation work into this method. This method will be invoked before {@code update(...)}.
+	 * All build supports named with 'UnknownBuildTool' will be skipped. See: {@link #buildToolName()}.
+	 */
+	default void onWillUpdate(Collection<IProject> projects, IProgressMonitor monitor) throws CoreException {
+		// do nothing
+	}
+
+	/**
 	 *
 	 * @param resource
 	 *            - a project to update

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
@@ -46,7 +46,6 @@ public interface IBuildSupport {
 
 	/**
 	 * Implementors can put preparation work into this method. This method will be invoked before {@code update(...)}.
-	 * All build supports named with 'UnknownBuildTool' will be skipped. See: {@link #buildToolName()}.
 	 */
 	default void onWillUpdate(Collection<IProject> projects, IProgressMonitor monitor) throws CoreException {
 		// do nothing

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IProjectsManager.java
@@ -48,6 +48,11 @@ public interface IProjectsManager {
 	Job updateProject(IProject project, boolean force);
 
 	/**
+	 * Update a set of project configurations.
+	 */
+	Job updateProjects(Collection<IProject> projects, boolean force);
+
+	/**
 	 * Check whether the resource is a build file.
 	 */
 	boolean isBuildFile(IResource resource);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ProjectConfigurationUpdateHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ProjectConfigurationUpdateHandlerTest.java
@@ -38,18 +38,18 @@ public class ProjectConfigurationUpdateHandlerTest extends AbstractProjectsManag
 	public void testUpdateConfiguration() throws Exception {
 		importProjects("maven/multimodule");
 		ProjectsManager pm = mock(ProjectsManager.class);
-		when(pm.updateProject(any(IProject.class), anyBoolean())).thenReturn(null);
+		when(pm.updateProjects(any(), anyBoolean())).thenReturn(null);
 		ProjectConfigurationUpdateHandler handler = new ProjectConfigurationUpdateHandler(pm);
 		IProject project = WorkspaceHelper.getProject("multimodule");
 		handler.updateConfiguration(new TextDocumentIdentifier(project.getLocationURI().toString()));
-		verify(pm, times(1)).updateProject(any(IProject.class), eq(true));
+		verify(pm, times(1)).updateProjects(any(), eq(true));
 	}
 
 	@Test
 	public void testUpdateConfigurations() throws Exception {
 		importProjects("maven/multimodule");
 		ProjectsManager pm = mock(ProjectsManager.class);
-		when(pm.updateProject(any(IProject.class), anyBoolean())).thenReturn(null);
+		when(pm.updateProjects(any(), anyBoolean())).thenReturn(null);
 		ProjectConfigurationUpdateHandler handler = new ProjectConfigurationUpdateHandler(pm);
 		List<TextDocumentIdentifier> list = new ArrayList<>();
 		IProject project = WorkspaceHelper.getProject("module1");
@@ -60,6 +60,6 @@ public class ProjectConfigurationUpdateHandlerTest extends AbstractProjectsManag
 		ProjectConfigurationsUpdateParam param = new ProjectConfigurationsUpdateParam(list);
 
 		handler.updateConfigurations(param.getIdentifiers());
-		verify(pm, times(2)).updateProject(any(IProject.class), eq(true));
+		verify(pm, times(1)).updateProjects(any(), eq(true));
 	}
 }


### PR DESCRIPTION
- A new API 'onWillUpdate()' is added to IBuildSupport, which can be used to do some preparation work before updating the project configuration. For example: For the Build Server support, send a reload request to Build Server, then do the real update task in 'update()'.
- When a bunch of projects need to be updated, extract out the invocation of 'registerWatchers()' and 'updateEncoding()'. See: ProjectsManager#updateProjects(Collection<IProject>, boolean force).