### PR TITLE
Do not invoke additional configurators after the Java LS Configurator.

### DIFF
--- a/org.eclipse.jdt.ls.logback.appender/src/org/eclipse/jdt/ls/logback/appender/JavaLsConfigurator.java
+++ b/org.eclipse.jdt.ls.logback.appender/src/org/eclipse/jdt/ls/logback/appender/JavaLsConfigurator.java
@@ -55,6 +55,6 @@ public class JavaLsConfigurator extends ContextAwareBase implements Configurator
 			defMavenFilter.setLevel(Level.INFO);
 			defMavenFilter.setAdditive(false);
 		}
-		return ExecutionStatus.INVOKE_NEXT_IF_ANY;
+		return ExecutionStatus.DO_NOT_INVOKE_NEXT_IF_ANY;
 	}
 }


### PR DESCRIPTION
- Fixes #2837 
- Prevent additional logging configurators from disturbing standard output