### PR TITLE
Correct constructor snippet for additional classes in a file

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/CodeSnippetTemplate.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/CodeSnippetTemplate.java
@@ -110,7 +110,7 @@ class TemplatePreferences {
 	public static final String TRYCATCH_CONTENT = "try {\n" + "\t$$TM_SELECTED_TEXT$${1}\n" + "} catch ($${2:Exception} $${3:e}) {\n" + "\t$${0}// TODO: handle exception\n" + "}";
 	public static final String TRYRESOURCES_CONTENT = "try ($${1}) {\n" + "\t$$TM_SELECTED_TEXT$${2}\n" + "} catch ($${3:Exception} $${4:e}) {\n" + "\t$${0}// TODO: handle exception\n" + "}";
 	public static final String MAIN_CONTENT = "public static void main(String[] args) {\n" + "\t$${0}\n" + "}";
-	public static final String CTOR_CONTENT = "$${1|public,protected,private|} $${2:$$TM_FILENAME_BASE}($${3}) {\n" + "\t$${4:super();}$${0}\n" + "}";
+	public static final String CTOR_CONTENT = "$${1|public,protected,private|} ${enclosing_simple_type}($${2}) {\n" + "\t$${3:super();}$${0}\n" + "}";
 	public static final String METHOD_CONTENT = "$${1|public,protected,private|}$${2| , static |}$${3:void} $${4:name}($${5}) {\n" + "\t$${0}\n" + "}";
 	public static final String NEW_CONTENT = "$${1:Object} $${2:foo} = new $${1}($${3});\n" + "$${0}";
 	public static final String FIELD_CONTENT = "$${1|public,protected,private|} $${2:String} $${3:name};";

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -1283,6 +1283,28 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 	}
 
 	@Test
+	public void testSnippet_ctor() throws JavaModelException {
+		//@formatter:off
+			ICompilationUnit unit = getWorkingCopy(
+				"src/org/sample/Test.java",
+				"package org.sample;\n" +
+				"public class MainClass {\n"
+				+ "}" +
+				"class AnotherClass {\n"
+				+ "ctor\n"
+				+ "}"
+			);
+			//@formatter:on
+		CompletionList list = requestCompletions(unit, "ctor");
+		assertNotNull(list);
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		CompletionItem item = items.get(0);
+		assertEquals("ctor", item.getLabel());
+		String newText = item.getTextEdit().getLeft().getNewText();
+		assertEquals("${1|public,protected,private|} AnotherClass(${2}) {\n" + "\t${3:super();}${0}\n" + "}", newText);
+	}
+
+	@Test
 	public void testSnippet_interface() throws JavaModelException {
 		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java", "");
 		CompletionList list = requestCompletions(unit, "");


### PR DESCRIPTION
Fixes redhat-developer/vscode-java#725

Before:
![Peek 2023-09-07 16-17](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/3c3c200d-aa5c-4b01-9814-ec31b597265d)

After:
![Peek 2023-09-07 16-13](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/318538f7-ace6-49c2-87d3-f2280330d9be)