### PR TITLE
Update target platform to 4.30-I-builds.

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -25,7 +25,7 @@
             <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
             <unit id="org.mockito.mockito-core" version="0.0.0"/>
             <unit id="org.apache.commons.commons-io" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.29-I-builds/I20230806-1800/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.29/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.xtext.xbase.lib" version="0.0.0"/>

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/DiagnosticsCommandTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/DiagnosticsCommandTest.java
@@ -76,9 +76,9 @@ public class DiagnosticsCommandTest extends AbstractProjectsManagerBasedTest {
 	private Preferences mockPreferences() {
 		Preferences mockPreferences = Mockito.mock(Preferences.class);
 		Mockito.when(preferenceManager.getPreferences()).thenReturn(mockPreferences);
-		Mockito.when(preferenceManager.getPreferences(Mockito.any())).thenReturn(mockPreferences);
+		Mockito.lenient().when(preferenceManager.getPreferences(Mockito.any())).thenReturn(mockPreferences);
 		when(this.preferenceManager.getClientPreferences()).thenReturn(clientPreferences);
-		when(clientPreferences.isSupportedCodeActionKind(CodeActionKind.QuickFix)).thenReturn(true);
+		Mockito.lenient().when(clientPreferences.isSupportedCodeActionKind(CodeActionKind.QuickFix)).thenReturn(true);
 		return mockPreferences;
 	}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/NonProjectFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/NonProjectFixTest.java
@@ -83,14 +83,14 @@ public class NonProjectFixTest extends AbstractProjectsManagerBasedTest {
 
 	private Preferences mockPreferences() {
 		Preferences mockPreferences = Mockito.mock(Preferences.class);
-		Mockito.when(preferenceManager.getPreferences()).thenReturn(mockPreferences);
-		Mockito.when(preferenceManager.getPreferences(Mockito.any())).thenReturn(mockPreferences);
+		Mockito.lenient().when(preferenceManager.getPreferences()).thenReturn(mockPreferences);
+		Mockito.lenient().when(preferenceManager.getPreferences(Mockito.any())).thenReturn(mockPreferences);
 		when(this.preferenceManager.getClientPreferences()).thenReturn(clientPreferences);
 		when(clientPreferences.isSupportedCodeActionKind(CodeActionKind.QuickFix)).thenReturn(true);
 		return mockPreferences;
 	}
 
-	private List<Either<Command, CodeAction>> getCodeActions(ICompilationUnit cu, IProblem problem) throws JavaModelException {		
+	private List<Either<Command, CodeAction>> getCodeActions(ICompilationUnit cu, IProblem problem) throws JavaModelException {
 		CodeActionParams parms = new CodeActionParams();
 		Range range = JDTUtils.toRange(cu, problem.getSourceStart(), 0);
 
@@ -139,7 +139,7 @@ public class NonProjectFixTest extends AbstractProjectsManagerBasedTest {
 			assertEquals(3, action.getCommand().getArguments().size());
 			assertEquals("thisFile", action.getCommand().getArguments().get(1));
 			assertEquals(false, action.getCommand().getArguments().get(2));
-	
+
 			action = actions.get(1).getRight();
 			assertEquals(CodeActionKind.QuickFix, action.getKind());
 			assertEquals(ActionMessages.ReportAllErrorsForAnyNonProjectFile, action.getCommand().getTitle());
@@ -212,7 +212,7 @@ public class NonProjectFixTest extends AbstractProjectsManagerBasedTest {
 			assertEquals(3, action.getCommand().getArguments().size());
 			assertEquals("thisFile", action.getCommand().getArguments().get(1));
 			assertEquals(true, action.getCommand().getArguments().get(2));
-	
+
 			action = actions.get(1).getRight();
 			assertEquals(CodeActionKind.QuickFix, action.getKind());
 			assertEquals(ActionMessages.ReportSyntaxErrorsForAnyNonProjectFile, action.getCommand().getTitle());

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionInsertReplaceCapabilityTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionInsertReplaceCapabilityTest.java
@@ -28,6 +28,7 @@ import org.eclipse.lsp4j.InsertReplaceEdit;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -92,7 +93,7 @@ public class CompletionInsertReplaceCapabilityTest extends AbstractCompilationUn
 	private void mockClient() {
 		// Mock the preference manager to use LSP v3 support.
 		when(preferenceManager.getClientPreferences().isCompletionSnippetsSupported()).thenReturn(true);
-		when(preferenceManager.getClientPreferences().isSignatureHelpSupported()).thenReturn(true);
+		Mockito.lenient().when(preferenceManager.getClientPreferences().isSignatureHelpSupported()).thenReturn(true);
 		when(preferenceManager.getClientPreferences().isCompletionInsertReplaceSupport()).thenReturn(true);
 	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/PrepareRenameHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/PrepareRenameHandlerTest.java
@@ -38,6 +38,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -56,8 +57,8 @@ public class PrepareRenameHandlerTest extends AbstractProjectsManagerBasedTest {
 		this.clientPreferences = preferenceManager.getClientPreferences();
 		when(clientPreferences.isResourceOperationSupported()).thenReturn(false);
 		Preferences p = mock(Preferences.class);
-		when(preferenceManager.getPreferences()).thenReturn(p);
-		when(p.isRenameEnabled()).thenReturn(true);
+		Mockito.lenient().when(preferenceManager.getPreferences()).thenReturn(p);
+		Mockito.lenient().when(p.isRenameEnabled()).thenReturn(true);
 		handler = new PrepareRenameHandler(preferenceManager);
 	}
 
@@ -160,7 +161,7 @@ public class PrepareRenameHandlerTest extends AbstractProjectsManagerBasedTest {
 
 	@Test
 	public void testRenameTypeWithResourceChanges() throws JavaModelException, BadLocationException {
-		when(clientPreferences.isResourceOperationSupported()).thenReturn(true);
+		Mockito.lenient().when(clientPreferences.isResourceOperationSupported()).thenReturn(true);
 
 		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
 
@@ -276,7 +277,7 @@ public class PrepareRenameHandlerTest extends AbstractProjectsManagerBasedTest {
 
 	@Test(expected = ResponseErrorException.class)
 	public void testRenamePackage() throws JavaModelException, BadLocationException {
-		when(clientPreferences.isResourceOperationSupported()).thenReturn(true);
+		Mockito.lenient().when(clientPreferences.isResourceOperationSupported()).thenReturn(true);
 
 		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
 		IPackageFragment pack2 = sourceFolder.createPackageFragment("parent.test2", false, null);
@@ -312,7 +313,7 @@ public class PrepareRenameHandlerTest extends AbstractProjectsManagerBasedTest {
 
 	@Test(expected = ResponseErrorException.class)
 	public void testRenameMiddleOfPackage() throws JavaModelException, BadLocationException {
-		when(clientPreferences.isResourceOperationSupported()).thenReturn(true);
+		Mockito.lenient().when(clientPreferences.isResourceOperationSupported()).thenReturn(true);
 
 		IPackageFragment pack1 = sourceFolder.createPackageFragment("ex.amples", false, null);
 
@@ -358,7 +359,7 @@ public class PrepareRenameHandlerTest extends AbstractProjectsManagerBasedTest {
 
 	@Test(expected = ResponseErrorException.class)
 	public void testRenameImportDeclaration() throws JavaModelException, BadLocationException {
-		when(clientPreferences.isResourceOperationSupported()).thenReturn(true);
+		Mockito.lenient().when(clientPreferences.isResourceOperationSupported()).thenReturn(true);
 
 		IPackageFragment pack1 = sourceFolder.createPackageFragment("ex.amples", false, null);
 
@@ -379,7 +380,7 @@ public class PrepareRenameHandlerTest extends AbstractProjectsManagerBasedTest {
 	}
 
 	private void testRenameClassFile(String type) throws JavaModelException, BadLocationException {
-		when(clientPreferences.isResourceOperationSupported()).thenReturn(true);
+		Mockito.lenient().when(clientPreferences.isResourceOperationSupported()).thenReturn(true);
 
 		IPackageFragment pack1 = sourceFolder.createPackageFragment("ex.amples", false, null);
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectPreferenceChangeListenerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectPreferenceChangeListenerTest.java
@@ -193,7 +193,7 @@ public class InvisibleProjectPreferenceChangeListenerTest extends AbstractInvisi
 		JavaLanguageClient client = mock(JavaLanguageClient.class);
 		ProjectsManager pm = JavaLanguageServerPlugin.getProjectsManager();
 		pm.setConnection(client);
-		doNothing().when(client).showMessage(any(MessageParams.class));
+		Mockito.lenient().doNothing().when(client).showMessage(any(MessageParams.class));
 		copyAndImportFolder("singlefile/simple", "src/App.java");
 
 		List<IPath> rootPaths = new ArrayList<>(preferenceManager.getPreferences().getRootPaths());


### PR DESCRIPTION
- I20230912-1800

Today is Eclipse 2023-09 (4.30) GA, so they've removed https://download.eclipse.org/eclipse/updates/4.29-I-builds/, ~~but https://download.eclipse.org/eclipse/updates/4.29/ isn't yet in place, which means I have to bump to 4.30-I-builds. There shouldn't be anything to cause issues.~~

It would be ideal to use updates/4.29, since I20230806-1800 is just a week before 2023-09 M3 but if we need to build now this should also work.

**Update:** Nevermind. I see https://download.eclipse.org/eclipse/updates/4.29/ exists. I was wrongly waiting for 4.30 which definitely isn't going to be released :rofl: 

CC: @testforstephen 