### PR TITLE
Changelog for 1.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# [1.27.1 (September 14th, 2023)](https://github.com/eclipse/eclipse.jdt.ls/milestone/118?closed=1)
+ * bug fix - Log errors from project importer. See [#2843](https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/2843).
+ * build - Update target platform to 4.29 Release build. See [#2848](https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/2848).
+
 # [1.27.0 (September 12th, 2023)](https://github.com/eclipse/eclipse.jdt.ls/milestone/117?closed=1)
  * performance - Stale code actions should be cancellable and paste actions should have higher priority. See [#2799](https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/2799).
  * enhancement - Introduce new snippet templates with appropriate context. See [#2800](https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/2800).

--- a/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.jdt.ls.core;singleton:=true
-Bundle-Version: 1.28.0.qualifier
+Bundle-Version: 1.27.1.qualifier
 Bundle-Activator: org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.ls.core/pom.xml
+++ b/org.eclipse.jdt.ls.core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.jdt.ls</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.28.0-SNAPSHOT</version>
+		<version>1.27.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.eclipse.jdt.ls.core</artifactId>
 	<packaging>eclipse-plugin</packaging>

--- a/org.eclipse.jdt.ls.filesystem/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.filesystem/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.jdt.ls.filesystem;singleton:=true
 Bundle-Name: %Bundle-Name
-Bundle-Version: 1.28.0.qualifier
+Bundle-Version: 1.27.1.qualifier
 Export-Package: org.eclipse.jdt.ls.core.internal.filesystem;x-friends:="org.eclipse.jdt.ls.tests"
 Bundle-Localization: plugin
 Bundle-Activator: org.eclipse.jdt.ls.core.internal.filesystem.JDTLSFilesystemActivator

--- a/org.eclipse.jdt.ls.filesystem/pom.xml
+++ b/org.eclipse.jdt.ls.filesystem/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.jdt.ls</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.28.0-SNAPSHOT</version>
+		<version>1.27.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.eclipse.jdt.ls.filesystem</artifactId>
 	<packaging>eclipse-plugin</packaging>

--- a/org.eclipse.jdt.ls.logback.appender/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.logback.appender/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.jdt.ls.logback.appender;singleton:=true
-Bundle-Version: 1.28.0.qualifier
+Bundle-Version: 1.27.1.qualifier
 Fragment-Host: ch.qos.logback.classic
 Automatic-Module-Name: org.eclipse.jdt.ls.logback.appender
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.jdt.ls.logback.appender/pom.xml
+++ b/org.eclipse.jdt.ls.logback.appender/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.jdt.ls</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.28.0-SNAPSHOT</version>
+		<version>1.27.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.eclipse.jdt.ls.logback.appender</artifactId>
 	<name>${base.name} :: Java LS Logback.appender</name>

--- a/org.eclipse.jdt.ls.product/pom.xml
+++ b/org.eclipse.jdt.ls.product/pom.xml
@@ -4,7 +4,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<version>1.28.0-SNAPSHOT</version>
+		<version>1.27.1-SNAPSHOT</version>
 		<groupId>org.eclipse.jdt.ls</groupId>
 		<artifactId>parent</artifactId>
 	</parent>

--- a/org.eclipse.jdt.ls.repository/pom.xml
+++ b/org.eclipse.jdt.ls.repository/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.jdt.ls</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.28.0-SNAPSHOT</version>
+		<version>1.27.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.eclipse.jdt.ls.repository</artifactId>
 	<packaging>eclipse-repository</packaging>

--- a/org.eclipse.jdt.ls.target/pom.xml
+++ b/org.eclipse.jdt.ls.target/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.jdt.ls</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.28.0-SNAPSHOT</version>
+		<version>1.27.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.eclipse.jdt.ls.tp</artifactId>
 	<name>${base.name} :: Target Platform</name>

--- a/org.eclipse.jdt.ls.tests.syntaxserver/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.tests.syntaxserver/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.jdt.ls.tests.syntaxserver;singleton:=true
-Bundle-Version: 1.28.0.qualifier
+Bundle-Version: 1.27.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: org.osgi.framework;version="1.3.0"
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.ls.tests.syntaxserver/pom.xml
+++ b/org.eclipse.jdt.ls.tests.syntaxserver/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.jdt.ls</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.28.0-SNAPSHOT</version>
+		<version>1.27.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.eclipse.jdt.ls.tests.syntaxserver</artifactId>
 	<name>${base.name} :: SyntaxServer Tests</name>

--- a/org.eclipse.jdt.ls.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Automatic-Module-Name: org.eclipse.jdt.ls.tests
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.jdt.ls.tests;singleton:=true
-Bundle-Version: 1.28.0.qualifier
+Bundle-Version: 1.27.1.qualifier
 Export-Package: org.eclipse.jdt.ls.core.internal;x-friends:="org.eclipse.jdt.ls.tests.syntaxserver"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: org.osgi.framework;version="1.3.0"

--- a/org.eclipse.jdt.ls.tests/pom.xml
+++ b/org.eclipse.jdt.ls.tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.jdt.ls</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.28.0-SNAPSHOT</version>
+		<version>1.27.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.eclipse.jdt.ls.tests</artifactId>
 	<name>${base.name} :: Tests</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>org.eclipse.jdt.ls</groupId>
 	<artifactId>parent</artifactId>
 	<name>${base.name} :: Parent</name>
-	<version>1.28.0-SNAPSHOT</version>
+	<version>1.27.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<licenses>
 		<license>


### PR DESCRIPTION
I needed to include this update because https://download.eclipse.org/eclipse/updates/4.29-I-builds/ is gone (4.29 went GA and they clean the I-build repo immediately), so we needed an update to 4.29 Release to do a rebuild.

Longer term, being able to rebuild by packaging from the milestones (eg. https://download.eclipse.org/jdtls/milestones/1.27.0/ ) would have solved this, but we rarely need this.