### PR TITLE
Update current method snippet and add static_method snippet for interface

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/CodeSnippetTemplate.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/CodeSnippetTemplate.java
@@ -34,6 +34,7 @@ public enum CodeSnippetTemplate {
 	TRY_RESOURCES(TemplatePreferences.TRYRESOURCES_ID, JavaContextType.ID_STATEMENTS, TemplatePreferences.TRYRESOURCES_CONTENT, TemplatePreferences.TRYRESOURCES_DESCRIPTION),
 	CTOR(TemplatePreferences.CTOR_ID, JavaContextType.ID_MEMBERS, TemplatePreferences.CTOR_CONTENT, TemplatePreferences.CTOR_DESCRIPTION),
 	METHOD(TemplatePreferences.METHOD_ID, JavaContextType.ID_MEMBERS, TemplatePreferences.METHOD_CONTENT, TemplatePreferences.METHOD_DESCRIPTION),
+	STATIC_METHOD(TemplatePreferences.STATICMETHOD_ID, JavaContextType.ID_MEMBERS, TemplatePreferences.STATIC_METHOD_CONTENT, TemplatePreferences.STATIC_METHOD_DESCRIPTION),
 	FIELD(TemplatePreferences.FIELD_ID, JavaContextType.ID_MEMBERS, TemplatePreferences.FIELD_CONTENT, TemplatePreferences.FIELD_DESCRIPTION),
 	MAIN(TemplatePreferences.MAIN_ID, JavaContextType.ID_MEMBERS, TemplatePreferences.MAIN_CONTENT, TemplatePreferences.MAIN_DESCRIPTION),
 	NEW(TemplatePreferences.NEW_ID, JavaContextType.ID_ALL, TemplatePreferences.NEW_CONTENT, TemplatePreferences.NEW_DESCRIPTION),
@@ -91,6 +92,7 @@ class TemplatePreferences {
 	public static final String PSVM_ID = "org.eclipse.jdt.ls.templates.psvm";
 	public static final String CTOR_ID = "org.eclipse.jdt.ls.templates.ctor";
 	public static final String METHOD_ID = "org.eclipse.jdt.ls.templates.method";
+	public static final String STATICMETHOD_ID = "org.eclipse.jdt.ls.templates.staticmethod";
 	public static final String NEW_ID = "org.eclipse.jdt.ls.templates.new";
 	public static final String FIELD_ID = "org.eclipse.jdt.ls.templates.field";
 
@@ -112,6 +114,7 @@ class TemplatePreferences {
 	public static final String MAIN_CONTENT = "public static void main(String[] args) {\n" + "\t$${0}\n" + "}";
 	public static final String CTOR_CONTENT = "$${1|public,protected,private|} ${enclosing_simple_type}($${2}) {\n" + "\t$${3:super();}$${0}\n" + "}";
 	public static final String METHOD_CONTENT = "$${1|public,protected,private|}$${2| , static |}$${3:void} $${4:name}($${5}) {\n" + "\t$${0}\n" + "}";
+	public static final String STATIC_METHOD_CONTENT = "$${1|public,private|} static $${2:void} $${3:name}($${4}) {\n" + "\t$${0}\n" + "}";
 	public static final String NEW_CONTENT = "$${1:Object} $${2:foo} = new $${1}($${3});\n" + "$${0}";
 	public static final String FIELD_CONTENT = "$${1|public,protected,private|} $${2:String} $${3:name};";
 
@@ -133,6 +136,7 @@ class TemplatePreferences {
 	public static final String MAIN_DESCRIPTION = "public static main method";
 	public static final String CTOR_DESCRIPTION = "constructor";
 	public static final String METHOD_DESCRIPTION = "method";
+	public static final String STATIC_METHOD_DESCRIPTION = "static method";
 	public static final String NEW_DESCRIPTION = "create new object";
 	public static final String FIELD_DESCRIPTION = "field";
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -1398,6 +1398,47 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 	}
 
 	@Test
+	public void testSnippet_interface_method() throws JavaModelException {
+		//@formatter:off
+			ICompilationUnit unit = getWorkingCopy(
+				"src/org/sample/Test.java",
+				"package org.sample;\n" +
+				"public interface Test {\n"
+				+ "method\n"
+				+ "}"
+			);
+			//@formatter:on
+		CompletionList list = requestCompletions(unit, "method");
+		assertNotNull(list);
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		CompletionItem itemOne = items.get(6);
+		CompletionItem itemTwo = items.get(7);
+		assertEquals("method", itemOne.getLabel());
+		assertEquals("static_method", itemTwo.getLabel());
+		String methodText = itemOne.getTextEdit().getLeft().getNewText();
+		String staticMethodText = itemTwo.getTextEdit().getLeft().getNewText();
+		assertEquals("${1|public,private|} ${2:void} ${3:name}(${4});", methodText);
+		assertEquals("${1|public,private|} static ${2:void} ${3:name}(${4}) {\n" + "\t${0}\n" + "}", staticMethodText);
+	}
+
+	@Test
+	public void testSnippet_interface_no_ctor() throws JavaModelException {
+		//@formatter:off
+			ICompilationUnit unit = getWorkingCopy(
+				"src/org/sample/Test.java",
+				"package org.sample;\n" +
+				"public interface Test {\n"
+				+ "ctor\n"
+				+ "}"
+			);
+			//@formatter:on
+		CompletionList list = requestCompletions(unit, "ctor");
+		assertNotNull(list);
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		assertFalse("No ctor snippet should be available", items.stream().anyMatch(i -> "ctor".equals(i.getLabel())));
+	}
+
+	@Test
 	public void testSnippet_class() throws JavaModelException {
 		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java", "");
 		CompletionList list = requestCompletions(unit, "");
@@ -1511,6 +1552,23 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		String te = item.getInsertText();
 		assertNotNull(te);
 		assertEquals("/**\n * ${1:InnerTest_1}\n */\npublic class ${1:InnerTest_1} {\n\n\t${0}\n}", te);
+	}
+
+	@Test
+	public void testSnippet_class_no_static_method() throws JavaModelException {
+		//@formatter:off
+			ICompilationUnit unit = getWorkingCopy(
+				"src/org/sample/Test.java",
+				"package org.sample;\n" +
+				"public class Test {\n"
+				+ "static_method\n"
+				+ "}"
+			);
+			//@formatter:on
+		CompletionList list = requestCompletions(unit, "static_method");
+		assertNotNull(list);
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		assertFalse("No static_method snippet should be available", items.stream().anyMatch(i -> "static_method".equals(i.getLabel())));
 	}
 
 	@Test


### PR DESCRIPTION
Fixes redhat-developer/vscode-java#1697, including the removal of the ctor snippet within an interface, the modification of the method snippet (removal of the method body, protected choice, and static choice), and the addition of a static_method snippet with a method body.

Before:
![Peek 2023-09-20 15-16](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/958bd482-2a5f-4234-a547-38ccb8a85c70)

After:
![Peek 2023-09-20 15-41](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/c6e68dfb-4354-4a8f-b302-d54a5b71b41b)
