### PR TITLE
Add isEmpty() check to avoid java.util.EmptyStackException in FoldingRangeHandler

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/FoldingRangeHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/FoldingRangeHandler.java
@@ -237,7 +237,7 @@ public class FoldingRangeHandler {
 							}
 						}
 						// For curly braces enclosing a case statement, begin the folding range on the line with the case statement
-						if (prevTokenLine != currentLine && prevTokenLine == prevCaseLines.peek()) {
+						if (prevTokenLine != currentLine && !prevCaseLines.isEmpty() && prevTokenLine == prevCaseLines.peek()) {
 							leftParens.push(prevTokenLine);
 						} else {
 							leftParens.push(currentLine);

--- a/org.eclipse.jdt.ls.tests/projects/maven/foldingRange/src/main/java/org/sample/NestedSwitchFoldingRange.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/foldingRange/src/main/java/org/sample/NestedSwitchFoldingRange.java
@@ -2,6 +2,13 @@ package org.sample;
 
 public class NestedSwitchFoldingRange {
     
+	void testNoException()
+	{
+		if (true)
+		{
+		}
+	}
+
     void foo(){
 
         int x = 1;

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/FoldingRangeHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/FoldingRangeHandlerTest.java
@@ -128,19 +128,29 @@ public class FoldingRangeHandlerTest extends AbstractProjectsManagerBasedTest {
 	public void testNestedSwitchFoldingRanges() throws Exception {
 		String className = "org.sample.NestedSwitchFoldingRange";
 		List<FoldingRange> foldingRanges = getFoldingRanges(className);
-		assertTrue(foldingRanges.size() == 8);
-		assertHasFoldingRange(2, 25, null, foldingRanges);
-		assertHasFoldingRange(4, 24, null, foldingRanges);
+		assertTrue(foldingRanges.size() == 10);
+		assertHasFoldingRange(2, 33, null, foldingRanges);
+		assertHasFoldingRange(12, 32, null, foldingRanges);
 
 		// First switch statement
-		assertHasFoldingRange(9, 23, null, foldingRanges);
-		assertHasFoldingRange(10, 18, null, foldingRanges);
-		assertHasFoldingRange(19, 22, null, foldingRanges);
+		assertHasFoldingRange(17, 31, null, foldingRanges);
+		assertHasFoldingRange(18, 26, null, foldingRanges);
+		assertHasFoldingRange(27, 30, null, foldingRanges);
 
 		// Nested switch statement:
-		assertHasFoldingRange(12, 17, null, foldingRanges);
-		assertHasFoldingRange(13, 14, null, foldingRanges);
-		assertHasFoldingRange(15, 16, null, foldingRanges);
+		assertHasFoldingRange(20, 25, null, foldingRanges);
+		assertHasFoldingRange(21, 22, null, foldingRanges);
+		assertHasFoldingRange(23, 24, null, foldingRanges);
+	}
+
+	// https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/2865
+	@Test
+	public void testCurlyBracesOwnLine() throws Exception {
+		String className = "org.sample.NestedSwitchFoldingRange";
+		List<FoldingRange> foldingRanges = getFoldingRanges(className);
+		assertTrue(foldingRanges.size() == 10);
+		assertHasFoldingRange(4, 10, null, foldingRanges);
+		assertHasFoldingRange(7, 9, null, foldingRanges);
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #2865