### PR TITLE
Fix NPE in JDTUtils.getClassFile()

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
@@ -489,7 +489,9 @@ public final class JDTUtils {
 			if (primaryType != null) {
 				String fqn = primaryType.getFullyQualifiedName();
 				IType type = unit.getJavaProject().findType(fqn);
-				return type.getClassFile();
+				if (type != null) {
+					return type.getClassFile();
+				}
 			}
 		}
 		return null;


### PR DESCRIPTION
java.lang.NullPointerException: Cannot invoke
"org.eclipse.jdt.core.IType.getClassFile()" because "type" is null
  at org.eclipse.jdt.ls.core.internal.JDTUtils.getClassFile(JDTUtils.java:492)
  at org.eclipse.jdt.ls.core.internal.JDTUtils.discardClassFileWorkingCopy(JDTUtils.java:478)
  at org.eclipse.jdt.ls.core.internal.handlers.HoverHandler.hover(HoverHandler.java:51)

This happens in eclipseide-jdtls, when skipProjectConfiguration=true , and causes an error response when decent response can be returned here.