### PR TITLE
Fix order and filtering of completion items for overloaded methods

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -120,6 +120,12 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 				}
 				res = p2Length - p1Length;
 			}
+			if (res == 0) {
+				int paramCount1 = Signature.getParameterCount(p1.getSignature());
+				int paramCount2 = Signature.getParameterCount(p2.getSignature());
+
+				res = paramCount1 - paramCount2;
+			}
 			return res;
 		}
 
@@ -413,7 +419,16 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 		if ($.getTextEdit() != null) {
 			String newText = $.getTextEdit().isLeft() ? $.getTextEdit().getLeft().getNewText() : $.getTextEdit().getRight().getNewText();
 			Range range = $.getTextEdit().isLeft() ? $.getTextEdit().getLeft().getRange() : ($.getTextEdit().getRight().getInsert() != null ? $.getTextEdit().getRight().getInsert() : $.getTextEdit().getRight().getReplace());
-			if (range != null && newText != null) {
+			boolean labelDetailsEnabled = preferenceManager.getClientPreferences().isCompletionItemLabelDetailsSupport();
+			String filterText = "";
+			if (labelDetailsEnabled && $.getKind() == CompletionItemKind.Method) {
+				filterText = CompletionProposalDescriptionProvider.createMethodProposalDescription(proposal).toString();
+			} else if (labelDetailsEnabled && $.getKind() == CompletionItemKind.Constructor && $.getLabelDetails() != null) {
+				filterText = newText.concat($.getLabelDetails().getDetail());
+			}
+			if (range != null && !filterText.isEmpty()) {
+				$.setFilterText(filterText);
+			} else if (range != null && newText != null) {
 				$.setFilterText(newText);
 			}
 			// See https://github.com/eclipse/eclipse.jdt.ls/issues/2387

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -3912,6 +3912,29 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		}
 	}
 
+	@Test
+	public void testCompletion_order() throws Exception {
+		when(preferenceManager.getClientPreferences().isCompletionItemLabelDetailsSupport()).thenReturn(true);
+		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java", String.join("\n",
+		//@formatter:off
+				"package org.sample",
+				"public class Test {",
+				"	public void test(String x){}",
+				"	public void test(String x, int y){}",
+				"	public void test(String x, int y, boolean z){}",
+				"	public static void main(String[] args) {",
+				"		  Test obj = new Test();",
+				"		  obj.test",
+				"	}",
+				"}"));
+				//@formatter:on
+		CompletionList list = requestCompletions(unit, "obj.test");
+		assertFalse(list.getItems().isEmpty());
+		assertTrue(list.getItems().get(0).getFilterText().startsWith("test(String x)"));
+		assertTrue(list.getItems().get(1).getFilterText().startsWith("test(String x, int y)"));
+		assertTrue(list.getItems().get(2).getFilterText().startsWith("test(String x, int y, boolean z)"));
+	}
+
 	private CompletionList requestCompletions(ICompilationUnit unit, String completeBehind) throws JavaModelException {
 		return requestCompletions(unit, completeBehind, 0);
 	}


### PR DESCRIPTION
Fixes #2705 and redhat-developer/vscode-java#3206

Before:
![Peek 2023-09-27 15-35](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/b8dc69bd-1f8b-4fb4-88e1-3bcdd1cbe1f1)

After:
![Peek 2023-09-27 15-40](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/62f6dda7-3b82-43ed-9762-d90619e0904f)

Note that the completion suggestions disappear after a space is typed in the parameters, though this issue was present before the addition of labelDetails that introduced the original bug in #2705.

Additionally, even with this fix, the highlight does not persist past the entry of `(`, though this is likely a client-side issue.