### PR TITLE
Use Eclipse FileStore for external files

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/DocumentAdapter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/DocumentAdapter.java
@@ -20,6 +20,8 @@ import org.eclipse.core.filebuffers.FileBuffers;
 import org.eclipse.core.filebuffers.ITextFileBuffer;
 import org.eclipse.core.filebuffers.ITextFileBufferManager;
 import org.eclipse.core.filebuffers.LocationKind;
+import org.eclipse.core.filesystem.EFS;
+import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourceAttributes;
@@ -31,7 +33,6 @@ import org.eclipse.jdt.core.IBuffer;
 import org.eclipse.jdt.core.IBufferChangedListener;
 import org.eclipse.jdt.core.IOpenable;
 import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jdt.core.WorkingCopyOwner;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.IDocument;
@@ -126,8 +127,9 @@ public class DocumentAdapter implements IBuffer, IDocumentListener {
 
 		ITextFileBufferManager manager= FileBuffers.getTextFileBufferManager();
 		try {
-			manager.connect(filePath, LocationKind.LOCATION, null);
-			fTextFileBuffer= manager.getTextFileBuffer(filePath, LocationKind.LOCATION);
+			IFileStore store = EFS.getStore(path.toUri());
+			manager.connectFileStore(store, null);
+			fTextFileBuffer= manager.getFileStoreTextFileBuffer(store);
 			if (fTextFileBuffer != null) {
 				fDocument = fTextFileBuffer.getDocument();
 			}


### PR DESCRIPTION
This integrates better with other bits of Eclipse Platform and allows native synchronization between editor and LS in case LS runs in same workspace.
Also, the FileStore API provides some convenient features that may improve also synchronization with external changes.