### PR TITLE
Move snippet suggestions above keywords in completion list

### DIFF
--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerLazyResolveTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerLazyResolveTest.java
@@ -417,7 +417,7 @@ public class CompletionHandlerLazyResolveTest extends AbstractCompilationUnitBas
 		assertNotNull(list);
 
 		List<CompletionItem> items = new ArrayList<>(list.getItems());
-		CompletionItem item = items.get(1);
+		CompletionItem item = items.get(0);
 		assertEquals("while", item.getLabel());
 		assertNull(item.getLabelDetails().getDetail());
 		assertEquals("while statement", item.getLabelDetails().getDescription());
@@ -595,7 +595,7 @@ public class CompletionHandlerLazyResolveTest extends AbstractCompilationUnitBas
 		assertEquals(InsertTextMode.AdjustIndentation, list.getItemDefaults().getInsertTextMode());
 
 		List<CompletionItem> items = new ArrayList<>(list.getItems());
-		CompletionItem item = items.get(1);
+		CompletionItem item = items.get(0);
 		assertEquals("while", item.getLabel());
 		String insertText = item.getTextEditText();
 		assertEquals("while (${1:condition:var(boolean)}) {\n\t$TM_SELECTED_TEXT${0}\n}", insertText);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -1314,7 +1314,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertFalse(items.isEmpty());
 		items.sort((i1, i2) -> (i1.getSortText().compareTo(i2.getSortText())));
 
-		CompletionItem item = items.get(9);
+		CompletionItem item = items.get(1);
 		assertEquals("interface", item.getLabel());
 		String te = item.getInsertText();
 		assertEquals("package org.sample;\n\n/**\n * Test\n */\npublic interface Test {\n\n\t${0}\n}", ResourceUtils.dos2Unix(te));
@@ -1333,7 +1333,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertFalse(items.isEmpty());
 		items.sort((i1, i2) -> (i1.getSortText().compareTo(i2.getSortText())));
 
-		CompletionItem item = items.get(8);
+		CompletionItem item = items.get(1);
 		assertEquals("interface", item.getLabel());
 		String te = item.getInsertText();
 		assertEquals("/**\n * Test\n */\npublic interface Test {\n\n\t${0}\n}", te);
@@ -1349,7 +1349,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertFalse(items.isEmpty());
 		items.sort((i1, i2) -> (i1.getSortText().compareTo(i2.getSortText())));
 
-		CompletionItem item = items.get(6);
+		CompletionItem item = items.get(1);
 		assertEquals("interface", item.getLabel());
 		String te = item.getInsertText();
 		assertEquals("/**\n * ${1:InnerTest}\n */\npublic interface ${1:InnerTest} {\n\n\t${0}\n}", te);
@@ -1365,7 +1365,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertFalse(items.isEmpty());
 		items.sort((i1, i2) -> (i1.getSortText().compareTo(i2.getSortText())));
 
-		CompletionItem item = items.get(6);
+		CompletionItem item = items.get(1);
 		assertEquals("interface", item.getLabel());
 		String te = item.getInsertText();
 		assertEquals("/**\n * ${1:InnerTest_1}\n */\npublic interface ${1:InnerTest_1} {\n\n\t${0}\n}", te);
@@ -1381,7 +1381,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertFalse(items.isEmpty());
 		items.sort((i1, i2) -> (i1.getSortText().compareTo(i2.getSortText())));
 
-		CompletionItem item = items.get(23);
+		CompletionItem item = items.get(14);
 		assertEquals("interface", item.getLabel());
 		String te = item.getInsertText();
 		assertEquals("/**\n * ${1:InnerTest_1}\n */\npublic interface ${1:InnerTest_1} {\n\n\t${0}\n}", te);
@@ -1448,7 +1448,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertFalse(items.isEmpty());
 		items.sort((i1, i2) -> (i1.getSortText().compareTo(i2.getSortText())));
 
-		CompletionItem item = items.get(8);
+		CompletionItem item = items.get(0);
 		assertEquals("class", item.getLabel());
 		String te = item.getInsertText();
 		assertEquals("package org.sample;\n\n/**\n * Test\n */\npublic class Test {\n\n\t${0}\n}", ResourceUtils.dos2Unix(te));
@@ -1464,7 +1464,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertFalse(items.isEmpty());
 		items.sort((i1, i2) -> (i1.getSortText().compareTo(i2.getSortText())));
 
-		CompletionItem item = items.get(7);
+		CompletionItem item = items.get(0);
 		assertEquals("class", item.getLabel());
 		String te = item.getInsertText();
 		assertEquals("/**\n * Test\n */\npublic class Test {\n\n\t${0}\n}", te);
@@ -1480,7 +1480,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertFalse(items.isEmpty());
 		items.sort((i1, i2) -> (i1.getSortText().compareTo(i2.getSortText())));
 
-		CompletionItem item = items.get(5);
+		CompletionItem item = items.get(0);
 		assertEquals("class", item.getLabel());
 		String te = item.getInsertText();
 		assertEquals("/**\n * ${1:InnerTest}\n */\npublic class ${1:InnerTest} {\n\n\t${0}\n}", te);
@@ -1501,7 +1501,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertFalse(items.isEmpty());
 		items.sort((i1, i2) -> (i1.getSortText().compareTo(i2.getSortText())));
 
-		CompletionItem item = items.get(5);
+		CompletionItem item = items.get(0);
 		assertEquals("class", item.getLabel());
 		String te = item.getTextEditText();
 		assertEquals("/**\n * ${1:InnerTest}\n */\npublic class ${1:InnerTest} {\n\n\t${0}\n}", te);
@@ -1521,7 +1521,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertFalse(items.isEmpty());
 		items.sort((i1, i2) -> (i1.getSortText().compareTo(i2.getSortText())));
 
-		CompletionItem item = items.get(5);
+		CompletionItem item = items.get(0);
 		assertEquals("class", item.getLabel());
 		String te = item.getInsertText();
 		assertEquals("/**\n * ${1:InnerTest_1}\n */\npublic class ${1:InnerTest_1} {\n\n\t${0}\n}", te);
@@ -1547,7 +1547,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertFalse(items.isEmpty());
 		items.sort((i1, i2) -> (i1.getSortText().compareTo(i2.getSortText())));
 
-		CompletionItem item = items.get(21);
+		CompletionItem item = items.get(13);
 		assertEquals("class", item.getLabel());
 		String te = item.getInsertText();
 		assertNotNull(te);
@@ -1594,7 +1594,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertFalse(items.isEmpty());
 		items.sort((i1, i2) -> (i1.getSortText().compareTo(i2.getSortText())));
 
-		CompletionItem item = items.get(10);
+		CompletionItem item = items.get(2);
 		assertEquals("record", item.getLabel());
 		String te = item.getInsertText();
 		assertEquals("package org.sample;\n\n/**\n * Test\n */\npublic record Test(${0}) {\n}", ResourceUtils.dos2Unix(te));
@@ -1615,7 +1615,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertFalse(items.isEmpty());
 		items.sort((i1, i2) -> (i1.getSortText().compareTo(i2.getSortText())));
 
-		CompletionItem item = items.get(9);
+		CompletionItem item = items.get(2);
 		assertEquals("record", item.getLabel());
 		String te = item.getInsertText();
 		assertEquals("/**\n * Test\n */\npublic record Test(${0}) {\n}", te);


### PR DESCRIPTION
Fixes redhat-developer/vscode-java#2584

Before:
![Screenshot from 2023-10-12 16-21-00](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/9bc1bfa6-07fb-4b5c-b241-04969a73cb0d)
![Screenshot from 2023-10-03 13-36-41](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/a2e2d565-99d4-4692-8b86-3c3e79bc66bf)

After:
![Screenshot from 2023-10-03 13-23-19](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/2d9bf742-dcda-4acc-8b6a-4e5d05aa1b47)
![Screenshot from 2023-10-03 13-25-24](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/736e5273-13a7-424f-8b1f-25bc96783715)
