### PR TITLE
Fix first letter matching for method overrides

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -713,6 +713,8 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 		if (proposal.getKind() == CompletionProposal.TYPE_REF) {
 			String simpleTypeName = SignatureUtil.getSimpleTypeName(proposal);
 			firstCharOfCompletion = simpleTypeName.charAt(0);
+		} else if (proposal.getKind() == CompletionProposal.METHOD_DECLARATION) {
+			firstCharOfCompletion = proposal.getName()[0];
 		} else {
 			firstCharOfCompletion = proposal.getCompletion()[0];
 		}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -3707,6 +3707,25 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		}
 	}
 
+	// https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/2884
+	@Test
+	public void testCompletion_MatchCaseFirstLetterForMethodOverride() throws Exception {
+		preferenceManager.getPreferences().setCompletionMatchCaseMode(CompletionMatchCaseMode.FIRSTLETTER);
+		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java", String.join("\n",
+		//@formatter:off
+				"package org.sample",
+				"public class Test {",
+				"	public void testMethod(){}",
+				"}",
+				"class TestOverride extends Test{",
+				"	t",
+				"}"));
+				//@formatter:on
+		CompletionList list = requestCompletions(unit, "t");
+		assertFalse(list.getItems().isEmpty());
+		assertTrue(list.getItems().get(1).getLabel().startsWith("testMethod"));
+	}
+
 	// https://github.com/eclipse/eclipse.jdt.ls/issues/2376
 	@Test
 	public void testCompletion_selectSnippetItem() throws Exception {


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/2884, https://github.com/redhat-developer/vscode-java/issues/3186, and https://github.com/redhat-developer/vscode-java/issues/3214.