### PR TITLE
Automatically add the existing static imports in user code as the favorite static members

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalUtils.java
@@ -71,24 +71,16 @@ public class CompletionProposalUtils {
 	public static void addStaticImportsAsFavoriteImports(ICompilationUnit unit) {
 		try {
 			List<String> staticImports = Arrays.stream(unit.getImports())
-				.filter(t -> {
-					try {
-						return Flags.isStatic(t.getFlags());
-					} catch (JavaModelException e) {
-						// ignore
-					}
-					return false;})
-				.map(t -> t.getElementName())
-				.map(t -> {
-					int lastDot = t.lastIndexOf(".");
-					if (lastDot > -1) {
-						return t.substring(0, lastDot) + ".*";
-					}
-					return t;
-				}).toList();
-			if (!staticImports.isEmpty()) {
-				Preferences.DISCOVERED_STATIC_IMPORTS.addAll(staticImports);
-			}
+					.filter(t -> {
+						try {
+							return Flags.isStatic(t.getFlags());
+						} catch (JavaModelException e) {
+							return false;
+						}
+					})
+					.map(t -> t.getElementName().replaceFirst("\\.[^\\.]+$", ".*"))
+					.toList();
+			Preferences.DISCOVERED_STATIC_IMPORTS.addAll(staticImports);
 		} catch (JavaModelException e) {
 			// ignore
 		}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
@@ -45,6 +45,7 @@ import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.contentassist.ChainCompletionProposalComputer;
 import org.eclipse.jdt.ls.core.internal.contentassist.CompletionProposalRequestor;
+import org.eclipse.jdt.ls.core.internal.contentassist.CompletionProposalUtils;
 import org.eclipse.jdt.ls.core.internal.contentassist.JavadocCompletionProposal;
 import org.eclipse.jdt.ls.core.internal.contentassist.SnippetCompletionProposal;
 import org.eclipse.jdt.ls.core.internal.contentassist.SortTextHelper;
@@ -230,6 +231,7 @@ public class CompletionHandler{
 			}
 		}
 
+		CompletionProposalUtils.addStaticImportsAsFavoriteImports(unit);
 		List<CompletionItem> proposals = new ArrayList<>();
 
 		final int offset = JsonRpcHelpers.toOffset(unit.getBuffer(), params.getPosition().getLine(), params.getPosition().getCharacter());

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -559,6 +560,9 @@ public class Preferences {
 	public static final String IMPLEMENTATION_ID = UUID.randomUUID().toString();
 	public static final String SELECTION_RANGE_ID = UUID.randomUUID().toString();
 	public static final String INLAY_HINT_ID = UUID.randomUUID().toString();
+
+	public static final Set<String> DISCOVERED_STATIC_IMPORTS = new LinkedHashSet<>();
+
 	private static final String GRADLE_OFFLINE_MODE = "gradle.offline.mode";
 	private static final int DEFAULT_TAB_SIZE = 4;
 
@@ -1610,7 +1614,9 @@ public class Preferences {
 	}
 
 	public String[] getJavaCompletionFavoriteMembers() {
-		return javaCompletionFavoriteMembers.toArray(new String[0]);
+		Set<String> favorites = new LinkedHashSet<>(javaCompletionFavoriteMembers);
+		favorites.addAll(DISCOVERED_STATIC_IMPORTS);
+		return favorites.toArray(new String[0]);
 	}
 
 	public String getJavaHome() {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerChainTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerChainTest.java
@@ -13,6 +13,7 @@ import org.eclipse.jdt.core.manipulation.CoreASTProvider;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaClientConnection;
 import org.eclipse.jdt.ls.core.internal.JsonMessageHelper;
+import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionList;
 import org.junit.After;
@@ -54,6 +55,7 @@ public class CompletionHandlerChainTest extends AbstractCompilationUnitBasedTest
 		lifeCycleHandler = new DocumentLifeCycleHandler(javaClient, preferenceManager, projectsManager, true);
 		preferences.setPostfixCompletionEnabled(false);
 		preferences.setChainCompletionEnabled(true);
+		Preferences.DISCOVERED_STATIC_IMPORTS.clear();
 	}
 
 	@After

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -129,6 +129,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		lifeCycleHandler = new DocumentLifeCycleHandler(javaClient, preferenceManager, projectsManager, true);
 		preferences.setPostfixCompletionEnabled(false);
 		preferences.setCompletionLazyResolveTextEditEnabled(false);
+		Preferences.DISCOVERED_STATIC_IMPORTS.clear();
 	}
 
 	@After

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -3207,6 +3208,33 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 			CompletionList list = requestCompletions(unit, "java.util.");
 			assertNotNull(list);
 		} finally {
+			PreferenceManager.getPrefs(null).setFilteredTypes(Collections.emptyList());
+		}
+	}
+
+	@Test
+	public void testCompletion_autoAddStaticImportAsFavoriteImport() throws JavaModelException {
+		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java", """
+				package org.sample;
+				import static java.util.Arrays.sort;
+				public class Test {
+					public static void main(String[] args) {
+						asList
+					}
+				}""");
+		String[] oldFavorites = JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getJavaCompletionFavoriteMembers();
+		Set<String> oldStaticImports = new LinkedHashSet<>(Preferences.DISCOVERED_STATIC_IMPORTS);
+		try {
+			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setJavaCompletionFavoriteMembers(Arrays.asList("org.junit.Assert.*"));
+			Preferences.DISCOVERED_STATIC_IMPORTS.clear();
+			CompletionList list = requestCompletions(unit, "asList");
+			assertNotNull(list);
+			assertFalse(list.getItems().isEmpty());
+			CompletionItem item = list.getItems().stream().filter(i -> i.getDetail() != null && i.getDetail().startsWith("java.util.Arrays.asList(")).collect(Collectors.toList()).get(0);
+			assertNotNull(item);
+		} finally {
+			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setJavaCompletionFavoriteMembers(Arrays.asList(oldFavorites));
+			Preferences.DISCOVERED_STATIC_IMPORTS.addAll(oldStaticImports);
 			PreferenceManager.getPrefs(null).setFilteredTypes(Collections.emptyList());
 		}
 	}


### PR DESCRIPTION
We assume that users who have static imports in their Java files want to use them more often. Therefore, we suggest to automatically detect and add these static imports to the favorite static members whitelist when they edit the files. This will enhance the smartness of the Java language server.