### PR TITLE
Ensure line delimiter exists after the file header template.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetCompletionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetCompletionProposal.java
@@ -190,11 +190,11 @@ public class SnippetCompletionProposal extends CompletionProposal {
 			return completionContext;
 		}
 
-		String getPackageHeader() throws JavaModelException {
+		String getPackageHeader(String lineDelimiter) throws JavaModelException {
 			if (packageHeader == null) {
 				IPackageDeclaration[] packageDeclarations = cu.getPackageDeclarations();
 				String packageName = cu.getParent().getElementName();
-				packageHeader = ((packageName != null && !packageName.isEmpty()) && (packageDeclarations == null || packageDeclarations.length == 0)) ? "package " + packageName + ";\n\n" : "";
+				packageHeader = ((packageName != null && !packageName.isEmpty()) && (packageDeclarations == null || packageDeclarations.length == 0)) ? "package " + packageName + ";" + lineDelimiter + lineDelimiter : "";
 			}
 			return packageHeader;
 		}
@@ -630,9 +630,10 @@ public class SnippetCompletionProposal extends CompletionProposal {
 		}
 		CodeTemplateContext context = new CodeTemplateContext(template.getContextTypeId(), cu.getJavaProject(), scc.getRecommendedLineSeprator());
 
-		String fileComment = cu.getTypes().length == 0 ? CodeGeneration.getFileComment(cu, StubUtility.getLineDelimiterUsed(cu.getJavaProject())) : null;
-		context.setVariable(CodeTemplateContextType.FILE_COMMENT, fileComment != null ? fileComment + "\n" : "");
-		context.setVariable(PACKAGEHEADER, scc.getPackageHeader());
+		String lineDelimiter = StubUtility.getLineDelimiterUsed(cu.getJavaProject());
+		String fileComment = cu.getTypes().length == 0 ? CodeGeneration.getFileComment(cu, lineDelimiter) : null;
+		context.setVariable(CodeTemplateContextType.FILE_COMMENT, fileComment != null ? fileComment + lineDelimiter : "");
+		context.setVariable(PACKAGEHEADER, scc.getPackageHeader(lineDelimiter));
 		String typeName = JavaCore.removeJavaLikeExtension(cu.getElementName());
 		List<IType> types = Arrays.asList(cu.getAllTypes());
 		int postfix = 0;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/NewCUProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/NewCUProposal.java
@@ -359,6 +359,10 @@ public class NewCUProposal extends ChangeCorrectionProposal {
 
 	private String constructCUContent(ICompilationUnit cu, String typeContent, String lineDelimiter) throws CoreException {
 		String fileComment = CodeGeneration.getFileComment(cu, lineDelimiter);
+		// Ensure separation after (optional) file comment
+		if (fileComment != null && !fileComment.isEmpty()) {
+			fileComment += lineDelimiter;
+		}
 		String typeComment = CodeGeneration.getTypeComment(cu, cu.getElementName(), lineDelimiter);
 		IPackageFragment pack = (IPackageFragment) cu.getParent();
 		String content = CodeGeneration.getCompilationUnitContent(cu, fileComment, typeComment, typeContent, lineDelimiter);


### PR DESCRIPTION
With `java.templates.fileHeader` defined. When a type is annotated as `SampleClass cannot be resolved to a Type`, the `Create {class|interface|enum} SampleClass` code action produces : 

![image](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/1417342/67fe2f2d-05d9-4d52-96ba-82aa35d16f8d)

This regressed in https://github.com/eclipse-jdtls/eclipse.jdt.ls/commit/d8e523664639a4e8ccc62200302e30d7e53c9252#diff-253491dd873df873b33c21cb35ead8d713dd6ac01d2a5b0d2cf91ce5b3f942b9R122 . I must have tried to make all templates containing `${filecomment}${package_declaration}` look the same, and so removed the newline from the "newtype" template, not realizing we manually add a line delimiter for the snippet type declaration templates but not for "newtype"

- When a file header template is defined there should be a line delimiter between it and the package declaration (or type declaration)