### PR TITLE
Fix filterText and sorting for method declaration completions

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalDescriptionProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalDescriptionProvider.java
@@ -82,6 +82,7 @@ public class CompletionProposalDescriptionProvider {
 			case CompletionProposal.METHOD_NAME_REFERENCE:
 			case CompletionProposal.POTENTIAL_METHOD_DECLARATION:
 			case CompletionProposal.CONSTRUCTOR_INVOCATION:
+			case CompletionProposal.METHOD_DECLARATION:
 
 				// method name
 				description.append(proposal.getName());

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -104,8 +104,8 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 				res = p1.getKind() - p2.getKind();
 			}
 			if (res == 0) {
-				char[] completion1 = getCompletion(p1);
-				char[] completion2 = getCompletion(p2);
+				char[] completion1 = p1.getKind() == CompletionProposal.METHOD_DECLARATION ? p1.getName() : getCompletion(p1);
+				char[] completion2 = p2.getKind() == CompletionProposal.METHOD_DECLARATION ? p2.getName() : getCompletion(p2);
 
 				int p1Length = completion1.length;
 				int p2Length = completion2.length;
@@ -122,7 +122,7 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 			}
 			CompletionItemKind p1Kind = mapKind(p1);
 			CompletionItemKind p2Kind = mapKind(p2);
-			if (res == 0 && (p1Kind == CompletionItemKind.Method || p1Kind == CompletionItemKind.Constructor) 
+			if (res == 0 && (p1Kind == CompletionItemKind.Method || p1Kind == CompletionItemKind.Constructor)
 						&& (p2Kind == CompletionItemKind.Method || p2Kind == CompletionItemKind.Constructor)) {
 				int paramCount1 = Signature.getParameterCount(p1.getSignature());
 				int paramCount2 = Signature.getParameterCount(p2.getSignature());

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -3744,7 +3744,8 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		//@formatter:off
 				"package org.sample",
 				"public class Test {",
-				"	public void testMethod(){}",
+				"	public void testMethod(int a, int b){}",
+				"	public void testMethod(int b){}",
 				"}",
 				"class TestOverride extends Test{",
 				"	t",
@@ -3752,7 +3753,8 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 				//@formatter:on
 		CompletionList list = requestCompletions(unit, "t");
 		assertFalse(list.getItems().isEmpty());
-		assertTrue(list.getItems().get(1).getLabel().startsWith("testMethod"));
+		assertTrue(list.getItems().get(0).getLabel().startsWith("testMethod(int b"));
+		assertTrue(list.getItems().get(1).getLabel().startsWith("testMethod(int a"));
 	}
 
 	// https://github.com/eclipse/eclipse.jdt.ls/issues/2376


### PR DESCRIPTION
Fixes #2907

Before:
![Peek 2023-10-17 16-29](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/bb5af780-da53-4565-8cf0-920a1b5144a3)

After:
![Peek 2023-10-17 16-33](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/aff9e1ce-f399-4813-b813-d00c4e195389)