### PR TITLE
Fix the error 'Invalid project description' caused by incorrect glob patterns for Windows paths

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/EclipseProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/EclipseProjectImporter.java
@@ -48,7 +48,15 @@ public class EclipseProjectImporter extends AbstractProjectImporter {
 					.addExclusions("**/bin");//default Eclipse build dir
 			for (IProject project : ProjectUtils.getAllProjects(false)) {
 				File projectFile = project.getLocation().toFile();
-				eclipseDetector.addExclusions(projectFile.getAbsolutePath());
+				/**
+				 * The exclusion pattern will be used as a regular expression
+				 * that matches the files or folders to be excluded. On Windows,
+				 * the path separator (\) is a special character in regular
+				 * expressions, so it needs to be escaped with another backslash (\)
+				 * to be treated literally. For example, to exclude the folder
+				 * C:\Users\Hello, the exclusion pattern should be C:\\Users\\Hello.
+				 */
+				eclipseDetector.addExclusions(projectFile.getAbsolutePath().replace("\\", "\\\\"));
 			}
 			directories = eclipseDetector.scan(monitor);
 		}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
@@ -148,7 +148,7 @@ public class GradleProjectImporter extends AbstractProjectImporter {
 			for (IProject project : ProjectUtils.getAllProjects()) {
 				if (!ProjectUtils.isGradleProject(project)) {
 					String path = project.getLocation().toOSString();
-					gradleDetector.addExclusions(path);
+					gradleDetector.addExclusions(path.replace("\\", "\\\\"));
 				}
 			}
 			directories = gradleDetector.scan(monitor);
@@ -552,15 +552,11 @@ public class GradleProjectImporter extends AbstractProjectImporter {
 			if (persistentFile.exists()) {
 				long modified = persistentFile.lastModified();
 				if (projectDir.exists()) {
-					File[] files = projectDir.listFiles(new FilenameFilter() {
-
-						@Override
-						public boolean accept(File dir, String name) {
-							if (name != null && GradleBuildSupport.GRADLE_FILE_EXT.matcher(name).matches()) {
-								return new File(dir, name).lastModified() > modified;
-							}
-							return false;
+					File[] files = projectDir.listFiles((FilenameFilter) (dir, name) -> {
+						if (name != null && GradleBuildSupport.GRADLE_FILE_EXT.matcher(name).matches()) {
+							return new File(dir, name).lastModified() > modified;
 						}
+						return false;
 					});
 					shouldSynchronize = files != null && files.length > 0;
 				}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporter.java
@@ -99,7 +99,7 @@ public class MavenProjectImporter extends AbstractProjectImporter {
 			for (IProject project : ProjectUtils.getAllProjects()) {
 				if (!ProjectUtils.isMavenProject(project)) {
 					String path = project.getLocation().toOSString();
-					mavenDetector.addExclusions(path);
+					mavenDetector.addExclusions(path.replace("\\", "\\\\"));
 				}
 			}
 			directories = mavenDetector.scan(monitor);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/EclipseProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/EclipseProjectImporterTest.java
@@ -281,6 +281,18 @@ public class EclipseProjectImporterTest extends AbstractProjectsManagerBasedTest
 		}
 	}
 
+	@Test
+	public void DoNotDuplicateImportProject() throws Exception {
+		String name = "hello";
+		importProjects("eclipse/"+name);
+		IProject project = getProject(name );
+		assertIsJavaProject(project);
+		EclipseProjectImporter importer = new EclipseProjectImporter();
+		importer.initialize(project.getLocation().toFile());
+		boolean hasUnimportedProjects = importer.applies(new NullProgressMonitor());
+		assertFalse(hasUnimportedProjects);
+	}
+
 	@After
 	public void after() {
 		importer = null;

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporterTest.java
@@ -566,6 +566,23 @@ public class GradleProjectImporterTest extends AbstractGradleBasedTest{
 	}
 
 	@Test
+	public void avoidImportDuplicatedProjects2() throws Exception {
+		try {
+			this.preferences.setImportGradleEnabled(false);
+			importProjects("multi-buildtools");
+			IProject project = getProject("multi-build-tools");
+			assertIsJavaProject(project);
+			GradleProjectImporter importer = new GradleProjectImporter();
+			importer.initialize(project.getLocation().toFile());
+
+			this.preferences.setImportGradleEnabled(true);
+			assertFalse(importer.applies(null));
+		} finally {
+			this.preferences.setImportGradleEnabled(true);
+		}
+	}
+
+	@Test
 	public void testProtoBufSupport() throws Exception {
 		try {
 			this.preferences.setProtobufSupportEnabled(true);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporterTest.java
@@ -378,6 +378,23 @@ public class MavenProjectImporterTest extends AbstractMavenBasedTest {
 		}
 	}
 
+	@Test
+	public void avoidImportDuplicatedProjects2() throws Exception {
+		try {
+			this.preferences.setImportMavenEnabled(false);
+			importProjects("multi-buildtools");
+			IProject project = WorkspaceHelper.getProject("multi-buildtools");
+			assertIsJavaProject(project);
+			MavenProjectImporter importer = new MavenProjectImporter();
+			importer.initialize(project.getLocation().toFile());
+
+			this.preferences.setImportMavenEnabled(true);
+			assertFalse(importer.applies(null));
+		} finally {
+			this.preferences.setImportMavenEnabled(true);
+		}
+	}
+
 	// https://github.com/redhat-developer/vscode-java/issues/2712
 	@Test
 	public void testNullAnalysisDisabled() throws Exception {


### PR DESCRIPTION
Fixes #2845

It's a Windows specific bug. The root cause for the error 'Invalid project description' is that some importer fails to exclude the already imported projects during scanning, and attempts to import the same projects again. The fix is to exclude the already imported projects from scanning by using valid glob patterns for Windows paths.