### PR TITLE
Import projects by configurations

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
@@ -23,10 +23,11 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
-import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -173,28 +174,37 @@ public abstract class ProjectsManager implements ISaveParticipant, IProjectsMana
 		MultiStatus importStatusCollection = new MultiStatus(IConstants.PLUGIN_ID, -1, "Failed to import projects", null);
 		for (IPath rootPath : rootPaths) {
 			File rootFolder = rootPath.toFile();
-			Map<String, List<IPath>> configurationsByFileName = projectConfigurations.stream()
-					.filter(rootPath::isPrefixOf)
-					.collect(Collectors.groupingBy(IPath::lastSegment));
-			for (List<IPath> configurations : configurationsByFileName.values()) {
-				try {
-					for (IProjectImporter importer : importers()) {
-						importer.initialize(rootFolder);
-						if (importer.applies(configurations, subMonitor.split(1))) {
-							importer.importToWorkspace(subMonitor.split(70));
-							break;
-						}
+			Set<IPath> buildFiles = projectConfigurations.stream()
+					.filter(rootPath::isPrefixOf).collect(Collectors.toSet());
+			try {
+				for (IProjectImporter importer : importers()) {
+					importer.initialize(rootFolder);
+					if (importer.applies(buildFiles, subMonitor.split(1))) {
+						importer.importToWorkspace(subMonitor.split(70));
+						buildFiles = removeImportedConfigurations(buildFiles, importer);
 					}
-				} catch (CoreException e) {
-					// if one type of the project import failed, keep importing the next type
-					importStatusCollection.add(e.getStatus());
-					JavaLanguageServerPlugin.logException("Failed to import projects", e);
 				}
+			} catch (CoreException e) {
+				// if a rootPath import failed, keep importing the next rootPath
+				importStatusCollection.add(e.getStatus());
+				JavaLanguageServerPlugin.logException("Failed to import projects", e);
 			}
 		}
 		if (!importStatusCollection.isOK()) {
 			throw new CoreException(importStatusCollection);
 		}
+	}
+
+	private Set<IPath> removeImportedConfigurations(Set<IPath> configurations, IProjectImporter importer) {
+		return configurations.stream()
+			.filter(config -> {
+				try {
+					return !importer.isResolved(config.toFile());
+				} catch (OperationCanceledException | CoreException e) {
+					return true;
+				}
+			})
+			.collect(Collectors.toSet());
 	}
 
 	public void importProjects(IProgressMonitor monitor) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManagerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManagerTest.java
@@ -231,13 +231,14 @@ public class ProjectsManagerTest extends AbstractProjectsManagerBasedTest {
 
 	@Test
 	public void testImportMavenSubModule() throws IOException, OperationCanceledException, CoreException {
-		Path projectDir = copyFiles("maven/multimodule", true).toPath();
+		File projectDir = copyFiles("maven/multimodule", true);
+		Path projectDirPath = projectDir.toPath();
 		Collection<IPath> configurationPaths = new ArrayList<>();
-		Path subModuleConfiguration = projectDir.resolve("module1/pom.xml");
+		Path subModuleConfiguration = projectDirPath.resolve("module1/pom.xml");
 		IPath filePath = ResourceUtils.canonicalFilePathFromURI(subModuleConfiguration.toUri().toString());
 		configurationPaths.add(filePath);
 		preferenceManager.getPreferences().setProjectConfigurations(configurationPaths);
-		projectsManager.initializeProjects(Collections.singleton(new org.eclipse.core.runtime.Path(projectDir.toString())), monitor);
+		projectsManager.initializeProjects(Collections.singleton(new org.eclipse.core.runtime.Path(projectDir.getAbsolutePath())), monitor);
 		IProject[] allProjects = ProjectUtils.getAllProjects();
 		Set<String> expectedProjects = new HashSet<>(Arrays.asList(
 			"module1",
@@ -252,13 +253,14 @@ public class ProjectsManagerTest extends AbstractProjectsManagerBasedTest {
 
 	@Test
 	public void testImportMixedProjects() throws IOException, OperationCanceledException, CoreException {
-		Path projectDir = copyFiles("mixed", true).toPath();
+		File projectDir = copyFiles("mixed", true);
+		Path projectDirPath = projectDir.toPath();
 		Collection<IPath> configurationPaths = new ArrayList<>();
-		configurationPaths.add(ResourceUtils.canonicalFilePathFromURI(projectDir.resolve("hello/.project").toUri().toString()));
-		configurationPaths.add(ResourceUtils.canonicalFilePathFromURI(projectDir.resolve("simple-gradle/build.gradle").toUri().toString()));
-		configurationPaths.add(ResourceUtils.canonicalFilePathFromURI(projectDir.resolve("salut/pom.xml").toUri().toString()));
+		configurationPaths.add(ResourceUtils.canonicalFilePathFromURI(projectDirPath.resolve("hello/.project").toUri().toString()));
+		configurationPaths.add(ResourceUtils.canonicalFilePathFromURI(projectDirPath.resolve("simple-gradle/build.gradle").toUri().toString()));
+		configurationPaths.add(ResourceUtils.canonicalFilePathFromURI(projectDirPath.resolve("salut/pom.xml").toUri().toString()));
 		preferenceManager.getPreferences().setProjectConfigurations(configurationPaths);
-		projectsManager.initializeProjects(Collections.singleton(new org.eclipse.core.runtime.Path(projectDir.toString())), monitor);
+		projectsManager.initializeProjects(Collections.singleton(new org.eclipse.core.runtime.Path(projectDir.getAbsolutePath())), monitor);
 		IProject[] allProjects = ProjectUtils.getAllProjects();
 		Set<String> expectedProjects = new HashSet<>(Arrays.asList(
 			"jdt.ls-java-project",
@@ -274,12 +276,13 @@ public class ProjectsManagerTest extends AbstractProjectsManagerBasedTest {
 
 	@Test
 	public void testImportMixedProjectsPartially() throws IOException, OperationCanceledException, CoreException {
-		Path projectDir = copyFiles("mixed", true).toPath();
+		File projectDir = copyFiles("mixed", true);
+		Path projectDirPath = projectDir.toPath();
 		Collection<IPath> configurationPaths = new ArrayList<>();
-		configurationPaths.add(ResourceUtils.canonicalFilePathFromURI(projectDir.resolve("simple-gradle/build.gradle").toUri().toString()));
-		configurationPaths.add(ResourceUtils.canonicalFilePathFromURI(projectDir.resolve("salut/pom.xml").toUri().toString()));
+		configurationPaths.add(ResourceUtils.canonicalFilePathFromURI(projectDirPath.resolve("simple-gradle/build.gradle").toUri().toString()));
+		configurationPaths.add(ResourceUtils.canonicalFilePathFromURI(projectDirPath.resolve("salut/pom.xml").toUri().toString()));
 		preferenceManager.getPreferences().setProjectConfigurations(configurationPaths);
-		projectsManager.initializeProjects(Collections.singleton(new org.eclipse.core.runtime.Path(projectDir.toString())), monitor);
+		projectsManager.initializeProjects(Collections.singleton(new org.eclipse.core.runtime.Path(projectDir.getAbsolutePath())), monitor);
 		IProject[] allProjects = ProjectUtils.getAllProjects();
 		Set<String> expectedProjects = new HashSet<>(Arrays.asList(
 			"jdt.ls-java-project",


### PR DESCRIPTION
- Group the configuration files by file names and import them group by group, and
  make sure one project type will only be imported by one importer.