### PR TITLE
Fix wrongly encoded semantic tokens around class keyword

### DIFF
--- a/org.eclipse.jdt.ls.tests/projects/maven/semantic-tokens/src/main/java/foo/Types.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/semantic-tokens/src/main/java/foo/Types.java
@@ -10,13 +10,20 @@ public class Types {
 
 	public SomeClass<String, SomeClass<String, Integer>> someClass;
 
-	class SomeClass<T1, T2> {
+	/**
+	 * class
+	 */
+	@SomeAnnotation(Types.class)
+	// class
+	public class SomeClass<T1, T2> {
 		T1 t1;
 		T2 t2;
 	}
 	interface SomeInterface {}
 	enum SomeEnum {}
-	@interface SomeAnnotation {}
+	@interface SomeAnnotation {
+		Class<?> value();
+	}
 	record SomeRecord() {}
 
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SemanticTokensHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SemanticTokensHandlerTest.java
@@ -258,29 +258,44 @@ public class SemanticTokensHandlerTest extends AbstractProjectsManagerBasedTest 
 
 	@Test
 	public void testSemanticTokens_Types() throws JavaModelException {
-		TokenAssertionHelper.beginAssertion(getURI("Types.java"), "class", "interface", "enum", "annotation", "record", "typeParameter", "keyword")
+		TokenAssertionHelper.beginAssertion(getURI("Types.java"), "class", "interface", "enum", "annotation", "record", "typeParameter", "keyword", "modifier")
+			.assertNextToken("public", "modifier")
+			.assertNextToken("class", "modifier")
 			.assertNextToken("Types", "class", "public", "declaration")
+
+			.assertNextToken("public", "modifier")
 			.assertNextToken("String", "class", "public", "readonly")
 
+			.assertNextToken("protected", "modifier")
+			.assertNextToken("final", "modifier")
 			.assertNextToken("Class", "class", "public", "readonly", "generic")
 			.assertNextToken("String", "class", "public", "readonly")
 			.assertNextToken("class", "keyword")
 
-			.assertNextToken("SomeClass", "class", "generic")
+			.assertNextToken("public", "modifier")
+			.assertNextToken("SomeClass", "class", "public", "generic")
 			.assertNextToken("String", "class", "public", "readonly", "typeArgument")
-			.assertNextToken("SomeClass", "class", "generic", "typeArgument")
+			.assertNextToken("SomeClass", "class", "public", "generic", "typeArgument")
 			.assertNextToken("String", "class", "public", "readonly", "typeArgument")
 			.assertNextToken("Integer", "class", "public", "readonly", "typeArgument")
 
-			.assertNextToken("SomeClass", "class", "generic", "declaration")
+			.assertNextToken("SomeAnnotation", "annotation", "static")
+			.assertNextToken("Types", "class", "public")
+			.assertNextToken("class", "keyword")
+			.assertNextToken("public", "modifier")
+			.assertNextToken("class", "modifier")
+			.assertNextToken("SomeClass", "class", "public", "generic", "declaration")
 			.assertNextToken("T1", "typeParameter", "declaration")
 			.assertNextToken("T2", "typeParameter", "declaration")
 			.assertNextToken("T1", "typeParameter")
 			.assertNextToken("T2", "typeParameter")
 
+			.assertNextToken("interface", "modifier")
 			.assertNextToken("SomeInterface", "interface", "static", "declaration")
 			.assertNextToken("SomeEnum", "enum", "static", "readonly", "declaration")
 			.assertNextToken("SomeAnnotation", "annotation", "static", "declaration")
+			.assertNextToken("Class", "class", "public", "readonly", "generic")
+			.assertNextToken("record", "modifier")
 			.assertNextToken("SomeRecord", "record", "static", "readonly", "declaration")
 		.endAssertion();
 	}


### PR DESCRIPTION
Fixes #2920

I added some helper functions for making sure that we only scan the gap between the AST nodes (to avoid overlapping/out-of-order tokens). The more general helper functions can be used in the future if we discover more "gaps" in the AST that we need to scan.