### PR TITLE
Add new aliases for sysout and syserr snippets

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/CodeSnippetTemplate.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/CodeSnippetTemplate.java
@@ -46,7 +46,8 @@ public enum CodeSnippetTemplate {
 	SOUTM(TemplatePreferences.SOUTM_ID, JavaContextType.ID_STATEMENTS, TemplatePreferences.SYSTRACE_CONTENT, TemplatePreferences.SYSTRACE_DESCRIPTION),
 	ITER(TemplatePreferences.ITER_ID, JavaContextType.ID_STATEMENTS, TemplatePreferences.FOREACH_CONTENT, TemplatePreferences.FOREACH_DESCRIPTION),
 	PSVM(TemplatePreferences.PSVM_ID, JavaContextType.ID_MEMBERS, TemplatePreferences.MAIN_CONTENT, TemplatePreferences.MAIN_DESCRIPTION),
-	PRINT(TemplatePreferences.PRINT_ID, JavaContextType.ID_STATEMENTS, TemplatePreferences.SYSOUT_CONTENT, TemplatePreferences.SYSOUT_DESCRIPTION),
+	SYS_OUT(TemplatePreferences.SYS_OUT_ID, "System.out.println()", JavaContextType.ID_STATEMENTS, TemplatePreferences.SYSOUT_CONTENT, TemplatePreferences.SYSOUT_DESCRIPTION),
+	SYS_ERR(TemplatePreferences.SYS_ERR_ID, "System.err.println()", JavaContextType.ID_STATEMENTS, TemplatePreferences.SYSERR_CONTENT, TemplatePreferences.SYSERR_DESCRIPTION),
 	PUBLIC_MAIN(TemplatePreferences.PUBLIC_MAIN_ID, "public static void main(String[] args)", JavaContextType.ID_MEMBERS, TemplatePreferences.MAIN_CONTENT, TemplatePreferences.MAIN_DESCRIPTION);
 
 	//@formatter:on
@@ -109,7 +110,8 @@ class TemplatePreferences {
 	public static final String STATICMETHOD_ID = "org.eclipse.jdt.ls.templates.staticmethod";
 	public static final String NEW_ID = "org.eclipse.jdt.ls.templates.new";
 	public static final String FIELD_ID = "org.eclipse.jdt.ls.templates.field";
-	public static final String PRINT_ID = "org.eclipse.jdt.ls.templates.print";
+	public static final String SYS_OUT_ID = "org.eclipse.jdt.ls.templates.sys_out";
+	public static final String SYS_ERR_ID = "org.eclipse.jdt.ls.templates.sys_err";
 	public static final String PUBLIC_MAIN_ID = "org.eclipse.jdt.ls.templates.publicmain";
 
 	// DefaultContents

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -3705,7 +3705,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 			CompletionList list = requestCompletions(unit, "		i");
 			assertFalse(list.getItems().isEmpty());
 			boolean hasUpperCase = list.getItems().stream()
-				.anyMatch(t -> Character.isUpperCase(t.getLabel().charAt(0)));
+				.anyMatch(t -> t.getKind() != CompletionItemKind.Snippet && Character.isUpperCase(t.getLabel().charAt(0)));
 			assertFalse(hasUpperCase);
 		} finally {
 			preferenceManager.getPreferences().setCompletionMatchCaseMode(CompletionMatchCaseMode.OFF);
@@ -3831,7 +3831,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 	}
 
 	@Test
-	public void testCompletion_printSnippet() throws JavaModelException {
+	public void testCompletion_printSnippets() throws JavaModelException {
 		preferenceManager.getPreferences().setCompletionLazyResolveTextEditEnabled(false);
 		ICompilationUnit unit = getWorkingCopy(
 		//@formatter:off
@@ -3846,10 +3846,12 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		//@formatter:on
 		CompletionList list = requestCompletions(unit, "prin");
 		assertNotNull(list);
-		assertEquals(4, list.getItems().size());
-		CompletionItem item = list.getItems().get(3);
-		assertEquals("print", item.getLabel());
-		assertEquals(new Range(new Position(2, 2), new Position(2, 6)), item.getTextEdit().map(TextEdit::getRange, InsertReplaceEdit::getReplace));
+		CompletionItem outItem = list.getItems().get(3);
+		CompletionItem errItem = list.getItems().get(4);
+		assertEquals("System.out.println()", outItem.getLabel());
+		assertEquals("System.err.println()", errItem.getLabel());
+		assertEquals(new Range(new Position(2, 2), new Position(2, 6)), outItem.getTextEdit().map(TextEdit::getRange, InsertReplaceEdit::getReplace));
+		assertEquals(new Range(new Position(2, 2), new Position(2, 6)), errItem.getTextEdit().map(TextEdit::getRange, InsertReplaceEdit::getReplace));
 	}
 
 	@Test


### PR DESCRIPTION
Implements solution proposed in https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/2918#issuecomment-1774367339.

![Screenshot from 2023-10-25 11-32-10](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/f408a18a-ebc5-419e-ad2e-0363c4e1044b)
