### PR TITLE
Update to JSoup 1.16.2

### DIFF
--- a/org.eclipse.jdt.ls.core/.classpath
+++ b/org.eclipse.jdt.ls.core/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry exported="true" kind="lib" path="lib/jsoup-1.14.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/jsoup-1.16.2.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/remark-1.2.0.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/java-decompiler-engine-231.9011.34.jar"/>
 	<classpathentry kind="src" path="src/"/>

--- a/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
@@ -60,7 +60,7 @@ Export-Package: org.eclipse.jdt.ls.core.contentassist;x-friends:="org.eclipse.jd
  org.eclipse.jdt.ls.internal.gradle.checksums;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.lsp4j.extended;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.lsp4j.legacy.typeHierarchy;x-friends:="org.eclipse.jdt.ls.tests"
-Bundle-ClassPath: lib/jsoup-1.14.2.jar,
+Bundle-ClassPath: lib/jsoup-1.16.2.jar,
  lib/remark-1.2.0.jar,
  lib/java-decompiler-engine-231.9011.34.jar,
  .

--- a/org.eclipse.jdt.ls.core/build.properties
+++ b/org.eclipse.jdt.ls.core/build.properties
@@ -3,7 +3,7 @@ output.. = target/classes
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\
-               lib/jsoup-1.14.2.jar,\
+               lib/jsoup-1.16.2.jar,\
                lib/remark-1.2.0.jar,\
                lib/java-decompiler-engine-231.9011.34.jar,\
                lifecycle-mapping-metadata.xml,\

--- a/org.eclipse.jdt.ls.core/pom.xml
+++ b/org.eclipse.jdt.ls.core/pom.xml
@@ -25,7 +25,7 @@
 						<artifactItem>
 							<groupId>org.jsoup</groupId>
 							<artifactId>jsoup</artifactId>
-							<version>1.14.2</version>
+							<version>1.16.2</version>
 						</artifactItem>
 						<artifactItem>
 							<groupId>com.jetbrains.intellij.java</groupId>


### PR DESCRIPTION
Version 1.14.2 used till now is vulnerable to
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-36033 .