### PR TITLE
Tycho target-platform-configuration no longer has resolver config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,6 @@
 					<artifactId>target-platform-configuration</artifactId>
 					<version>${tycho-version}</version>
 					<configuration>
-						<resolver>p2</resolver>
 						<target>
 							<artifact>
 								<groupId>org.eclipse.jdt.ls</groupId>


### PR DESCRIPTION
Fixes a warning during the build