### PR TITLE
Update commons-codec to 1.16.0

### DIFF
--- a/org.eclipse.jdt.ls.product/languageServer.product
+++ b/org.eclipse.jdt.ls.product/languageServer.product
@@ -24,7 +24,7 @@
       <plugin id="ch.qos.logback.classic"/>
       <plugin id="ch.qos.logback.core"/>
       <plugin id="jakarta.servlet-api" version="5.0.0"/>
-      <plugin id="org.apache.commons.codec"/>
+      <plugin id="org.apache.commons.commons-codec"/>
       <plugin id="org.apache.felix.scr"/>
       <plugin id="org.eclipse.ant.core"/>
       <plugin id="org.eclipse.buildship.core"/>

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -16,10 +16,6 @@
             <repository location="https://download.eclipse.org/technology/m2e/releases/2.4.0/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="org.apache.commons.codec" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.29/"/>
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.equinox.core.feature.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.equinox.core.sdk.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
@@ -45,6 +41,12 @@
 				    <groupId>org.apache.commons</groupId>
 				    <artifactId>commons-lang3</artifactId>
 				    <version>3.8.1</version>
+				    <type>jar</type>
+			    </dependency>
+			    <dependency>
+				    <groupId>commons-codec</groupId>
+				    <artifactId>commons-codec</artifactId>
+				    <version>1.16.0</version>
 				    <type>jar</type>
 			    </dependency>
 		    </dependencies>


### PR DESCRIPTION
Benefits are:
* Use upstream bundle id
* No longer refer to 4.29 updates
* Move to latest version of commons-codec