### PR TITLE
Add capability to list all vm installs and update project jdk

### DIFF
--- a/org.eclipse.jdt.ls.core/plugin.xml
+++ b/org.eclipse.jdt.ls.core/plugin.xml
@@ -110,6 +110,9 @@
                   id="java.project.resolveWorkspaceSymbol">
             </command>
             <command
+                  id="java.project.updateJdk">
+            </command>
+            <command
                   id="java.protobuf.generateSources">
             </command>
             <command
@@ -126,6 +129,9 @@
             </command>
              <command
                   id="java.edit.smartSemicolonDetection">
+            </command>
+            <command
+                  id="java.vm.getAllInstalls">
             </command>
       </delegateCommandHandler>
    </extension>

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2022 Microsoft Corporation and others.
+ * Copyright (c) 2017-2023 Microsoft Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -29,6 +29,7 @@ import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand;
 import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand.ClasspathOptions;
 import org.eclipse.jdt.ls.core.internal.commands.SourceAttachmentCommand;
 import org.eclipse.jdt.ls.core.internal.commands.TypeHierarchyCommand;
+import org.eclipse.jdt.ls.core.internal.commands.VmCommand;
 import org.eclipse.jdt.ls.core.internal.framework.protobuf.ProtobufSupport;
 import org.eclipse.jdt.ls.core.internal.handlers.BundleUtils;
 import org.eclipse.jdt.ls.core.internal.handlers.CompletionHandler;
@@ -134,16 +135,22 @@ public class JDTDelegateCommandHandler implements IDelegateCommandHandler {
 					params.setPosition(textParams.getPosition());
 					TypeHierarchyItem typeHierarchyItem = typeHierarchyCommand.typeHierarchy(params, monitor);
 					return typeHierarchyItem;
-				case "java.project.upgradeGradle":
+				case "java.project.upgradeGradle": {
 					String projectUri = (String) arguments.get(0);
 					String gradleVersion = arguments.size() > 1 ? (String) arguments.get(1) : null;
 					if (gradleVersion == null) {
 						gradleVersion = GradleVersion.current().getVersion();
 					}
 					return GradleProjectImporter.upgradeGradleVersion(projectUri, gradleVersion, monitor);
+				}
 				case "java.project.resolveWorkspaceSymbol":
 					SymbolInformation si = JSONUtility.toModel(arguments.get(0), SymbolInformation.class);
 					return ProjectCommand.resolveWorkspaceSymbol(si);
+				case "java.project.updateJdk": {
+					String projectUri = (String) arguments.get(0);
+					String jdkPath = (String) arguments.get(1);
+					return ProjectCommand.updateProjectJdk(projectUri, jdkPath, monitor);
+				}
 				case "java.protobuf.generateSources":
 					ProtobufSupport.generateProtobufSources((ArrayList<String>) arguments.get(0), monitor);
 					return null;
@@ -177,6 +184,8 @@ public class JDTDelegateCommandHandler implements IDelegateCommandHandler {
 					}
 					SmartDetectionParams smartDetectionParams = JSONUtility.toModel(arguments.get(0), SmartDetectionParams.class);
 					return new SmartDetectionHandler(smartDetectionParams).getLocation(monitor);
+				case VmCommand.GET_ALL_INSTALL_COMMAND_ID:
+					return VmCommand.getAllVmInstalls();
 				default:
 					break;
 			}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
@@ -371,7 +371,7 @@ public class ProjectCommand {
 		IVMInstall vmInstall = getVmInstallByPath(jdkPath);
 		if (vmInstall == null) {
 			JavaLanguageServerPlugin.log(new Status(IStatus.ERROR, IConstants.PLUGIN_ID, "The select JDK path is not valid."));
-			return new JdkUpdateResult(false, "The select JDK path is not valid.");
+			return new JdkUpdateResult(false, "The selected JDK path is not valid.");
 		}
 		newClasspathEntries.add(JavaCore.newContainerEntry(
 				JavaRuntime.newJREContainerPath(vmInstall),

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/VmCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/VmCommand.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.commands;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.launching.IVMInstall;
+import org.eclipse.jdt.launching.IVMInstall2;
+import org.eclipse.jdt.launching.IVMInstallType;
+import org.eclipse.jdt.launching.JavaRuntime;
+
+public class VmCommand {
+	private VmCommand() {}
+
+	public static final String GET_ALL_INSTALL_COMMAND_ID = "java.vm.getAllInstalls";
+
+	/**
+	 * List all available VM installs on the machine.
+	 */
+	public static final List<VmInstall> getAllVmInstalls() {
+		List<VmInstall> vmInstallList = new ArrayList<>();
+		IVMInstallType[] vmInstallTypes = JavaRuntime.getVMInstallTypes();
+		for (IVMInstallType vmInstallType : vmInstallTypes) {
+			IVMInstall[] vmInstalls = vmInstallType.getVMInstalls();
+			for (IVMInstall vmInstall : vmInstalls) {
+				VmInstall vm = new VmInstall(
+						vmInstallType.getName(),
+						vmInstall.getName(),
+						vmInstall.getInstallLocation().getAbsolutePath()
+				);
+				if (vmInstall instanceof IVMInstall2) {
+					vm.version = ((IVMInstall2) vmInstall).getJavaVersion();
+				}
+				vmInstallList.add(vm);
+			}
+		}
+		return vmInstallList;
+	}
+
+	public static final class VmInstall {
+		public String typeName;
+		public String name;
+		public String path;
+		public String version;
+
+		public VmInstall(String typeName, String name, String path) {
+			this.typeName = typeName;
+			this.name = name;
+			this.path = path;
+		}
+	}
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Microsoft Corporation and others.
+ * Copyright (c) 2020-2023 Microsoft Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jdt.core.ICompilationUnit;
@@ -38,6 +39,8 @@ import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
 import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand.ClasspathOptions;
 import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand.ClasspathResult;
+import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand.JdkUpdateResult;
+import org.eclipse.jdt.ls.core.internal.commands.VmCommand.VmInstall;
 import org.eclipse.jdt.ls.core.internal.managers.AbstractInvisibleProjectBasedTest;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
@@ -51,82 +54,82 @@ import org.junit.Test;
  */
 public class ProjectCommandTest extends AbstractInvisibleProjectBasedTest {
 
-    @Test
-    public void testGetProjectSettingsForMavenJava7() throws Exception {
-        importProjects("maven/salut");
-        IProject project = WorkspaceHelper.getProject("salut");
-        String uriString = project.getFile("src/main/java/Foo.java").getLocationURI().toString();
-        List<String> settingKeys = Arrays.asList("org.eclipse.jdt.core.compiler.compliance", "org.eclipse.jdt.core.compiler.source");
-        Map<String, Object> options = ProjectCommand.getProjectSettings(uriString, settingKeys);
+	@Test
+	public void testGetProjectSettingsForMavenJava7() throws Exception {
+		importProjects("maven/salut");
+		IProject project = WorkspaceHelper.getProject("salut");
+		String uriString = project.getFile("src/main/java/Foo.java").getLocationURI().toString();
+		List<String> settingKeys = Arrays.asList("org.eclipse.jdt.core.compiler.compliance", "org.eclipse.jdt.core.compiler.source");
+		Map<String, Object> options = ProjectCommand.getProjectSettings(uriString, settingKeys);
 
-        assertEquals(settingKeys.size(), options.size());
-        assertEquals("1.7", options.get("org.eclipse.jdt.core.compiler.compliance"));
-        assertEquals("1.7", options.get("org.eclipse.jdt.core.compiler.source"));
-    }
+		assertEquals(settingKeys.size(), options.size());
+		assertEquals("1.7", options.get("org.eclipse.jdt.core.compiler.compliance"));
+		assertEquals("1.7", options.get("org.eclipse.jdt.core.compiler.source"));
+	}
 
-    @Test
-    public void testGetProjectSettingsForMavenJava8() throws Exception {
-        importProjects("maven/salut2");
-        IProject project = WorkspaceHelper.getProject("salut2");
-        String uriString = project.getFile("src/main/java/foo/Bar.java").getLocationURI().toString();
-        List<String> settingKeys = Arrays.asList("org.eclipse.jdt.core.compiler.compliance", "org.eclipse.jdt.core.compiler.source");
-        Map<String, Object> options = ProjectCommand.getProjectSettings(uriString, settingKeys);
+	@Test
+	public void testGetProjectSettingsForMavenJava8() throws Exception {
+		importProjects("maven/salut2");
+		IProject project = WorkspaceHelper.getProject("salut2");
+		String uriString = project.getFile("src/main/java/foo/Bar.java").getLocationURI().toString();
+		List<String> settingKeys = Arrays.asList("org.eclipse.jdt.core.compiler.compliance", "org.eclipse.jdt.core.compiler.source");
+		Map<String, Object> options = ProjectCommand.getProjectSettings(uriString, settingKeys);
 
-        assertEquals(settingKeys.size(), options.size());
-        assertEquals("1.8", options.get("org.eclipse.jdt.core.compiler.compliance"));
-        assertEquals("1.8", options.get("org.eclipse.jdt.core.compiler.source"));
-    }
+		assertEquals(settingKeys.size(), options.size());
+		assertEquals("1.8", options.get("org.eclipse.jdt.core.compiler.compliance"));
+		assertEquals("1.8", options.get("org.eclipse.jdt.core.compiler.source"));
+	}
 
-    @Test
-    public void testGetProjectVMInstallation() throws Exception {
-        importProjects("maven/salut2");
-        IProject project = WorkspaceHelper.getProject("salut2");
-        String uriString = project.getFile("src/main/java/foo/Bar.java").getLocationURI().toString();
-        List<String> settingKeys = Arrays.asList(ProjectCommand.VM_LOCATION);
-        Map<String, Object> options = ProjectCommand.getProjectSettings(uriString, settingKeys);
+	@Test
+	public void testGetProjectVMInstallation() throws Exception {
+		importProjects("maven/salut2");
+		IProject project = WorkspaceHelper.getProject("salut2");
+		String uriString = project.getFile("src/main/java/foo/Bar.java").getLocationURI().toString();
+		List<String> settingKeys = Arrays.asList(ProjectCommand.VM_LOCATION);
+		Map<String, Object> options = ProjectCommand.getProjectSettings(uriString, settingKeys);
 
-        IJavaProject javaProject = ProjectCommand.getJavaProjectFromUri(uriString);
-        IVMInstall vmInstall = JavaRuntime.getVMInstall(javaProject);
-        assertNotNull(vmInstall);
-        File location = vmInstall.getInstallLocation();
-        assertNotNull(location);
-        assertEquals(location.getAbsolutePath(), options.get(ProjectCommand.VM_LOCATION));
-    }
+		IJavaProject javaProject = ProjectCommand.getJavaProjectFromUri(uriString);
+		IVMInstall vmInstall = JavaRuntime.getVMInstall(javaProject);
+		assertNotNull(vmInstall);
+		File location = vmInstall.getInstallLocation();
+		assertNotNull(location);
+		assertEquals(location.getAbsolutePath(), options.get(ProjectCommand.VM_LOCATION));
+	}
 
-    @Test
-    public void testGetProjectSourcePaths() throws Exception {
-        IProject project = copyAndImportFolder("singlefile/simple", "src/App.java");
-        String linkedFolder = project.getFolder(ProjectUtils.WORKSPACE_LINK).getLocationURI().toString();
-        List<String> settingKeys = Arrays.asList(ProjectCommand.SOURCE_PATHS);
-        Map<String, Object> options = ProjectCommand.getProjectSettings(linkedFolder, settingKeys);
-        String[] actualSourcePaths = (String[]) options.get(ProjectCommand.SOURCE_PATHS);
-        assertTrue(actualSourcePaths.length == 2);
-        assertTrue(Arrays.stream(actualSourcePaths).anyMatch(sourcePath -> {
-            return sourcePath.equals(project.getFolder(ProjectUtils.WORKSPACE_LINK).getFolder("src").getLocation().toOSString())
-                    || sourcePath.equals(project.getFolder(ProjectUtils.WORKSPACE_LINK).getFolder("test").getLocation().toOSString());
-        }));
-    }
+	@Test
+	public void testGetProjectSourcePaths() throws Exception {
+		IProject project = copyAndImportFolder("singlefile/simple", "src/App.java");
+		String linkedFolder = project.getFolder(ProjectUtils.WORKSPACE_LINK).getLocationURI().toString();
+		List<String> settingKeys = Arrays.asList(ProjectCommand.SOURCE_PATHS);
+		Map<String, Object> options = ProjectCommand.getProjectSettings(linkedFolder, settingKeys);
+		String[] actualSourcePaths = (String[]) options.get(ProjectCommand.SOURCE_PATHS);
+		assertTrue(actualSourcePaths.length == 2);
+		assertTrue(Arrays.stream(actualSourcePaths).anyMatch(sourcePath -> {
+			return sourcePath.equals(project.getFolder(ProjectUtils.WORKSPACE_LINK).getFolder("src").getLocation().toOSString())
+					|| sourcePath.equals(project.getFolder(ProjectUtils.WORKSPACE_LINK).getFolder("test").getLocation().toOSString());
+		}));
+	}
 
-    @Test
-    public void testGetProjectOutputPath() throws Exception {
-        IProject project = copyAndImportFolder("singlefile/simple", "src/App.java");
-        String linkedFolder = project.getFolder(ProjectUtils.WORKSPACE_LINK).getLocationURI().toString();
-        List<String> settingKeys = Arrays.asList(ProjectCommand.OUTPUT_PATH);
-        Map<String, Object> options = ProjectCommand.getProjectSettings(linkedFolder, settingKeys);
-        String actualOutputPath = (String) options.get(ProjectCommand.OUTPUT_PATH);
-        String expectedOutputPath = project.getFolder("bin").getLocation().toOSString();
-        assertEquals(expectedOutputPath, actualOutputPath);
-    }
+	@Test
+	public void testGetProjectOutputPath() throws Exception {
+		IProject project = copyAndImportFolder("singlefile/simple", "src/App.java");
+		String linkedFolder = project.getFolder(ProjectUtils.WORKSPACE_LINK).getLocationURI().toString();
+		List<String> settingKeys = Arrays.asList(ProjectCommand.OUTPUT_PATH);
+		Map<String, Object> options = ProjectCommand.getProjectSettings(linkedFolder, settingKeys);
+		String actualOutputPath = (String) options.get(ProjectCommand.OUTPUT_PATH);
+		String expectedOutputPath = project.getFolder("bin").getLocation().toOSString();
+		assertEquals(expectedOutputPath, actualOutputPath);
+	}
 
-    @Test
-    public void testGetProjectReferencedLibraryPaths() throws Exception {
-        IProject project = copyAndImportFolder("singlefile/simple", "src/App.java");
-        String linkedFolder = project.getFolder(ProjectUtils.WORKSPACE_LINK).getLocationURI().toString();
-        List<String> settingKeys = Arrays.asList(ProjectCommand.REFERENCED_LIBRARIES);
-        Map<String, Object> options = ProjectCommand.getProjectSettings(linkedFolder, settingKeys);
-        String[] actualReferencedLibraryPaths = (String[]) options.get(ProjectCommand.REFERENCED_LIBRARIES);
-        String expectedReferencedLibraryPath = project.getFolder(ProjectUtils.WORKSPACE_LINK).getFolder("lib").getFile("mylib.jar").getLocation().toOSString();
-        assertTrue(actualReferencedLibraryPaths.length == 1);
+	@Test
+	public void testGetProjectReferencedLibraryPaths() throws Exception {
+		IProject project = copyAndImportFolder("singlefile/simple", "src/App.java");
+		String linkedFolder = project.getFolder(ProjectUtils.WORKSPACE_LINK).getLocationURI().toString();
+		List<String> settingKeys = Arrays.asList(ProjectCommand.REFERENCED_LIBRARIES);
+		Map<String, Object> options = ProjectCommand.getProjectSettings(linkedFolder, settingKeys);
+		String[] actualReferencedLibraryPaths = (String[]) options.get(ProjectCommand.REFERENCED_LIBRARIES);
+		String expectedReferencedLibraryPath = project.getFolder(ProjectUtils.WORKSPACE_LINK).getFolder("lib").getFile("mylib.jar").getLocation().toOSString();
+		assertTrue(actualReferencedLibraryPaths.length == 1);
 		if (Platform.OS_WIN32.equals(Platform.getOS())) {
 			IPath expected = new Path(expectedReferencedLibraryPath);
 			IPath actual = new Path(actualReferencedLibraryPaths[0]);
@@ -140,162 +143,162 @@ public class ProjectCommandTest extends AbstractInvisibleProjectBasedTest {
 		} else {
 			assertEquals(expectedReferencedLibraryPath, actualReferencedLibraryPaths[0]);
 		}
-    }
+	}
 
-    @Test
-    public void testGetMavenProjectFromUri() throws Exception {
-        importProjects("maven/salut");
-        IProject project = WorkspaceHelper.getProject("salut");
-        String javaSource = project.getFile("src/main/java/Foo.java").getLocationURI().toString();
-        IJavaProject javaProject = ProjectCommand.getJavaProjectFromUri(javaSource);
-        assertNotNull("Can get project from java file uri", javaProject);
+	@Test
+	public void testGetMavenProjectFromUri() throws Exception {
+		importProjects("maven/salut");
+		IProject project = WorkspaceHelper.getProject("salut");
+		String javaSource = project.getFile("src/main/java/Foo.java").getLocationURI().toString();
+		IJavaProject javaProject = ProjectCommand.getJavaProjectFromUri(javaSource);
+		assertNotNull("Can get project from java file uri", javaProject);
 
-        String projectUri = project.getLocationURI().toString();
-        javaProject = ProjectCommand.getJavaProjectFromUri(projectUri);
-        assertNotNull("Can get project from project uri", javaProject);
-    }
+		String projectUri = project.getLocationURI().toString();
+		javaProject = ProjectCommand.getJavaProjectFromUri(projectUri);
+		assertNotNull("Can get project from project uri", javaProject);
+	}
 
-    @Test
-    public void testGetMultiModuleMavenProjectFromUri() throws Exception {
-        importProjects("maven/multimodule3");
-        IProject project = WorkspaceHelper.getProject("this_is_a_very_long_module_name");
-        String javaSource = project.getFile("src/main/org/eclipse/App.java").getLocationURI().toString();
-        IJavaProject javaProject = ProjectCommand.getJavaProjectFromUri(javaSource);
-        assertEquals("this_is_a_very_long_module_name", javaProject.getElementName());
+	@Test
+	public void testGetMultiModuleMavenProjectFromUri() throws Exception {
+		importProjects("maven/multimodule3");
+		IProject project = WorkspaceHelper.getProject("this_is_a_very_long_module_name");
+		String javaSource = project.getFile("src/main/org/eclipse/App.java").getLocationURI().toString();
+		IJavaProject javaProject = ProjectCommand.getJavaProjectFromUri(javaSource);
+		assertEquals("this_is_a_very_long_module_name", javaProject.getElementName());
 
-        String projectUri = project.getLocationURI().toString();
-        javaProject = ProjectCommand.getJavaProjectFromUri(projectUri);
-        assertEquals("this_is_a_very_long_module_name", javaProject.getElementName());
-    }
+		String projectUri = project.getLocationURI().toString();
+		javaProject = ProjectCommand.getJavaProjectFromUri(projectUri);
+		assertEquals("this_is_a_very_long_module_name", javaProject.getElementName());
+	}
 
-    @Test
-    public void testGetInvisibleProjectFromUri() throws Exception {
-        IProject project = copyAndImportFolder("singlefile/simple", "src/App.java");
-        String linkedFolder = project.getFolder(ProjectUtils.WORKSPACE_LINK).getLocationURI().toString();
-        IJavaProject javaProject = ProjectCommand.getJavaProjectFromUri(linkedFolder);
-        assertNotNull("Can get project from linked folder uri", javaProject);
-    }
+	@Test
+	public void testGetInvisibleProjectFromUri() throws Exception {
+		IProject project = copyAndImportFolder("singlefile/simple", "src/App.java");
+		String linkedFolder = project.getFolder(ProjectUtils.WORKSPACE_LINK).getLocationURI().toString();
+		IJavaProject javaProject = ProjectCommand.getJavaProjectFromUri(linkedFolder);
+		assertNotNull("Can get project from linked folder uri", javaProject);
+	}
 
-    @Test
-    public void testGetClasspathsForMaven() throws Exception {
-        importProjects("maven/classpathtest");
-        IProject project = WorkspaceHelper.getProject("classpathtest");
-        String uriString = project.getFile("src/main/java/main/App.java").getLocationURI().toString();
-        ClasspathOptions options = new ClasspathOptions();
-        options.scope = "runtime";
-        ClasspathResult result = ProjectCommand.getClasspaths(uriString, options);
-        assertEquals(1, result.classpaths.length);
-        assertEquals(0, result.modulepaths.length);
-        assertTrue(result.classpaths[0].indexOf("junit") == -1);
+	@Test
+	public void testGetClasspathsForMaven() throws Exception {
+		importProjects("maven/classpathtest");
+		IProject project = WorkspaceHelper.getProject("classpathtest");
+		String uriString = project.getFile("src/main/java/main/App.java").getLocationURI().toString();
+		ClasspathOptions options = new ClasspathOptions();
+		options.scope = "runtime";
+		ClasspathResult result = ProjectCommand.getClasspaths(uriString, options);
+		assertEquals(1, result.classpaths.length);
+		assertEquals(0, result.modulepaths.length);
+		assertTrue(result.classpaths[0].indexOf("junit") == -1);
 
-        options.scope = "test";
-        result = ProjectCommand.getClasspaths(uriString, options);
-        assertEquals(4, result.classpaths.length);
-        assertEquals(0, result.modulepaths.length);
-        boolean containsJunit = Arrays.stream(result.classpaths).anyMatch(element -> {
-            return element.indexOf("junit") > -1;
-        });
-        assertTrue(containsJunit);
-    }
+		options.scope = "test";
+		result = ProjectCommand.getClasspaths(uriString, options);
+		assertEquals(4, result.classpaths.length);
+		assertEquals(0, result.modulepaths.length);
+		boolean containsJunit = Arrays.stream(result.classpaths).anyMatch(element -> {
+			return element.indexOf("junit") > -1;
+		});
+		assertTrue(containsJunit);
+	}
 
-    @Test
-    public void testGetClasspathsForMavenWhenUpdating() throws Exception {
-        importProjects("maven/classpathtest");
-        IProject project = WorkspaceHelper.getProject("classpathtest");
-        String uriString = project.getFile("src/main/java/main/App.java").getLocationURI().toString();
-        ClasspathOptions options = new ClasspathOptions();
-        options.scope = "test";
+	@Test
+	public void testGetClasspathsForMavenWhenUpdating() throws Exception {
+		importProjects("maven/classpathtest");
+		IProject project = WorkspaceHelper.getProject("classpathtest");
+		String uriString = project.getFile("src/main/java/main/App.java").getLocationURI().toString();
+		ClasspathOptions options = new ClasspathOptions();
+		options.scope = "test";
 
-        projectsManager.updateProject(project, true);
+		projectsManager.updateProject(project, true);
 
-        for (int i = 0; i < 10; i++) {
-            ClasspathResult result = ProjectCommand.getClasspaths(uriString, options);
-            assertEquals(4, result.classpaths.length);
-            assertEquals(0, result.modulepaths.length);
-            boolean containsJunit = Arrays.stream(result.classpaths).anyMatch(element -> {
-                return element.indexOf("junit") > -1;
-            });
-            assertTrue(containsJunit);
-        }
-    }
+		for (int i = 0; i < 10; i++) {
+			ClasspathResult result = ProjectCommand.getClasspaths(uriString, options);
+			assertEquals(4, result.classpaths.length);
+			assertEquals(0, result.modulepaths.length);
+			boolean containsJunit = Arrays.stream(result.classpaths).anyMatch(element -> {
+				return element.indexOf("junit") > -1;
+			});
+			assertTrue(containsJunit);
+		}
+	}
 
-    @Test
-    public void testGetClasspathsForGradle() throws Exception {
-        importProjects("gradle/simple-gradle");
-        IProject project = WorkspaceHelper.getProject("simple-gradle");
-        String uriString = project.getFile("src/main/java/Library.java").getLocationURI().toString();
-        ClasspathOptions options = new ClasspathOptions();
-        options.scope = "runtime";
-        ClasspathResult result = ProjectCommand.getClasspaths(uriString, options);
-        assertEquals(3, result.classpaths.length);
-        assertEquals(0, result.modulepaths.length);
-        assertTrue(result.classpaths[0].indexOf("junit") == -1);
+	@Test
+	public void testGetClasspathsForGradle() throws Exception {
+		importProjects("gradle/simple-gradle");
+		IProject project = WorkspaceHelper.getProject("simple-gradle");
+		String uriString = project.getFile("src/main/java/Library.java").getLocationURI().toString();
+		ClasspathOptions options = new ClasspathOptions();
+		options.scope = "runtime";
+		ClasspathResult result = ProjectCommand.getClasspaths(uriString, options);
+		assertEquals(3, result.classpaths.length);
+		assertEquals(0, result.modulepaths.length);
+		assertTrue(result.classpaths[0].indexOf("junit") == -1);
 
-        options.scope = "test";
-        result = ProjectCommand.getClasspaths(uriString, options);
-        assertEquals(5, result.classpaths.length);
-        assertEquals(0, result.modulepaths.length);
-        boolean containsJunit = Arrays.stream(result.classpaths).anyMatch(element -> {
-            return element.indexOf("junit") > -1;
-        });
-        assertTrue(containsJunit);
-    }
+		options.scope = "test";
+		result = ProjectCommand.getClasspaths(uriString, options);
+		assertEquals(5, result.classpaths.length);
+		assertEquals(0, result.modulepaths.length);
+		boolean containsJunit = Arrays.stream(result.classpaths).anyMatch(element -> {
+			return element.indexOf("junit") > -1;
+		});
+		assertTrue(containsJunit);
+	}
 
-    @Test
-    public void testGetClasspathsForMavenModular() throws Exception {
-        importProjects("maven/modular-project");
-        IProject project = WorkspaceHelper.getProject("modular-project");
-        String uriString = project.getFile("src/main/java/modular/Main.java").getLocationURI().toString();
-        ClasspathOptions options = new ClasspathOptions();
-        options.scope = "test";
-        ClasspathResult result = ProjectCommand.getClasspaths(uriString, options);
-        assertEquals(0, result.classpaths.length);
-        assertEquals(1, result.modulepaths.length);
-    }
+	@Test
+	public void testGetClasspathsForMavenModular() throws Exception {
+		importProjects("maven/modular-project");
+		IProject project = WorkspaceHelper.getProject("modular-project");
+		String uriString = project.getFile("src/main/java/modular/Main.java").getLocationURI().toString();
+		ClasspathOptions options = new ClasspathOptions();
+		options.scope = "test";
+		ClasspathResult result = ProjectCommand.getClasspaths(uriString, options);
+		assertEquals(0, result.classpaths.length);
+		assertEquals(1, result.modulepaths.length);
+	}
 
-    @Test
-    public void testGetClasspathsForEclipse() throws Exception {
-        importProjects("eclipse/hello");
-        IProject project = WorkspaceHelper.getProject("hello");
-        String uriString = project.getFile("src/java/Bar.java").getLocationURI().toString();
-        ClasspathOptions options = new ClasspathOptions();
-        options.scope = "runtime";
-        ClasspathResult result = ProjectCommand.getClasspaths(uriString, options);
-        assertEquals(1, result.classpaths.length);
-        assertEquals(0, result.modulepaths.length);
+	@Test
+	public void testGetClasspathsForEclipse() throws Exception {
+		importProjects("eclipse/hello");
+		IProject project = WorkspaceHelper.getProject("hello");
+		String uriString = project.getFile("src/java/Bar.java").getLocationURI().toString();
+		ClasspathOptions options = new ClasspathOptions();
+		options.scope = "runtime";
+		ClasspathResult result = ProjectCommand.getClasspaths(uriString, options);
+		assertEquals(1, result.classpaths.length);
+		assertEquals(0, result.modulepaths.length);
 
-        options.scope = "test";
-        result = ProjectCommand.getClasspaths(uriString, options);
-        assertEquals(2, result.classpaths.length);
-        assertEquals(0, result.modulepaths.length);
-    }
+		options.scope = "test";
+		result = ProjectCommand.getClasspaths(uriString, options);
+		assertEquals(2, result.classpaths.length);
+		assertEquals(0, result.modulepaths.length);
+	}
 
-    @Test
-    public void testIsTestFileForMaven() throws Exception {
-        importProjects("maven/classpathtest");
-        IProject project = WorkspaceHelper.getProject("classpathtest");
-        String srcUri = project.getFile("src/main/java/main/App.java").getLocationURI().toString();
-        String testUri = project.getFile("src/test/java/test/AppTest.java").getLocationURI().toString();
-        assertFalse(ProjectCommand.isTestFile(srcUri));
-        assertTrue(ProjectCommand.isTestFile(testUri));
-    }
+	@Test
+	public void testIsTestFileForMaven() throws Exception {
+		importProjects("maven/classpathtest");
+		IProject project = WorkspaceHelper.getProject("classpathtest");
+		String srcUri = project.getFile("src/main/java/main/App.java").getLocationURI().toString();
+		String testUri = project.getFile("src/test/java/test/AppTest.java").getLocationURI().toString();
+		assertFalse(ProjectCommand.isTestFile(srcUri));
+		assertTrue(ProjectCommand.isTestFile(testUri));
+	}
 
-    @Test
-    public void testIsTestFileForGradle() throws Exception {
-        importProjects("gradle/simple-gradle");
-        IProject project = WorkspaceHelper.getProject("simple-gradle");
-        String srcUri = project.getFile("src/main/java/Library.java").getLocationURI().toString();
-        String testUri = project.getFile("src/test/java/LibraryTest.java").getLocationURI().toString();
-        assertFalse(ProjectCommand.isTestFile(srcUri));
-        assertTrue(ProjectCommand.isTestFile(testUri));
-    }
+	@Test
+	public void testIsTestFileForGradle() throws Exception {
+		importProjects("gradle/simple-gradle");
+		IProject project = WorkspaceHelper.getProject("simple-gradle");
+		String srcUri = project.getFile("src/main/java/Library.java").getLocationURI().toString();
+		String testUri = project.getFile("src/test/java/LibraryTest.java").getLocationURI().toString();
+		assertFalse(ProjectCommand.isTestFile(srcUri));
+		assertTrue(ProjectCommand.isTestFile(testUri));
+	}
 
-    @Test
-    public void getAllJavaProject() throws Exception {
-        importProjects("maven/multimodule");
-        List<URI> projects = ProjectCommand.getAllJavaProjects();
-        assertEquals(4, projects.size());
-    }
+	@Test
+	public void getAllJavaProject() throws Exception {
+		importProjects("maven/multimodule");
+		List<URI> projects = ProjectCommand.getAllJavaProjects();
+		assertEquals(4, projects.size());
+	}
 
 	private static Range START_OF_DOCUMENT = new Range(new Position(0, 0), new Position(0, 0));
 
@@ -318,6 +321,36 @@ public class ProjectCommandTest extends AbstractInvisibleProjectBasedTest {
 		requestedSymbol.setName("MyClass");
 		SymbolInformation resolvedSymbol = ProjectCommand.resolveWorkspaceSymbol(requestedSymbol);
 		assertEquals(resolvedSymbol.getLocation().getRange(), new Range(new Position(17, 21), new Position(17, 28)));
+	}
+
+	@Test
+	public void testUpdateProjectJdk() throws Exception {
+		importProjects("maven/salut");
+		IProject project = WorkspaceHelper.getProject("salut");
+		List<VmInstall> allVmInstalls = VmCommand.getAllVmInstalls();
+		VmInstall vmInstall = allVmInstalls.stream()
+				.filter(vm -> !vm.typeName.contains("org.eclipse.jdt.ls.core.internal.TestVMType"))
+				.findFirst().get();
+		ProjectCommand.updateProjectJdk(
+			project.getLocationURI().toString(),
+			vmInstall.path,
+			new NullProgressMonitor()
+		);
+		IJavaProject javaProject = ProjectUtils.getJavaProject(project);
+		IVMInstall vm = JavaRuntime.getVMInstall(javaProject);
+		assertEquals(vmInstall.path, vm.getInstallLocation().getAbsolutePath());
+	}
+
+	@Test
+	public void testUpdateInvalidProjectJdk() throws Exception {
+		importProjects("maven/salut");
+		IProject project = WorkspaceHelper.getProject("salut");
+		JdkUpdateResult updateProjectJdk = ProjectCommand.updateProjectJdk(
+			project.getLocationURI().toString(),
+			"invalid/path",
+			new NullProgressMonitor()
+		);
+		assertFalse(updateProjectJdk.success);
 	}
 
 	private SymbolInformation buildClassSymbol(IProject project, String fqClassName) throws Exception {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/VmCommandTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/VmCommandTest.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.commands;
+
+import org.eclipse.jdt.ls.core.internal.commands.VmCommand.VmInstall;
+import org.eclipse.jdt.ls.core.internal.managers.AbstractInvisibleProjectBasedTest;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+
+public class VmCommandTest extends AbstractInvisibleProjectBasedTest {
+
+	@Test
+	public void testGetAllVmInstalls() {
+		List<VmInstall> allVmInstalls = VmCommand.getAllVmInstalls();
+		assertTrue(allVmInstalls.size() > 0);
+
+		assertTrue(allVmInstalls.stream()
+				.anyMatch(vm -> vm.typeName.contains("org.eclipse.jdt.ls.core.internal.TestVMType"))
+		);
+	}
+}


### PR DESCRIPTION
Two delegate command is added:

`java.vm.getAllInstalls` - Get all vm installs.
`java.project.updateJdk` - Update the given project's jdk.

They will be used by the configure classpath webview at client side.

related with https://github.com/microsoft/vscode-java-pack/pull/1263