### PR TITLE
Introduce delegate command for java file paste

### DIFF
--- a/org.eclipse.jdt.ls.core/plugin.xml
+++ b/org.eclipse.jdt.ls.core/plugin.xml
@@ -136,6 +136,9 @@
             <command
                   id="java.vm.getAllInstalls">
             </command>
+             <command
+                  id="java.project.resolveText">
+            </command>
       </delegateCommandHandler>
    </extension>
    <extension

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
@@ -197,6 +197,8 @@ public class JDTDelegateCommandHandler implements IDelegateCommandHandler {
 					return new SmartDetectionHandler(smartDetectionParams).getLocation(monitor);
 				case VmCommand.GET_ALL_INSTALL_COMMAND_ID:
 					return VmCommand.getAllVmInstalls();
+				case "java.project.resolveText":
+					return PasteEventHandler.handleFilePasteEvent((String) arguments.get(0), (String) arguments.get(1), monitor);
 				default:
 					break;
 			}


### PR DESCRIPTION
Adds a delegate command that identifies whether or not some given clipboard text is a piece of java text and returns the correct path to the file to be created given relevant package declarations and/or type name.

Addresses https://github.com/redhat-developer/vscode-java/issues/3323.