### PR TITLE
Update target platform to 4.30 release.

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -25,7 +25,7 @@
             <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
             <unit id="org.mockito.mockito-core" version="0.0.0"/>
             <unit id="org.apache.commons.commons-io" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.30-I-builds/I20231030-1800/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.30/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.xtext.xbase.lib" version="0.0.0"/>


### PR DESCRIPTION
- Today is 4.30 GA and https://download.eclipse.org/eclipse/updates/4.30-I-builds/ are gone.