### PR TITLE
Fix multiline semantic highlighting for 'implements', 'extends', and 'permits' keywords

### DIFF
--- a/org.eclipse.jdt.ls.tests/projects/maven/semantic-tokens/src/main/java/foo/Constructors.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/semantic-tokens/src/main/java/foo/Constructors.java
@@ -32,5 +32,9 @@ public class Constructors {
 	}
 	
 	public interface TestInterface{}
-
+	class TestClass implements TestInterface{}
+	class TestExtends extends TestClass{}
+	class TestCombo extends TestClass implements TestInterface{}
+	sealed interface TestSealedInterface permits TestPermits{}
+	final class TestPermits implements TestSealedInterface{}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SemanticTokensHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SemanticTokensHandlerTest.java
@@ -219,9 +219,41 @@ public class SemanticTokensHandlerTest extends AbstractProjectsManagerBasedTest 
 			.assertNextToken("integer", "recordComponent", "declaration")
 			.assertNextToken("protected", "modifier")
 			.assertNextToken("InnerRecord", "record", "protected", "constructor", "declaration")
+
 			.assertNextToken("public", "modifier")
 			.assertNextToken("interface", "modifier")
 			.assertNextToken("TestInterface", "interface", "public", "static", "declaration")
+
+			.assertNextToken("class", "modifier")
+			.assertNextToken("TestClass", "class", "declaration")
+			.assertNextToken("implements", "modifier")
+			.assertNextToken("TestInterface", "interface", "public", "static")
+
+			.assertNextToken("class", "modifier")
+			.assertNextToken("TestExtends", "class", "declaration")
+			.assertNextToken("extends", "modifier")
+			.assertNextToken("TestClass", "class")
+
+			.assertNextToken("class", "modifier")
+			.assertNextToken("TestCombo", "class", "declaration")
+			.assertNextToken("extends", "modifier")
+			.assertNextToken("TestClass", "class")
+			.assertNextToken("implements", "modifier")
+			.assertNextToken("TestInterface", "interface", "public", "static")
+
+			.assertNextToken("sealed", "modifier")
+			.assertNextToken("interface", "modifier")
+			.assertNextToken("TestSealedInterface", "interface", "sealed", "static", "declaration")
+			.assertNextToken("permits", "modifier")
+			.assertNextToken("TestPermits", "class", "readonly")
+
+			.assertNextToken("final", "modifier")
+			.assertNextToken("class", "modifier")
+			.assertNextToken("TestPermits", "class", "readonly", "declaration")
+			.assertNextToken("implements", "modifier")
+			.assertNextToken("TestSealedInterface", "interface", "sealed", "static")
+
+
 		.endAssertion();
 	}
 


### PR DESCRIPTION
Addresses https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/2920#issuecomment-1788029479

Before:
![Screenshot from 2023-12-07 11-49-44](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/bf49fe58-43af-4d75-8a05-26c044821e3e)
![Screenshot from 2023-12-07 16-42-47](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/8db254aa-86a1-44a7-bf07-f1b4387bbf95)


After:
![Screenshot from 2023-12-07 14-52-59](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/a59faf35-af0f-4e4b-954c-8a457a13d53e)
![Screenshot from 2023-12-07 16-41-24](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/8e233733-7481-497d-81f5-63fcaae0c68b)
