### PR TITLE
Add support for new headless quick fixes from upstream

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -25,7 +25,7 @@
             <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
             <unit id="org.mockito.mockito-core" version="0.0.0"/>
             <unit id="org.apache.commons.commons-io" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.31-I-builds/I20231206-1800/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.31-I-builds/I20231208-1800/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.xtext.xbase.lib" version="0.0.0"/>

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/ConvertMethodReferenceToLambdaTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/ConvertMethodReferenceToLambdaTest.java
@@ -84,7 +84,7 @@ public class ConvertMethodReferenceToLambdaTest extends AbstractQuickFixTest {
 	@Test
 	public void testLambdaToMethodReference() throws Exception {
 		setIgnoredCommands("Assign statement to new field", "Extract to constant", "Extract to field", "Extract to local variable (replace all occurrences)", "Extract to local variable", "Introduce Parameter...",
-				ActionMessages.GenerateConstructorsAction_ellipsisLabel, ActionMessages.GenerateConstructorsAction_label, "Extract lambda body to method");
+				ActionMessages.GenerateConstructorsAction_ellipsisLabel, ActionMessages.GenerateConstructorsAction_label, "Extract lambda body to method", "Convert to method reference");
 		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
 		StringBuilder buf = new StringBuilder();
 		buf.append("package test1;\n");

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/VariableQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/VariableQuickFixTest.java
@@ -96,4 +96,34 @@ public class VariableQuickFixTest extends AbstractSelectionTest {
 		Expected e1 = new Expected("Join variable declaration", expected, JavaCodeActionKind.QUICK_ASSIST);
 		assertCodeActions(codeActions, e1);
 	}
+
+	@Test
+	public void testInvertEqualsExpectVariablesSwapped() throws Exception {
+		setOnly(JavaCodeActionKind.QUICK_ASSIST);
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+		String contents = """
+				package test1;
+				public class E {
+				    public void foo() {
+						String name1 = "John";
+						String name2 = "Doe";
+						if (name1.equals(name2)) {
+						}
+				    }
+				}""";
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", contents, false, null);
+		String expected = """
+				package test1;
+				public class E {
+				    public void foo() {
+						String name1 = "John";
+						String name2 = "Doe";
+						if (name2.equals(name1)) {
+						}
+				    }
+				}""";
+		List<Either<Command, CodeAction>> codeActions = evaluateCodeActions(cu, CodeActionUtil.getRange(cu, "name1.equals(name2)"));
+		Expected e1 = new Expected("Invert equals", expected, JavaCodeActionKind.QUICK_ASSIST);
+		assertCodeActions(codeActions, e1);
+	}
 }


### PR DESCRIPTION
Add new quick fixes namely

- ChangeLambdaBodyToBlock
- ChangeLambdaBodyToExpression
- ConvertLambdaToMethodReference
- AddInferredLambdaParameterTypes
- AddVarLambdaParameterTypes
- RemoveVarOrInferredLambdaParameterTypes
- InvertEqualsExpression