### PR TITLE
Use wrapper distribution when gradle-wrapper.properties exists.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/internal/gradle/checksums/WrapperValidator.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/internal/gradle/checksums/WrapperValidator.java
@@ -68,9 +68,9 @@ public class WrapperValidator {
 
 	public static final String GRADLE_CHECKSUMS = "/gradle/checksums/checksums.json";
 	public static final String GRADLE_VERSIONS = "/gradle/checksums/versions.json";
+	public static final String GRADLE_WRAPPER_JAR = "gradle/wrapper/gradle-wrapper.jar";
 	private static final int QUEUE_LENGTH = 20;
 	private static final String WRAPPER_CHECKSUM_URL = "wrapperChecksumUrl";
-	private static final String GRADLE_WRAPPER_JAR = "gradle/wrapper/gradle-wrapper.jar";
 
 	private static Set<String> allowed = new HashSet<>();
 	private static Set<String> disallowed = new HashSet<>();

--- a/org.eclipse.jdt.ls.tests/projects/gradle/no-gradlew/gradle/wrapper/gradle-wrapper.properties
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/no-gradlew/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+#Wed Aug 10 11:28:36 CST 2022
+distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionPath=wrapper/dists
+zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporterTest.java
@@ -741,6 +741,13 @@ public class GradleProjectImporterTest extends AbstractGradleBasedTest{
 		assertEquals("apt", AptConfig.getRawProcessorOptions(javaProject).get("test.arg"));
 	}
 
+	@Test
+	public void testGetGradleDistribution() {
+		File projectRoot = new File(getSourceProjectDirectory(), "gradle/no-gradlew");
+		GradleDistribution distribution = GradleProjectImporter.getGradleDistribution(projectRoot.toPath());
+		assertTrue(distribution instanceof WrapperGradleDistribution);
+	}
+
 	private ProjectConfiguration getProjectConfiguration(IProject project) {
 		org.eclipse.buildship.core.internal.configuration.BuildConfiguration buildConfig = CorePlugin.configurationManager().loadBuildConfiguration(project.getLocation().toFile());
 		return CorePlugin.configurationManager().createProjectConfiguration(buildConfig, project.getLocation().toFile());


### PR DESCRIPTION
In `GradleProjectImporter`, the previously implementation will use `GradleDistribution.fromBuild()` when the `gradlew` exists.

While checking the source of Gradle, the Gradle tooling api will check `gradle/wrapper/gradle-wrapper.properties` instead of the `gradlew`.

See: 

- https://github.com/gradle/gradle/blob/592f269cc959c3620413391e1dad68695e7adad2/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultGradleConnector.java#L169C48-L169C70
- https://github.com/gradle/gradle/blob/592f269cc959c3620413391e1dad68695e7adad2/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DistributionFactory.java#L59C59-L59C59
- https://github.com/gradle/gradle/blob/592f269cc959c3620413391e1dad68695e7adad2/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/wrapper/WrapperExecutor.java#L41

This PR changes the logic to use wrapper distribution (`GradleDistribution.fromBuild()`) when `gradle/wrapper/gradle-wrapper.properties` exists.

Meanwhile, this PR moves the gradle wrapper jar checksum validation into a non-blocking job, because tooling api will not use that jar to import the project. So, it's not necessary to do it during import synchronized.