### PR TITLE
Use AddMissingMethodDeclarationFixCore from jdt.core.manipulation. 

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/QuickAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/QuickAssistProcessor.java
@@ -1447,7 +1447,7 @@ public class QuickAssistProcessor {
 			if (fix != null) {
 				try {
 					var p = new ChangeCorrectionProposalCore(fix.getDisplayString(), fix.createChange(null), IProposalRelevance.ADD_INFERRED_LAMBDA_PARAMETER_TYPES);
-					resultingCollections.add(CodeActionHandler.wrap(p, CodeActionKind.QuickFix));
+					resultingCollections.add(CodeActionHandler.wrap(p, JavaCodeActionKind.QUICK_ASSIST));
 					return true;
 				} catch (CoreException e) {
 					// ignore

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/QuickAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/QuickAssistProcessor.java
@@ -62,15 +62,9 @@ import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.MethodReference;
 import org.eclipse.jdt.core.dom.Modifier;
-import org.eclipse.jdt.core.dom.Modifier.ModifierKeyword;
 import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.NameQualifiedType;
 import org.eclipse.jdt.core.dom.ParameterizedType;
-import org.eclipse.jdt.core.dom.PostfixExpression;
-import org.eclipse.jdt.core.dom.PrefixExpression;
-import org.eclipse.jdt.core.dom.PrefixExpression.Operator;
-import org.eclipse.jdt.core.dom.PrimitiveType;
-import org.eclipse.jdt.core.dom.QualifiedType;
 import org.eclipse.jdt.core.dom.ReturnStatement;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.SimpleType;
@@ -85,9 +79,7 @@ import org.eclipse.jdt.core.dom.ThisExpression;
 import org.eclipse.jdt.core.dom.ThrowStatement;
 import org.eclipse.jdt.core.dom.TryStatement;
 import org.eclipse.jdt.core.dom.Type;
-import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.TypeMethodReference;
-import org.eclipse.jdt.core.dom.TypeParameter;
 import org.eclipse.jdt.core.dom.UnionType;
 import org.eclipse.jdt.core.dom.VariableDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationExpression;
@@ -109,10 +101,10 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.Bindings;
 import org.eclipse.jdt.internal.corext.dom.CodeScopeBuilder;
 import org.eclipse.jdt.internal.corext.dom.GenericVisitor;
-import org.eclipse.jdt.internal.corext.dom.JdtASTMatcher;
 import org.eclipse.jdt.internal.corext.dom.ScopeAnalyzer;
 import org.eclipse.jdt.internal.corext.dom.Selection;
 import org.eclipse.jdt.internal.corext.fix.AddInferredLambdaParameterTypesFixCore;
+import org.eclipse.jdt.internal.corext.fix.AddMissingMethodDeclarationFixCore;
 import org.eclipse.jdt.internal.corext.fix.AddVarLambdaParameterTypesFixCore;
 import org.eclipse.jdt.internal.corext.fix.ChangeLambdaBodyToBlockFixCore;
 import org.eclipse.jdt.internal.corext.fix.ChangeLambdaBodyToExpressionFixCore;
@@ -140,7 +132,6 @@ import org.eclipse.jdt.internal.ui.text.correction.proposals.AssignToVariableAss
 import org.eclipse.jdt.internal.ui.text.correction.proposals.LinkedCorrectionProposalCore;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.RefactoringCorrectionProposalCore;
 import org.eclipse.jdt.ls.core.internal.JavaCodeActionKind;
-import org.eclipse.jdt.ls.core.internal.Messages;
 import org.eclipse.jdt.ls.core.internal.corrections.CorrectionMessages;
 import org.eclipse.jdt.ls.core.internal.corrections.ProposalKindWrapper;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.IProposalRelevance;
@@ -233,7 +224,8 @@ public class QuickAssistProcessor {
 				//				getMissingCaseStatementProposals(context, coveringNode, resultingCollections);
 			getStringConcatToTextBlockProposal(context, coveringNode, resultingCollections);
 			// }
-			getAddMethodDeclaration(context, coveringNode, resultingCollections);
+			//getAddMethodDeclaration(context, coveringNode, resultingCollections);
+			getAddMissingMethodDeclarationProposal(context, coveringNode, resultingCollections);
 			getTryWithResourceProposals(locations, context, coveringNode, resultingCollections);
 			getConvertToSwitchExpressionProposals(context, coveringNode, resultingCollections);
 
@@ -924,376 +916,6 @@ public class QuickAssistProcessor {
 		return true;
 	}
 
-	private static Expression getSingleExpressionFromLambdaBody(Block lambdaBody) {
-		if (lambdaBody.statements().size() != 1) {
-			return null;
-		}
-		Statement singleStatement = (Statement) lambdaBody.statements().get(0);
-		if (singleStatement instanceof ReturnStatement returnStatement) {
-			return returnStatement.getExpression();
-		} else if (singleStatement instanceof ExpressionStatement expressionStatement) {
-			Expression expression = expressionStatement.getExpression();
-			if (isValidLambdaExpressionBody(expression)) {
-				return expression;
-			}
-		}
-		return null;
-	}
-
-	private static boolean isValidLambdaExpressionBody(Expression expression) {
-		if (expression instanceof Assignment || expression instanceof ClassInstanceCreation || expression instanceof MethodInvocation || expression instanceof PostfixExpression || expression instanceof SuperMethodInvocation) {
-			return true;
-		}
-		if (expression instanceof PrefixExpression prefixExpression) {
-			Operator operator = prefixExpression.getOperator();
-			if (operator == Operator.INCREMENT || operator == Operator.DECREMENT) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	private static boolean isValidLambdaReferenceToMethod(Expression expression) {
-		return expression instanceof ClassInstanceCreation || expression instanceof ArrayCreation || expression instanceof SuperMethodInvocation || expression instanceof MethodInvocation;
-	}
-
-	private static boolean matches(List<Expression> expected, List<Expression> toMatch) {
-		if (toMatch.size() != expected.size()) {
-			return false;
-		}
-		for (int i = 0; i < toMatch.size(); i++) {
-			if (!JdtASTMatcher.doNodesMatch(expected.get(i), toMatch.get(i))) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	private static boolean representsDefiningNode(ASTNode innerNode, ASTNode definingNode) {
-		// Example: We want to enable the proposal when the method invocation node or
-		// the method name is near the caret. But not when the caret is on an argument of the method invocation.
-		if (innerNode == definingNode) {
-			return true;
-		}
-
-		switch (definingNode.getNodeType()) {
-			// types from isValidLambdaReferenceToMethod():
-			case ASTNode.CLASS_INSTANCE_CREATION:
-				return representsDefiningNode(innerNode, ((ClassInstanceCreation) definingNode).getType());
-			case ASTNode.ARRAY_CREATION:
-				return representsDefiningNode(innerNode, ((ArrayCreation) definingNode).getType());
-			case ASTNode.SUPER_METHOD_INVOCATION:
-				return innerNode == ((SuperMethodInvocation) definingNode).getName();
-			case ASTNode.METHOD_INVOCATION:
-				return innerNode == ((MethodInvocation) definingNode).getName();
-
-			// subtypes of Type:
-			case ASTNode.NAME_QUALIFIED_TYPE:
-				return innerNode == ((NameQualifiedType) definingNode).getName();
-			case ASTNode.QUALIFIED_TYPE:
-				return innerNode == ((QualifiedType) definingNode).getName();
-			case ASTNode.SIMPLE_TYPE:
-				return innerNode == ((SimpleType) definingNode).getName();
-			case ASTNode.ARRAY_TYPE:
-				return representsDefiningNode(innerNode, ((ArrayType) definingNode).getElementType());
-			case ASTNode.PARAMETERIZED_TYPE:
-				return representsDefiningNode(innerNode, ((ParameterizedType) definingNode).getType());
-
-			default:
-				return false;
-		}
-	}
-
-	private static boolean isNestedInterfaceClass(AST ast, ITypeBinding lambdaMethodDeclaringClass, ITypeBinding lambdaMethodInvokingClass) {
-		ITypeBinding[] methodNarrowingTypes = ASTResolving.getRelaxingTypes(ast, lambdaMethodDeclaringClass);
-		ITypeBinding[] lambdaNarrowingTypes = ASTResolving.getRelaxingTypes(ast, lambdaMethodInvokingClass);
-
-		if (methodNarrowingTypes.length != 1) {
-			return false;
-		}
-		ITypeBinding methodNarrowingType = methodNarrowingTypes[0];
-		for (ITypeBinding lambdaNarrowingType : lambdaNarrowingTypes) {
-			if (methodNarrowingType == lambdaNarrowingType) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	/*
-	 * return TRUE if lambda declaration class is nested class of method declaration class
-	 */
-	private static boolean isNestedClass(ITypeBinding methodDeclarationType, ITypeBinding lambdaDeclarationType) {
-		ITypeBinding parent = lambdaDeclarationType;
-		while (parent.isNested()) {
-			parent = parent.getDeclaringClass();
-			if (parent == methodDeclarationType) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	private static ITypeBinding getNestedRootClass(ITypeBinding lambdaDeclarationType) {
-		ITypeBinding parent = lambdaDeclarationType;
-		while (parent.isNested()) {
-			parent = parent.getDeclaringClass();
-		}
-		return parent;
-	}
-
-	/*
-	 * return TRUE if method declaration class is super class of lambda declaration class
-	 */
-	private static boolean isSuperClass(ITypeBinding methodDeclarationType, ITypeBinding lambdaDeclarationType) {
-		ITypeBinding parent = lambdaDeclarationType.getSuperclass();
-		while (parent != null) {
-			if (parent == methodDeclarationType) {
-				return true;
-			}
-			parent = parent.getSuperclass();
-		}
-		return false;
-	}
-
-	private static void addIfMissing(MethodDeclaration methodDeclaration, TypeParameter newTypeParameter) {
-		List<TypeParameter> typeParameters = methodDeclaration.typeParameters();
-		for (TypeParameter typeParameter : typeParameters) {
-			boolean equals = typeParameter.getName().getFullyQualifiedName().equals(newTypeParameter.getName().getFullyQualifiedName());
-			if (equals) {
-				return;
-			}
-		}
-		typeParameters.add(newTypeParameter);
-	}
-
-	private static class ReturnType {
-		public Type type;
-
-		public ITypeBinding binding;
-	}
-
-	private static ReturnType getReturnType(AST ast, ImportRewrite importRewrite, Type variableType) {
-		ReturnType returnType = new ReturnType();
-		if (variableType instanceof ParameterizedType parameterizedType) {
-			variableType = (Type) parameterizedType.typeArguments().get(0);
-			ITypeBinding returnTypeBinding = variableType.resolveBinding();
-			if (returnTypeBinding != null) {
-				if (returnTypeBinding.isCapture()) {
-					returnType.binding = returnTypeBinding.getErasure();
-					returnType.type = importRewrite.addImport(returnTypeBinding.getErasure(), ast);
-				} else if (returnTypeBinding.isWildcardType()) {
-					returnType.binding = returnTypeBinding.getBound();
-					returnType.type = importRewrite.addImport(returnTypeBinding.getBound(), ast);
-				} else {
-					returnType.type = importRewrite.addImport(returnTypeBinding, ast);
-					returnType.binding = returnTypeBinding;
-				}
-			}
-		}
-		return returnType;
-	}
-
-	private static Block getNewReturnBlock(AST ast, ITypeBinding returnTypeBinding) {
-		Block newBlock = ast.newBlock();
-		if (!"void".equals(returnTypeBinding.getName())) { //$NON-NLS-1$
-			ReturnStatement newReturnStatement = ast.newReturnStatement();
-			String bName = returnTypeBinding.getBinaryName();
-			if ("Z".equals(bName)) { //$NON-NLS-1$
-				newReturnStatement.setExpression(ast.newBooleanLiteral(false));
-			} else if (returnTypeBinding.isPrimitive()) {
-				newReturnStatement.setExpression(ast.newNumberLiteral());
-			} else if ("java.lang.String".equals(bName)) { //$NON-NLS-1$
-				newReturnStatement.setExpression(ast.newStringLiteral());
-			} else {
-				newReturnStatement.setExpression(ast.newNullLiteral());
-			}
-			newBlock.statements().add(newReturnStatement);
-		}
-		return newBlock;
-	}
-
-	public static boolean getAddMethodDeclaration(IInvocationContextCore context, ASTNode covering, Collection<ProposalKindWrapper> resultingCollections) {
-		CompilationUnit astRoot = context.getASTRoot();
-		ExpressionMethodReference methodReferenceNode = covering instanceof ExpressionMethodReference expressionMethodReference ? expressionMethodReference : ASTNodes.getParent(covering, ExpressionMethodReference.class);
-		if (methodReferenceNode == null) {
-			return false;
-		}
-		boolean addStaticModifier = false;
-		TypeDeclaration typeDeclaration = ASTNodes.getParent(methodReferenceNode, TypeDeclaration.class);
-
-		if (isTypeReferenceToInstanceMethod(methodReferenceNode)) {
-			String methodReferenceQualifiedName = ((Name) methodReferenceNode.getExpression()).getFullyQualifiedName();
-			String typeDeclarationName = astRoot.getPackage().getName().getFullyQualifiedName() + '.' + typeDeclaration.getName().getFullyQualifiedName();
-			if (!methodReferenceQualifiedName.equals(typeDeclarationName) && !methodReferenceQualifiedName.equals(typeDeclaration.getName().getFullyQualifiedName())) {
-				// only propose for references in same class
-				return false;
-			}
-			addStaticModifier = true;
-		}
-
-		AST ast = astRoot.getAST();
-		ASTRewrite rewrite = ASTRewrite.create(ast);
-		ListRewrite listRewrite = rewrite.getListRewrite(typeDeclaration, TypeDeclaration.BODY_DECLARATIONS_PROPERTY);
-
-		String label = Messages.format(CorrectionMessages.AddUnimplementedMethodReferenceOperation_AddMissingMethod_group,
-				new String[] { methodReferenceNode.getName().getIdentifier(), typeDeclaration.getName().getIdentifier() });
-		ASTRewriteCorrectionProposalCore proposal = new ASTRewriteCorrectionProposalCore(label, context.getCompilationUnit(), rewrite, IProposalRelevance.ADD_INFERRED_LAMBDA_PARAMETER_TYPES);
-		// ImportRewrite importRewrite= proposal.createImportRewrite(context.getASTRoot());
-		ImportRewrite importRewrite = StubUtility.createImportRewrite(astRoot, true);
-
-		VariableDeclarationStatement variableDeclarationStatement = ASTNodes.getParent(methodReferenceNode, VariableDeclarationStatement.class);
-		MethodInvocation methodInvocationNode = ASTNodes.getParent(methodReferenceNode, MethodInvocation.class);
-		Assignment variableAssignment = ASTNodes.getParent(methodReferenceNode, Assignment.class);
-
-		if ((variableAssignment != null || variableDeclarationStatement != null) && methodInvocationNode == null) {
-			/*
-			 * variable declaration
-			 */
-			Type type = null;
-			ReturnType returnType = null;
-			if (variableDeclarationStatement != null) {
-				type = variableDeclarationStatement.getType();
-				returnType = getReturnType(ast, importRewrite, type);
-			} else {
-				Expression leftHandSide = variableAssignment.getLeftHandSide();
-				ITypeBinding assignmentTypeBinding = leftHandSide.resolveTypeBinding();
-				if (assignmentTypeBinding == null) {
-					return false;
-				}
-				type = importRewrite.addImport(assignmentTypeBinding, ast);
-				returnType = new ReturnType();
-				returnType.type = type;
-				returnType.binding = assignmentTypeBinding;
-			}
-			if (returnType.binding == null) {
-				return false;
-			}
-			MethodDeclaration newMethodDeclaration = ast.newMethodDeclaration();
-			newMethodDeclaration.setName((SimpleName) rewrite.createCopyTarget(methodReferenceNode.getName()));
-			newMethodDeclaration.modifiers().add(ast.newModifier(ModifierKeyword.PRIVATE_KEYWORD));
-			if (addStaticModifier) {
-				newMethodDeclaration.modifiers().add(ast.newModifier(ModifierKeyword.STATIC_KEYWORD));
-			}
-
-			IMethodBinding functionalInterfaceMethod = variableDeclarationStatement == null ? returnType.binding.getFunctionalInterfaceMethod() : variableDeclarationStatement.getType().resolveBinding().getFunctionalInterfaceMethod();
-			if (functionalInterfaceMethod != null) {
-				returnType.type = importRewrite.addImport(functionalInterfaceMethod.getReturnType(), ast);
-				returnType.binding = functionalInterfaceMethod.getReturnType();
-				ITypeBinding[] typeArguments = functionalInterfaceMethod.getParameterTypes();
-				for (int i = 0; i < typeArguments.length; i++) {
-					ITypeBinding iTypeBinding = typeArguments[i];
-					SingleVariableDeclaration newSingleVariableDeclaration = ast.newSingleVariableDeclaration();
-					newSingleVariableDeclaration.setName(ast.newSimpleName(iTypeBinding.getErasure().getName().toLowerCase() + (i + 1)));
-					newSingleVariableDeclaration.setType(importRewrite.addImport(iTypeBinding.getErasure(), ast));
-					newMethodDeclaration.parameters().add(newSingleVariableDeclaration);
-				}
-			}
-			newMethodDeclaration.setReturnType2(returnType.type);
-			Block newBlock = getNewReturnBlock(ast, returnType.binding);
-			newMethodDeclaration.setBody(newBlock);
-			listRewrite.insertLast(newMethodDeclaration, null);
-
-			// add proposal
-			resultingCollections.add(CodeActionHandler.wrap(proposal,  CodeActionKind.QuickFix));
-			return true;
-		}
-
-		/*
-		 * method invocation
-		 */
-		IMethodBinding methodBinding = methodInvocationNode == null ? null : methodInvocationNode.resolveMethodBinding();
-		if (methodBinding == null) {
-			return false;
-		}
-		List<ASTNode> arguments = methodInvocationNode.arguments();
-		int index = -1;
-		for (int i = 0; i < arguments.size(); i++) {
-			ASTNode node = arguments.get(i);
-			if (node.equals(methodReferenceNode)) {
-				index = i;
-				break;
-			}
-		}
-		ITypeBinding[] parameterTypes = methodBinding.getParameterTypes();
-		ITypeBinding[] typeArguments = methodBinding.getTypeArguments();
-		ITypeBinding[] parameterTypesFunctionalInterface = parameterTypes[index].getFunctionalInterfaceMethod().getParameterTypes();
-		ITypeBinding returnTypeBindingFunctionalInterface = parameterTypes[index].getFunctionalInterfaceMethod().getReturnType();
-		MethodDeclaration newMethodDeclaration = ast.newMethodDeclaration();
-		newMethodDeclaration.modifiers().add(ast.newModifier(ModifierKeyword.PRIVATE_KEYWORD));
-		if (addStaticModifier) {
-			newMethodDeclaration.modifiers().add(ast.newModifier(ModifierKeyword.STATIC_KEYWORD));
-		}
-		Type newReturnType = null;
-		if (returnTypeBindingFunctionalInterface.isPrimitive()) {
-			newReturnType = ast.newPrimitiveType(PrimitiveType.toCode(returnTypeBindingFunctionalInterface.getName()));
-		} else {
-			newReturnType = importRewrite.addImport(returnTypeBindingFunctionalInterface, ast);
-			ITypeBinding[] typeParameters = typeDeclaration.resolveBinding().getTypeParameters();
-			bIf: if (returnTypeBindingFunctionalInterface.isTypeVariable() || returnTypeBindingFunctionalInterface.isParameterizedType()) {
-				for (ITypeBinding typeParameter : typeParameters) {
-					// check if parameter type is a Type parameter of the class
-					if (Bindings.equals(typeParameter, returnTypeBindingFunctionalInterface)) {
-						break bIf;
-					}
-				}
-				TypeParameter newTypeParameter = ast.newTypeParameter();
-				newTypeParameter.setName(ast.newSimpleName(returnTypeBindingFunctionalInterface.getName()));
-				addIfMissing(newMethodDeclaration, newTypeParameter);
-			}
-		}
-		newMethodDeclaration.setName((SimpleName) rewrite.createCopyTarget(methodReferenceNode.getName()));
-		newMethodDeclaration.setReturnType2(newReturnType);
-		pLoop: for (int i = 0; i < parameterTypesFunctionalInterface.length; i++) {
-			ITypeBinding parameterType2 = parameterTypesFunctionalInterface[i];
-			SingleVariableDeclaration newSingleVariableDeclaration = ast.newSingleVariableDeclaration();
-			if (parameterType2.isCapture()) {
-				newSingleVariableDeclaration.setName(ast.newSimpleName(parameterType2.getErasure().getName().toLowerCase() + (i + 1)));
-				newSingleVariableDeclaration.setType(importRewrite.addImport(parameterType2.getErasure(), ast));
-			} else {
-				newSingleVariableDeclaration.setName(ast.newSimpleName(parameterType2.getName().toLowerCase() + (i + 1)));
-				newSingleVariableDeclaration.setType(importRewrite.addImport(parameterType2, ast));
-			}
-			newMethodDeclaration.parameters().add(newSingleVariableDeclaration);
-			ITypeBinding[] typeParameters = typeDeclaration.resolveBinding().getTypeParameters();
-			if (parameterType2.isTypeVariable()) {
-				// check if parameter type is a Type parameter of the class
-				for (ITypeBinding typeParameter : typeParameters) {
-					if (Bindings.equals(typeParameter, parameterType2)) {
-						continue pLoop;
-					}
-				}
-
-				TypeParameter newTypeParameter = ast.newTypeParameter();
-				newTypeParameter.setName(ast.newSimpleName(importRewrite.addImport(parameterType2)));
-				ITypeBinding[] typeBounds = parameterType2.getTypeBounds();
-				for (ITypeBinding typeBound : typeBounds) {
-					newTypeParameter.typeBounds().add(importRewrite.addImport(typeBound, ast));
-				}
-				addIfMissing(newMethodDeclaration, newTypeParameter);
-			}
-		}
-		for (int i = 0; i < typeArguments.length; i++) {
-			ITypeBinding typeArgument = typeArguments[i];
-			SingleVariableDeclaration newSingleVariableDeclaration = ast.newSingleVariableDeclaration();
-			newSingleVariableDeclaration.setName(ast.newSimpleName(typeArgument.getName().toLowerCase() + (i + 1)));
-			newSingleVariableDeclaration.setType(importRewrite.addImport(typeArgument, ast));
-			newMethodDeclaration.parameters().add(newSingleVariableDeclaration);
-			if (typeArgument.isTypeVariable()) {
-				TypeParameter newTypeParameter = ast.newTypeParameter();
-				newTypeParameter.setName(ast.newSimpleName(importRewrite.addImport(typeArgument)));
-				newMethodDeclaration.typeParameters().add(newTypeParameter);
-			}
-		}
-		Block newBlock = getNewReturnBlock(ast, returnTypeBindingFunctionalInterface);
-		newMethodDeclaration.setBody(newBlock);
-		listRewrite.insertLast(newMethodDeclaration, null);
-
-		// add proposal
-		resultingCollections.add(CodeActionHandler.wrap(proposal, CodeActionKind.QuickFix));
-		return true;
-	}
-
 	public static boolean getTryWithResourceProposals(IProblemLocationCore[] locations, IInvocationContextCore context, ASTNode node, Collection<ProposalKindWrapper> resultingCollections) throws IllegalArgumentException, CoreException {
 		final List<Integer> exceptionProblems = Arrays.asList(IProblem.UnclosedCloseable, IProblem.UnclosedCloseable, IProblem.PotentiallyUnclosedCloseable, IProblem.UnhandledException);
 		if (problemExists(locations, exceptionProblems)) {
@@ -1810,6 +1432,22 @@ public class QuickAssistProcessor {
 				try {
 					var p = new ChangeCorrectionProposalCore(fix.getDisplayString(), fix.createChange(null), IProposalRelevance.CONVERT_TO_MESSAGE_FORMAT);
 					resultingCollections.add(CodeActionHandler.wrap(p, JavaCodeActionKind.QUICK_ASSIST));
+					return true;
+				} catch (CoreException e) {
+					// ignore
+				}
+			}
+		}
+		return false;
+	}
+
+	private boolean getAddMissingMethodDeclarationProposal(IInvocationContextCore context, ASTNode coveringNode, ArrayList<ProposalKindWrapper> resultingCollections) {
+		if (resultingCollections != null) {
+			var fix = AddMissingMethodDeclarationFixCore.createAddMissingMethodDeclaration(context.getASTRoot(), coveringNode);
+			if (fix != null) {
+				try {
+					var p = new ChangeCorrectionProposalCore(fix.getDisplayString(), fix.createChange(null), IProposalRelevance.ADD_INFERRED_LAMBDA_PARAMETER_TYPES);
+					resultingCollections.add(CodeActionHandler.wrap(p, CodeActionKind.QuickFix));
 					return true;
 				} catch (CoreException e) {
 					// ignore

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -25,7 +25,7 @@
             <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
             <unit id="org.mockito.mockito-core" version="0.0.0"/>
             <unit id="org.apache.commons.commons-io" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.31-I-builds/I20240111-0700/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.31-I-builds/I20240112-1800/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.xtext.xbase.lib" version="0.0.0"/>

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/AddMissingMethodDeclarationQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/AddMissingMethodDeclarationQuickFixTest.java
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Gayan Perera - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.correction;
+
+import java.util.Hashtable;
+import java.util.List;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.ls.core.internal.CodeActionUtil;
+import org.eclipse.jdt.ls.core.internal.JavaCodeActionKind;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionKind;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AddMissingMethodDeclarationQuickFixTest extends AbstractSelectionTest {
+
+	private IJavaProject fJProject1;
+
+	private IPackageFragmentRoot fSourceFolder;
+
+	@Before
+	public void setup() throws Exception {
+		fJProject1 = newEmptyProject();
+		Hashtable<String, String> options = TestOptions.getDefaultOptions();
+		fJProject1.setOptions(options);
+		fSourceFolder = fJProject1.getPackageFragmentRoot(fJProject1.getProject().getFolder("src"));
+	}
+
+	@Test
+	public void testAddMissingMethodDecl_MethodReferenceInStaticContext() throws Exception {
+		setOnly(JavaCodeActionKind.QUICK_ASSIST, CodeActionKind.QuickFix);
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+		//@formatter:off
+		var contents = """
+				package test1;
+				public class App {
+					public static void filter(Func<String> predication) {}
+
+					public static void foo() {
+						App.filter(App::notEmpty);
+					}
+
+					interface Func<T> {
+						boolean test(T value);
+					}
+				}
+				""";
+		//@formatter:on
+		ICompilationUnit cu = pack1.createCompilationUnit("App.java", contents, false, null);
+		//@formatter:off
+		var expected = """
+				package test1;
+				public class App {
+					public static void filter(Func<String> predication) {}
+
+					public static void foo() {
+						App.filter(App::notEmpty);
+					}
+
+					interface Func<T> {
+						boolean test(T value);
+					}
+
+				    private static boolean notEmpty(String string1) {
+				        return false;
+				    }
+				}
+				""";
+		//@formatter:on
+		List<Either<Command, CodeAction>> codeActions = evaluateCodeActions(cu, CodeActionUtil.getRange(cu, "notEmpty"));
+		Expected e1 = new Expected("Add missing method 'notEmpty' to class 'App'", expected, CodeActionKind.QuickFix);
+		assertCodeActions(codeActions, e1);
+	}
+
+	@Test
+	public void testAddMissingMethodDecl_MethodReferenceInObjectInstanceContext() throws Exception {
+		setOnly(JavaCodeActionKind.QUICK_ASSIST, CodeActionKind.QuickFix);
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+		//@formatter:off
+		var contents = """
+				package test1;
+				public class App {
+					public void filter(Func<String> predication) {}
+
+					public void foo() {
+						this.filter(this::notEmpty);
+					}
+
+					interface Func<T> {
+						boolean test(T value);
+					}
+				}
+				""";
+		//@formatter:on
+		ICompilationUnit cu = pack1.createCompilationUnit("App.java", contents, false, null);
+		//@formatter:off
+		var expected = """
+				package test1;
+				public class App {
+					public void filter(Func<String> predication) {}
+
+					public void foo() {
+						this.filter(this::notEmpty);
+					}
+
+					interface Func<T> {
+						boolean test(T value);
+					}
+
+				    private boolean notEmpty(String string1) {
+				        return false;
+				    }
+				}
+				""";
+		//@formatter:on
+		List<Either<Command, CodeAction>> codeActions = evaluateCodeActions(cu, CodeActionUtil.getRange(cu, "notEmpty"));
+		Expected e1 = new Expected("Add missing method 'notEmpty' to class 'App'", expected, CodeActionKind.QuickFix);
+		assertCodeActions(codeActions, e1);
+	}
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/AddMissingMethodDeclarationQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/AddMissingMethodDeclarationQuickFixTest.java
@@ -84,7 +84,7 @@ public class AddMissingMethodDeclarationQuickFixTest extends AbstractSelectionTe
 				""";
 		//@formatter:on
 		List<Either<Command, CodeAction>> codeActions = evaluateCodeActions(cu, CodeActionUtil.getRange(cu, "notEmpty"));
-		Expected e1 = new Expected("Add missing method 'notEmpty' to class 'App'", expected, CodeActionKind.QuickFix);
+		Expected e1 = new Expected("Add missing method 'notEmpty' to class 'App'", expected, JavaCodeActionKind.QUICK_ASSIST);
 		assertCodeActions(codeActions, e1);
 	}
 
@@ -130,7 +130,7 @@ public class AddMissingMethodDeclarationQuickFixTest extends AbstractSelectionTe
 				""";
 		//@formatter:on
 		List<Either<Command, CodeAction>> codeActions = evaluateCodeActions(cu, CodeActionUtil.getRange(cu, "notEmpty"));
-		Expected e1 = new Expected("Add missing method 'notEmpty' to class 'App'", expected, CodeActionKind.QuickFix);
+		Expected e1 = new Expected("Add missing method 'notEmpty' to class 'App'", expected, JavaCodeActionKind.QUICK_ASSIST);
 		assertCodeActions(codeActions, e1);
 	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandlerTest.java
@@ -635,7 +635,7 @@ public class CodeActionHandlerTest extends AbstractCompilationUnitBasedTest {
 		List<Either<Command, CodeAction>> codeActions = getCodeActions(params);
 
 		Assert.assertNotNull(codeActions);
-		CodeAction action = codeActions.get(0).getRight();
+		CodeAction action = codeActions.get(1).getRight();
 		Assert.assertEquals("Add missing method 'action' to class 'Foo'", action.getTitle());
 	}
 


### PR DESCRIPTION
Replace the LS specific implementation with the headless implementation from jdt.core for adding missing method reference quick fix proposals. 