### PR TITLE
Allow generic snippets to be computed when completion token is null.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetCompletionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetCompletionProposal.java
@@ -289,7 +289,7 @@ public class SnippetCompletionProposal extends CompletionProposal {
 		CompletionContext completionContext = scc.getCompletionContext();
 		char[] completionToken = completionContext.getToken();
 		if (completionToken == null) {
-			return Collections.emptyList();
+			completionToken = new char[0];
 		}
 		int tokenLocation = completionContext.getTokenLocation();
 		JavaContextType contextType = null;
@@ -430,7 +430,10 @@ public class SnippetCompletionProposal extends CompletionProposal {
 	public static String evaluateGenericTemplate(ICompilationUnit cu, CompletionContext completionContext, Template template) {
 		JavaContextType contextType = (JavaContextType) JavaLanguageServerPlugin.getInstance().getTemplateContextRegistry().getContextType(template.getContextTypeId());
 		char[] completionToken = completionContext.getToken();
-		if (contextType == null || completionToken == null) {
+		if (completionToken == null) {
+			completionToken = new char[0];
+		}
+		if (contextType == null) {
 			return null;
 		}
 


### PR DESCRIPTION
- Fixes redhat-developer/vscode-java#3466

This approach should be ok because we don't seem to use the token value at all when calculating generic snippets. Also, a similar approach in https://github.com/eclipse-jdtls/eclipse.jdt.ls/blob/8f0f822a89bf1f6109a9d95d048e7b53110df19f/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/JavadocCompletionProposal.java#L85 .