### PR TITLE
Support get project nature ids

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
@@ -73,6 +73,7 @@ import org.eclipse.lsp4j.SymbolInformation;
 
 public class ProjectCommand {
 
+	public static final String NATURE_IDS = IConstants.PLUGIN_ID + ".natureIds";
 	public static final String VM_LOCATION = IConstants.PLUGIN_ID + ".vm.location";
 	public static final String SOURCE_PATHS = IConstants.PLUGIN_ID + ".sourcePaths";
 	public static final String OUTPUT_PATH = IConstants.PLUGIN_ID + ".outputPath";
@@ -90,6 +91,7 @@ public class ProjectCommand {
 	 *        <p>
 	 *        Besides the options defined in JavaCore, the following keys can also be used:
 	 *        <ul>
+	 *          <li>"org.eclipse.jdt.ls.core.natureIds": Get the nature ids of the given project</li>
 	 *          <li>"org.eclipse.jdt.ls.core.vm.location": Get the location of the VM assigned to build the given Java project.</li>
 	 *          <li>"org.eclipse.jdt.ls.core.sourcePaths": Get the source root paths of the given Java project.</li>
 	 *          <li>"org.eclipse.jdt.ls.core.outputPath": Get the default output path of the given Java project. Note that the default output path
@@ -107,6 +109,9 @@ public class ProjectCommand {
 		Map<String, Object> settings = new HashMap<>();
 		for (String key : settingKeys) {
 			switch(key) {
+				case NATURE_IDS:
+					settings.putIfAbsent(key, project.getDescription().getNatureIds());
+					break;
 				case VM_LOCATION:
 					IVMInstall vmInstall = JavaRuntime.getVMInstall(javaProject);
 					if (vmInstall == null) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
@@ -32,6 +32,7 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.launching.IVMInstall;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
@@ -47,12 +48,26 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.m2e.core.internal.IMavenConstants;
 import org.junit.Test;
 
 /**
  * ProjectCommandTest
  */
 public class ProjectCommandTest extends AbstractInvisibleProjectBasedTest {
+
+	@Test
+	public void testGetProjectNatureIds() throws Exception {
+		importProjects("maven/salut");
+		IProject project = WorkspaceHelper.getProject("salut");
+		String uriString = project.getLocationURI().toString();
+		List<String> settingKeys = Arrays.asList("org.eclipse.jdt.ls.core.natureIds");
+		Map<String, Object> options = ProjectCommand.getProjectSettings(uriString, settingKeys);
+		List<String> natureIds = Arrays.asList((String[]) options.get("org.eclipse.jdt.ls.core.natureIds"));
+		assertEquals(2, natureIds.size());
+		assertTrue(natureIds.contains(JavaCore.NATURE_ID));
+		assertTrue(natureIds.contains(IMavenConstants.NATURE_ID));
+	}
 
 	@Test
 	public void testGetProjectSettingsForMavenJava7() throws Exception {


### PR DESCRIPTION
Can be used by other extensions to get the project type.