### PR TITLE
Adjust testcase due to differing diagnostics from JEP 445.

### DIFF
--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentLifeCycleHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentLifeCycleHandlerTest.java
@@ -1008,17 +1008,17 @@ public class DocumentLifeCycleHandlerTest extends AbstractProjectsManagerBasedTe
 		Path filePath = Files.createTempDirectory("testDiagnosticsOnExternalFileWithInternalProject").resolve("A.java");
 		try {
 			String content = "error public class A { }";
-			Files.writeString(filePath, content); 
+			Files.writeString(filePath, content);
 			lifeCycleHandler.didOpen(new DidOpenTextDocumentParams(new TextDocumentItem(filePath.toUri().toString(), "java", 0, content)));
 			List<PublishDiagnosticsParams> diagnosticReports = getClientRequests("publishDiagnostics");
 			assertFalse("No diagnostics sent on open", diagnosticReports.isEmpty());
 			List<Diagnostic> diagnostics = diagnosticReports.get(0).getDiagnostics();
-			assertTrue("First diagnostics not sent", diagnostics.stream().map(Diagnostic::getMessage).anyMatch(message -> message.contains("error on token \"error\"")));
+			assertTrue("First diagnostics not sent", diagnostics.stream().map(Diagnostic::getMessage).anyMatch(message -> message.contains("Syntax error")));
 			lifeCycleHandler.didChange(new DidChangeTextDocumentParams(new VersionedTextDocumentIdentifier(filePath.toUri().toString(), 0), List.of(new TextDocumentContentChangeEvent(new Range(new Position(0, 0), new Position(0, 0)), "another"))));
 			diagnosticReports = getClientRequests("publishDiagnostics");
 			assertEquals("No diagnostics sent on change", 2, diagnosticReports.size());
 			diagnostics = diagnosticReports.get(1).getDiagnostics();
-			assertTrue("diagnostics not updated upon edit", diagnostics.stream().map(Diagnostic::getMessage).anyMatch(message -> message.contains("error on token \"anothererror\"")));
+			assertTrue("diagnostics not updated upon edit", diagnostics.stream().map(Diagnostic::getMessage).anyMatch(message -> message.contains("Syntax error")));
 		} finally {
 			Files.delete(filePath);
 			Files.delete(filePath.getParent());


### PR DESCRIPTION
- Unnamed classes (JEP 445) has changed diagnostics reported on invalid class declarations

**Before JEP 445**
![Screenshot from 2024-02-02 20-51-20](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/1417342/67b64759-097b-4d97-99c6-fff647cf298f)

**With JEP 445**
![Screenshot from 2024-02-02 20-48-12](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/1417342/610c6218-25d4-4946-a2d4-0053f98b2fe5)

CC'in @datho7561 for awareness. We should probably run the JDT-LS tests as part of updating the incubator to avoid any surprises.