### PR TITLE
Introduce completion item collapse for method overloads

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalReplacementProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalReplacementProvider.java
@@ -209,7 +209,7 @@ public class CompletionProposalReplacementProvider {
 			if (!completionBuffer.isEmpty()) {
 				return completionBuffer.toString();
 			}
-			
+
 			String defaultText = getDefaultTextEditText(item);
 			int start = proposal.getReplaceStart();
 			int end = proposal.getReplaceEnd();
@@ -627,7 +627,7 @@ public class CompletionProposalReplacementProvider {
 		}
 
 		CompletionGuessMethodArgumentsMode guessMethodArgumentsMode = JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getGuessMethodArgumentsMode();
-		if (guessMethodArgumentsMode == CompletionGuessMethodArgumentsMode.OFF) {
+		if (guessMethodArgumentsMode == CompletionGuessMethodArgumentsMode.OFF || JavaLanguageServerPlugin.getPreferencesManager().getPreferences().isCollapseCompletionItemsEnabled()) {
 			buffer.append(CURSOR_POSITION);
 			return;
 		}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
@@ -182,7 +182,8 @@ public class CompletionResolveHandler {
 		// resolving documentation
 		// 1. get the required type proposal when the argument guessing is
 		// turned off and the proposal is a constructor.
-		if (manager.getPreferences().getGuessMethodArgumentsMode() == CompletionGuessMethodArgumentsMode.OFF) {
+		if (manager.getPreferences().getGuessMethodArgumentsMode() == CompletionGuessMethodArgumentsMode.OFF ||
+				JavaLanguageServerPlugin.getPreferencesManager().getPreferences().isCollapseCompletionItemsEnabled()) {
 			CompletionProposal requiredTypeProposal = CompletionProposalUtils.getRequiredTypeProposal(proposal);
 			if (requiredTypeProposal != null) {
 				proposal = requiredTypeProposal;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -398,6 +398,8 @@ public class Preferences {
 	 */
 	public static final String JAVA_COMPLETION_GUESS_METHOD_ARGUMENTS_KEY = "java.completion.guessMethodArguments";
 
+	public static final String JAVA_COMPLETION_COLLAPSE_KEY = "java.completion.collapseCompletionItems";
+
 	/**
 	 * A named preference that defines how member elements are ordered by code
 	 * actions.
@@ -622,6 +624,7 @@ public class Preferences {
 	private boolean foldingRangeEnabled;
 	private boolean selectionRangeEnabled;
 	private CompletionGuessMethodArgumentsMode guessMethodArguments;
+	private boolean collapseCompletionItems;
 
 	private boolean javaFormatComments;
 	private boolean hashCodeEqualsTemplateUseJava7Objects;
@@ -879,6 +882,7 @@ public class Preferences {
 		foldingRangeEnabled = true;
 		selectionRangeEnabled = true;
 		guessMethodArguments = CompletionGuessMethodArgumentsMode.INSERT_PARAMETER_NAMES;
+		collapseCompletionItems = false;
 		javaFormatComments = true;
 		hashCodeEqualsTemplateUseJava7Objects = false;
 		hashCodeEqualsTemplateUseInstanceof = false;
@@ -1082,6 +1086,9 @@ public class Preferences {
 			prefs.setGuessMethodArgumentsMode(CompletionGuessMethodArgumentsMode.fromString(guessMethodArgumentsMode,
 					CompletionGuessMethodArgumentsMode.INSERT_PARAMETER_NAMES));
 		}
+
+		boolean collapseCompletionItemsEnabled = getBoolean(configuration, JAVA_COMPLETION_COLLAPSE_KEY, false);
+		prefs.setCollapseCompletionItemsEnabled(collapseCompletionItemsEnabled);
 
 		boolean hashCodeEqualsTemplateUseJava7Objects = getBoolean(configuration, JAVA_CODEGENERATION_HASHCODEEQUALS_USEJAVA7OBJECTS, false);
 		prefs.setHashCodeEqualsTemplateUseJava7Objects(hashCodeEqualsTemplateUseJava7Objects);
@@ -1557,6 +1564,11 @@ public class Preferences {
 		return this;
 	}
 
+	public Preferences setCollapseCompletionItemsEnabled(boolean enabled) {
+		this.collapseCompletionItems = enabled;
+		return this;
+	}
+
 	public Preferences setJavaFormatEnabled(boolean enabled) {
 		this.javaFormatEnabled = enabled;
 		return this;
@@ -1875,6 +1887,10 @@ public class Preferences {
 
 	public CompletionGuessMethodArgumentsMode getGuessMethodArgumentsMode() {
 		return guessMethodArguments;
+	}
+
+	public boolean isCollapseCompletionItemsEnabled() {
+		return collapseCompletionItems;
 	}
 
 	public boolean isHashCodeEqualsTemplateUseJava7Objects() {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -4087,6 +4087,53 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertTrue(list.getItems().get(2).getFilterText().startsWith("test(String x, int y, boolean z)"));
 	}
 
+	@Test
+	public void testCompletion_collapse() throws Exception {
+		when(preferenceManager.getClientPreferences().isCompletionItemLabelDetailsSupport()).thenReturn(true);
+		preferenceManager.getPreferences().setCollapseCompletionItemsEnabled(true);
+		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java", String.join("\n",
+		//@formatter:off
+				"package org.sample",
+				"public class Test {",
+				"	public void test(String x){}",
+				"	public void test(String x, int y){}",
+				"	public void test(String x, int y, boolean z){}",
+				"	public static void main(String[] args) {",
+				"		  Test obj = new Test();",
+				"		  obj.test",
+				"	}",
+				"}"));
+				//@formatter:on
+		CompletionList list = requestCompletions(unit, "obj.test");
+		assertFalse(list.getItems().isEmpty());
+		assertTrue(list.getItems().get(0).getLabelDetails().getDetail().startsWith("(...)"));
+		assertTrue(list.getItems().get(0).getLabelDetails().getDescription().startsWith("3 overloads"));
+	}
+
+	@Test
+	public void testCompletion_collapse_extends() throws Exception {
+		when(preferenceManager.getClientPreferences().isCompletionItemLabelDetailsSupport()).thenReturn(true);
+		preferenceManager.getPreferences().setCollapseCompletionItemsEnabled(true);
+		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java", String.join("\n",
+		//@formatter:off
+				"package org.sample",
+				"class Test extends TestSuper {",
+				"	public void test(String x){}",
+				"	public static void main(String[] args) {",
+				"		  Test obj = new Test();",
+				"		  obj.test",
+				"	}",
+				"}",
+				"public class TestSuper {",
+				"	public void test(String x, int y){}",
+				"}"));
+				//@formatter:on
+		CompletionList list = requestCompletions(unit, "obj.test");
+		assertFalse(list.getItems().isEmpty());
+		assertTrue(list.getItems().get(0).getLabelDetails().getDetail().startsWith("(...)"));
+		assertTrue(list.getItems().get(0).getLabelDetails().getDescription().startsWith("2 overloads"));
+	}
+
 	private CompletionList requestCompletions(ICompilationUnit unit, String completeBehind) throws JavaModelException {
 		return requestCompletions(unit, completeBehind, 0);
 	}


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/2282

Before:
![Screenshot from 2024-02-09 13-36-36](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/3ec5498f-7b5d-4b77-baa0-602db465ce6d)

After:
![Screenshot from 2024-02-09 13-37-21](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/ea3bfae4-222e-4c3c-b081-948dac6d8eb8)

The list of methods should ideally be displayed in signature help after selecting the completion item, though there exists a [bug](https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/3052) in which this isn't always the case.
