### PR TITLE
Fix python script to retrieve JAVA_HOME exec in Windows OS

### DIFF
--- a/org.eclipse.jdt.ls.product/scripts/jdtls.py
+++ b/org.eclipse.jdt.ls.product/scripts/jdtls.py
@@ -23,7 +23,8 @@ def get_java_executable(validate_java_version):
 	java_executable = 'java'
 
 	if 'JAVA_HOME' in os.environ:
-		java_exec_to_test = Path(os.environ['JAVA_HOME']) / 'bin' / 'java'
+		ext = '.exe' if platform.system()  == 'Windows' else ''
+		java_exec_to_test = Path(os.environ['JAVA_HOME']) / 'bin' / f'java{ext}'
 		if java_exec_to_test.is_file():
 			java_executable = java_exec_to_test.resolve()
 


### PR DESCRIPTION
In Windows when I have the JAVA_HOME environment variable, the language server does not use the java version defined in JAVA_HOME. I found out that the python script section that get the java executable has a bug: in Windows the java executable ends with `.exe` but the script does not take it into consideration.

I tested this only by using it through Neovim with `nvim-jdtls` plugin (only on Windows). Also this might be a breaking change for all Windows users as they will use a new java executable if this is fixed. 