### PR TITLE
Add --java-executable argument to jdtls.py wrapper

### DIFF
--- a/org.eclipse.jdt.ls.product/scripts/jdtls.py
+++ b/org.eclipse.jdt.ls.product/scripts/jdtls.py
@@ -19,16 +19,19 @@ import subprocess
 from pathlib import Path
 import tempfile
 
-def get_java_executable(validate_java_version):
-	java_executable = 'java'
+def get_java_executable(known_args):
+	if known_args.java_executable is not None:
+		java_executable = known_args.java_executable
+	else:
+		java_executable = 'java'
 
-	if 'JAVA_HOME' in os.environ:
-		ext = '.exe' if platform.system()  == 'Windows' else ''
-		java_exec_to_test = Path(os.environ['JAVA_HOME']) / 'bin' / f'java{ext}'
-		if java_exec_to_test.is_file():
-			java_executable = java_exec_to_test.resolve()
+		if 'JAVA_HOME' in os.environ:
+			ext = '.exe' if platform.system()  == 'Windows' else ''
+			java_exec_to_test = Path(os.environ['JAVA_HOME']) / 'bin' / f'java{ext}'
+			if java_exec_to_test.is_file():
+				java_executable = java_exec_to_test.resolve()
 
-	if not validate_java_version:
+	if not known_args.validate_java_version:
 		return java_executable
 
 	out = subprocess.check_output([java_executable, '-version'], stderr = subprocess.STDOUT, universal_newlines=True)
@@ -73,14 +76,15 @@ def main(args):
 	parser = argparse.ArgumentParser()
 	parser.add_argument('--validate-java-version', action='store_true', default=True)
 	parser.add_argument('--no-validate-java-version', dest='validate_java_version', action='store_false')
+	parser.add_argument("--java-executable", help="Path to java executable used to start runtime.")
 	parser.add_argument("--jvm-arg",
 			default=[],
 			action="append",
 			help="An additional JVM option (can be used multiple times. Note, use with equal sign. For example: --jvm-arg=-Dlog.level=ALL")
 	parser.add_argument("-data", default=jdtls_data_path)
-
+	
 	known_args, args = parser.parse_known_args(args)
-	java_executable = get_java_executable(known_args.validate_java_version)
+	java_executable = get_java_executable(known_args)
 
 	jdtls_base_path = Path(__file__).parent.parent
 	shared_config_path = get_shared_config_path(jdtls_base_path)


### PR DESCRIPTION
Our project is stuck on JDK 11 and my build env. must point to this archaic JDK, which is insufficient for JDTLS. 

I found the script [org.eclipse.jdt.ls.product/scripts/jdtls.py ](https://github.com/eclipse-jdtls/eclipse.jdt.ls/blob/master/org.eclipse.jdt.ls.product/scripts/jdtls.py) very useful. However, it would be nice if this script had the ability to specify java executable path on the command line using an option, thus eliminating the need to wrap it in another script that sets up JAVA_HOME.