### PR TITLE
Update buildship version

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -4,7 +4,7 @@
     <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.buildship.feature.group" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/buildship/updates/e427/releases/3.x/3.1.8.v20231117-1658"/>
+            <repository location="https://download.eclipse.org/buildship/updates/latest-snapshot/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.m2e.jdt" version="0.0.0"/>


### PR DESCRIPTION
- To fix the marker property value too long issue - jls#2424.

The issue happens when the gradle project has some errors and buildship failed to import it. When this happens, buildship will add a marker with the full stacktrace as a property of the marker. Unfortunately, Eclipse has a limitation of the max length of the property value. When the length exceeds the limitation, an exception is thrown and abort the import.

fix #2424