### PR TITLE
Add null check for 'fCollapsedTypes' variable to avoid NPE when invoking completion in DEBUG CONSOLE

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalDescriptionProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalDescriptionProvider.java
@@ -15,6 +15,7 @@
 package org.eclipse.jdt.ls.core.internal.contentassist;
 
 import java.lang.reflect.Field;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.core.runtime.Assert;
@@ -52,7 +53,7 @@ public class CompletionProposalDescriptionProvider {
 	 */
 	private CompletionContext fContext;
 	private ICompilationUnit fUnit;
-	private Map<String, Integer> fCollapsedTypes;
+	private Map<String, Integer> fCollapsedTypes = new HashMap<>();
 
 	/**
 	 * Creates a new label provider.

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalDescriptionProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalDescriptionProvider.java
@@ -70,13 +70,11 @@ public class CompletionProposalDescriptionProvider {
 		super();
 		fContext = context;
 		fUnit = unit;
-		fCollapsedTypes = new HashMap<>();
 	}
 
 	public CompletionProposalDescriptionProvider(CompletionContext context) {
 		super();
 		fContext = context;
-		fCollapsedTypes = new HashMap<>();
 	}
 
 	/**
@@ -334,7 +332,7 @@ public class CompletionProposalDescriptionProvider {
 		String proposalName = String.valueOf(methodProposal.getName());
 		boolean skipDetail = false;
 		if (isCompletionItemLabelDetailsSupport()){
-			if (fCollapsedTypes.getOrDefault(proposalName, 0) > 1 && methodProposal.getKind() != CompletionProposal.CONSTRUCTOR_INVOCATION) {
+			if (fCollapsedTypes != null && fCollapsedTypes.getOrDefault(proposalName, 0) > 1 && methodProposal.getKind() != CompletionProposal.CONSTRUCTOR_INVOCATION) {
 				setLabelDetails(item, proposalName, "(...)", fCollapsedTypes.get(proposalName).toString() + " overloads");
 				skipDetail = true;
 			} else {
@@ -351,7 +349,7 @@ public class CompletionProposalDescriptionProvider {
 				}
 			}
 		} else {
-			if (fCollapsedTypes.getOrDefault(proposalName, 0) > 1 && methodProposal.getKind() != CompletionProposal.CONSTRUCTOR_INVOCATION) {
+			if (fCollapsedTypes != null && fCollapsedTypes.getOrDefault(proposalName, 0) > 1 && methodProposal.getKind() != CompletionProposal.CONSTRUCTOR_INVOCATION) {
 				item.setLabel(proposalName + "(...)");
 				item.setDetail(fCollapsedTypes.get(proposalName).toString() + " overloads");
 				skipDetail = true;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalDescriptionProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalDescriptionProvider.java
@@ -15,7 +15,6 @@
 package org.eclipse.jdt.ls.core.internal.contentassist;
 
 import java.lang.reflect.Field;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.core.runtime.Assert;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalDescriptionProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalDescriptionProvider.java
@@ -53,7 +53,7 @@ public class CompletionProposalDescriptionProvider {
 	 */
 	private CompletionContext fContext;
 	private ICompilationUnit fUnit;
-	private Map<String, Integer> fCollapsedTypes = new HashMap<>();
+	private Map<String, Integer> fCollapsedTypes;
 
 	/**
 	 * Creates a new label provider.
@@ -70,11 +70,13 @@ public class CompletionProposalDescriptionProvider {
 		super();
 		fContext = context;
 		fUnit = unit;
+		fCollapsedTypes = new HashMap<>();
 	}
 
 	public CompletionProposalDescriptionProvider(CompletionContext context) {
 		super();
 		fContext = context;
+		fCollapsedTypes = new HashMap<>();
 	}
 
 	/**


### PR DESCRIPTION
With the pre-release version of Java language support extension installed, triggering method completion on DEBUG CONSOLE will throw NPE exception as below.

```
Cannot invoke "java.util.Map.getOrDefault(Object, Object)" because "this.fCollapsedTypes" is null
!STACK 0
java.lang.NullPointerException: Cannot invoke "java.util.Map.getOrDefault(Object, Object)" because "this.fCollapsedTypes" is null
	at org.eclipse.jdt.ls.core.internal.contentassist.CompletionProposalDescriptionProvider.createMethodProposalLabel(CompletionProposalDescriptionProvider.java:334)
	at org.eclipse.jdt.ls.core.internal.contentassist.CompletionProposalDescriptionProvider.updateDescription(CompletionProposalDescriptionProvider.java:745)
	at com.microsoft.java.debug.plugin.internal.CompletionProposalRequestor.toCompletionItem(CompletionProposalRequestor.java:165)
	at com.microsoft.java.debug.plugin.internal.CompletionProposalRequestor.getCompletionItems(CompletionProposalRequestor.java:147)
	at com.microsoft.java.debug.plugin.internal.CompletionsProvider.codeComplete(CompletionsProvider.java:75)
	at com.microsoft.java.debug.core.adapter.handler.CompletionsHandler.lambda$handle$0(CompletionsHandler.java:68)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.exec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
```

The issue occurs because the Java Debugger uses the old constructor `CompletionProposalDescriptionProvider(CompletionContext context)` to initialize the DescriptionProvider. This constructor does not initialize the new field `fCollapsedTypes`, resulting in a `NullPointerException` when `fCollapsedTypes` is later referenced. It is important to ensure that when introducing new fields in the code, they do not break any existing usage.
