### PR TITLE
Allow multiple jdk registration for one runtime environment

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/RuntimeEnvironment.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/RuntimeEnvironment.java
@@ -17,6 +17,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Objects;
 
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
@@ -109,14 +110,8 @@ public class RuntimeEnvironment {
 			return false;
 		}
 		RuntimeEnvironment other = (RuntimeEnvironment) obj;
-		if (name == null) {
-			if (other.name != null) {
-				return false;
-			}
-		} else if (!name.equals(other.name)) {
-			return false;
-		}
-		return true;
+		return Objects.equals(name, other.name) &&
+				Objects.equals(path, other.path);
 	}
 
 	public boolean isValid() {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -1215,7 +1215,7 @@ public class Preferences {
 		prefs.setStaticImportOnDemandThreshold(staticOnDemandThreshold);
 
 		List<?> runtimeList = getList(configuration, JAVA_CONFIGURATION_RUNTIMES, JAVA_CONFIGURATION_RUNTIMES_DEFAULT);
-		Set<RuntimeEnvironment> runtimes = new HashSet<>();
+		Set<RuntimeEnvironment> runtimes = new LinkedHashSet<>();
 		boolean[] hasDefault = { false };
 		for (Object object : runtimeList) {
 			if (object instanceof Map<?, ?> map) {


### PR DESCRIPTION
This is a proposal to fix https://github.com/redhat-developer/vscode-java/issues/2115

Basically, this PR allows to register multiple jdks for the same environment. And the first registered one will become the default jdk for that runtime environment.

Then user can switch jdks for the same runtime environment in the classpath configuration webview.

Moreover, when some jdks are missed by the jdk detection, user can manually add them, the webview can persist them in the global `java.configuration.runtimes`, then all other workspaces will automatically have those added jdks via the settings.

![image](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/6193897/8475df4f-f390-43ce-846c-23a077ed90aa)

@rgrunber Please let me know your thoughts/concerns about this change