### PR TITLE
Fix tests failing to run on Mac

### DIFF
--- a/org.eclipse.jdt.ls.tests/pom.xml
+++ b/org.eclipse.jdt.ls.tests/pom.xml
@@ -81,9 +81,9 @@
 							<configuration>
 								<dependencies>
 									<dependency>
-										<artifactId>org.eclipse.jdt</artifactId>
+										<artifactId>org.eclipse.jdt.launching.macosx</artifactId>
 										<version>0.0.0</version>
-										<type>eclipse-feature</type>
+										<type>eclipse-plugin</type>
 									</dependency>
 								</dependencies>
 							</configuration>


### PR DESCRIPTION
Fixes this error:

```
[INFO] --- tycho-surefire:4.0.6:test (default-test) @ org.eclipse.jdt.ls.tests ---
[INFO] {osgi.os=macosx, [osgi.ws](http://osgi.ws/)=cocoa, org.eclipse.update.install.features=true, osgi.arch=x86_64, org.eclipse.update.install.sources=true}
[ERROR] Cannot resolve project dependencies:
[ERROR]   You requested to install ‘org.eclipse.equinox.p2.iu; org.eclipse.jdt.feature.group 0.0.0’ but it could not be found
[ERROR]
[ERROR] See https://wiki.eclipse.org/Tycho/Dependency_Resolution_Troubleshooting for help.
```