### PR TITLE
Fix NPE when fetching the classpath of the project

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
@@ -175,11 +175,11 @@ public class ProjectCommand {
 							continue;
 						} else if (entryKind == IClasspathEntry.CPE_LIBRARY) {
 							if (!path.toFile().exists()) {
-								// the case when lib path is relative
-								path = project.getFile(path.makeRelativeTo(project.getFullPath())).getLocation();
-							}
-							if (!path.toFile().exists()) {
-								continue;
+								// check if it's a project based full path
+								IPath filePath = project.getFile(path.makeRelativeTo(project.getFullPath())).getLocation();
+								if (filePath != null && filePath.toFile().exists()) {
+									path = filePath;
+								}
 							}
 						}
 						Map<String, String> attributes = new HashMap<>();


### PR DESCRIPTION
When the path of the lib classpath entry points to a file which does not exist on file system, `.getLocation()` could return `null`.