### PR TITLE
Handle non-existent completion item insert text mode capability.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -427,7 +427,10 @@ public class ClientPreferences {
 	}
 
 	public InsertTextMode getCompletionItemInsertTextModeDefault() {
-		return capabilities.getTextDocument().getCompletion().getInsertTextMode();
+		return v3supported
+			&& capabilities.getTextDocument().getCompletion() != null
+			? capabilities.getTextDocument().getCompletion().getInsertTextMode()
+			: null;
 	}
 
 	public boolean isCompletionListItemDefaultsSupport() {


### PR DESCRIPTION
- See https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/3116