### PR TITLE
Correctly declare support for "workspace/willRenameFiles".

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -52,6 +52,11 @@ import org.eclipse.lsp4j.CodeLensOptions;
 import org.eclipse.lsp4j.DocumentFilter;
 import org.eclipse.lsp4j.DocumentOnTypeFormattingOptions;
 import org.eclipse.lsp4j.ExecuteCommandOptions;
+import org.eclipse.lsp4j.FileOperationFilter;
+import org.eclipse.lsp4j.FileOperationOptions;
+import org.eclipse.lsp4j.FileOperationPattern;
+import org.eclipse.lsp4j.FileOperationPatternKind;
+import org.eclipse.lsp4j.FileOperationsServerCapabilities;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.SaveOptions;
@@ -219,6 +224,15 @@ final public class InitHandler extends BaseInitHandler {
 		WorkspaceFoldersOptions wsFoldersOptions = new WorkspaceFoldersOptions();
 		wsFoldersOptions.setSupported(Boolean.TRUE);
 		wsFoldersOptions.setChangeNotifications(Boolean.TRUE);
+
+		if (preferenceManager.getClientPreferences().isWorkspaceWillRenameFilesSupported()) {
+			FileOperationsServerCapabilities wsFileOperations = new FileOperationsServerCapabilities();
+			FileOperationPattern fileOpPattern = new FileOperationPattern("**/*.java");
+			fileOpPattern.setMatches(FileOperationPatternKind.File);
+			wsFileOperations.setWillRename(new FileOperationOptions(List.of(new FileOperationFilter(fileOpPattern, "file"))));
+			wsCapabilities.setFileOperations(wsFileOperations);
+		}
+
 		wsCapabilities.setWorkspaceFolders(wsFoldersOptions);
 		capabilities.setWorkspace(wsCapabilities);
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -65,6 +65,10 @@ public class ClientPreferences {
 		return capabilities.getWorkspace() != null && isTrue(capabilities.getWorkspace().getWorkspaceFolders());
 	}
 
+	public boolean isWorkspaceWillRenameFilesSupported() {
+		return v3supported && capabilities.getWorkspace() != null && capabilities.getWorkspace().getFileOperations() != null && isTrue(capabilities.getWorkspace().getFileOperations().getWillRename());
+	}
+
 	public boolean isCompletionDynamicRegistered() {
 		return v3supported && isDynamicRegistrationSupported(capabilities.getTextDocument().getCompletion());
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandlerTest.java
@@ -76,6 +76,9 @@ import org.eclipse.lsp4j.ExecuteCommandCapabilities;
 import org.eclipse.lsp4j.ExecuteCommandOptions;
 import org.eclipse.lsp4j.FileChangeType;
 import org.eclipse.lsp4j.FileEvent;
+import org.eclipse.lsp4j.FileOperationOptions;
+import org.eclipse.lsp4j.FileOperationPatternKind;
+import org.eclipse.lsp4j.FileOperationsServerCapabilities;
 import org.eclipse.lsp4j.FileSystemWatcher;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
@@ -366,6 +369,21 @@ public class InitHandlerTest extends AbstractProjectsManagerBasedTest {
 		newWatchers = watchers.subList(0, 9);
 		Collections.sort(newWatchers, Comparator.comparing(fileSystemWatcher -> fileSystemWatcher.getGlobPattern().map(Function.identity(), RelativePattern::getPattern)));
 		assertEquals(newWatchers, watchers);
+	}
+
+	@Test
+	public void testWorkspaceWillRenameFiles() throws Exception {
+		ClientPreferences mockCapabilies = mock(ClientPreferences.class);
+		when(preferenceManager.getClientPreferences()).thenReturn(mockCapabilies);
+		when(mockCapabilies.isWorkspaceWillRenameFilesSupported()).thenReturn(Boolean.TRUE);
+		InitializeResult result = initialize(true);
+		FileOperationsServerCapabilities fileOpSrvCap = result.getCapabilities().getWorkspace().getFileOperations();
+		assertNotNull(fileOpSrvCap);
+		FileOperationOptions fileOpOps = fileOpSrvCap.getWillRename();
+		assertNotNull(fileOpOps);
+		assertEquals("file", fileOpOps.getFilters().get(0).getScheme());
+		assertEquals(FileOperationPatternKind.File, fileOpOps.getFilters().get(0).getPattern().getMatches());
+		assertEquals("**/*.java", fileOpOps.getFilters().get(0).getPattern().getGlob());
 	}
 
 	// https://github.com/redhat-developer/vscode-java/issues/2429


### PR DESCRIPTION
@angelozerr , can you verify this change fixes things for you ? I also would need to adjust vscode-java as it appears to break it by sending a duplicate `workspace/willRenameFiles`, which causes some problems. Basically that client doesn't want the renames to be applied immediately, but rather get the edits and allow a user to apply/discard them.

- The server capabilities in the initialize response must contain a "willRename" object in the workspace's "fileOperations" object.
- Fixes #3126 

```diff
--- old.txt 2024-04-05 11:22:47.101634192 -0400
+++ new.txt 2024-04-05 11:31:28.769420565 -0400
@@ -1,4 +1,4 @@
-[Trace - 11:22:11] Received response 'initialize - (0)' in 5456ms.
+[Trace - 11:31:03] Received response 'initialize - (0)' in 6603ms.
 Result: {
     "capabilities": {
         "textDocumentSync": {
@@ -14,6 +14,19 @@
             "workspaceFolders": {
                 "supported": true,
                 "changeNotifications": true
+            },
+            "fileOperations": {
+                "willRename": {
+                    "filters": [
+                        {
+                            "pattern": {
+                                "glob": "**/*.java",
+                                "matches": "file"
+                            },
+                            "scheme": "file"
+                        }
+                    ]
+                }
             }
         },
         "callHierarchyProvider": true,

```