### PR TITLE
Update target platform to newer 4.32-I-builds (I20240327-1800).

### DIFF
--- a/org.eclipse.jdt.ls.product/languageServer.product
+++ b/org.eclipse.jdt.ls.product/languageServer.product
@@ -48,7 +48,7 @@
       <plugin id="org.eclipse.equinox.security"/>
       <plugin id="org.eclipse.equinox.security.linux" fragment="true"/>
       <plugin id="org.eclipse.equinox.security.macosx" fragment="true"/>
-      <plugin id="org.eclipse.equinox.security.win32.x86_64" fragment="true"/>
+      <plugin id="org.eclipse.equinox.security.win32" fragment="true"/>
       <plugin id="org.eclipse.jdt.apt.pluggable.core"/>
       <plugin id="org.eclipse.jdt.core"/>
       <plugin id="org.eclipse.jdt.launching"/>

--- a/org.eclipse.jdt.ls.product/syntaxServer.product
+++ b/org.eclipse.jdt.ls.product/syntaxServer.product
@@ -43,7 +43,7 @@
       <plugin id="org.eclipse.equinox.security"/>
       <plugin id="org.eclipse.equinox.security.linux" fragment="true"/>
       <plugin id="org.eclipse.equinox.security.macosx" fragment="true"/>
-      <plugin id="org.eclipse.equinox.security.win32.x86_64" fragment="true"/>
+      <plugin id="org.eclipse.equinox.security.win32" fragment="true"/>
       <plugin id="org.eclipse.jdt.core"/>
       <plugin id="org.eclipse.jdt.launching"/>
       <plugin id="org.eclipse.jdt.launching.macosx"/>

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -25,7 +25,7 @@
             <unit id="org.mockito.mockito-core" version="0.0.0"/>
             <unit id="org.apache.commons.commons-io" version="0.0.0"/>
             <unit id="org.eclipse.jdt.apt.pluggable.core" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.32-I-builds/I20240325-1800/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.32-I-builds/I20240327-1800/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.jdt.core.compiler.batch" version="0.0.0"/>


### PR DESCRIPTION
- Fixes https://github.com/redhat-developer/vscode-java/issues/3564
- https://github.com/eclipse-equinox/equinox/pull/564

I've updated the eclipse-jdt-core-incubator dev branch to 1 commit after I20240327-1800 (since that's what's needed to fix this). I couldn't move the I-build itself to a commit newer than I20240327-1800 without a lot of tests relating to the import of Maven projects failing to locate various types that should be on the classpath. @snjeza We'll need to address that in a separate commit.