### PR TITLE
Qualifier of workspace symbol search should be wildcard search.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandler.java
@@ -70,9 +70,8 @@ public class WorkspaceSymbolHandler {
 			if (qualIndex != -1) {
 				qualifierName = tQuery.substring(0, qualIndex);
 				typeName = tQuery.substring(qualIndex + 1);
-				qualifierMatchRule = SearchPattern.R_CAMELCASE_MATCH;
-				if (qualifierName.contains("*") || qualifierName.contains("?")) {
-					qualifierMatchRule = SearchPattern.R_PATTERN_MATCH;
+				if (!qualifierName.contains("*") && !qualifierName.contains("?")) {
+					qualifierName = String.format("*%s*", qualifierName);
 				}
 			}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
@@ -128,7 +128,7 @@ public class WorkspaceSymbolHandlerTest extends AbstractProjectsManagerBasedTest
 	public void testCamelCaseSearch() {
 		List<SymbolInformation> results = WorkspaceSymbolHandler.search("NPE", monitor);
 		assertNotNull(results);
-		assertEquals("NullPointerException", results.get(0).getName());
+		assertTrue(results.stream().anyMatch(s -> s.getName().equals("NullPointerException")));
 
 		results = WorkspaceSymbolHandler.search("HaMa", monitor);
 		String className = "HashMap";
@@ -199,6 +199,17 @@ public class WorkspaceSymbolHandlerTest extends AbstractProjectsManagerBasedTest
 		results = WorkspaceSymbolHandler.search("java.lang", monitor);
 		assertTrue(results.size() > 1);
 		assertTrue(results.stream().anyMatch(s -> "Exception".equals(s.getName()) && "java.lang".equals(s.getContainerName())));
+	}
+
+	@Test
+	public void testSearchPartialPackage() {
+		List<SymbolInformation> results = WorkspaceSymbolHandler.search("util.Array", monitor);
+		assertTrue(results.size() > 1);
+		assertTrue(results.stream().anyMatch(s -> s.getName().equals("ArrayList") && s.getContainerName().equals("java.util")));
+
+		results = WorkspaceSymbolHandler.search("util.Pattern", monitor);
+		assertTrue(results.size() > 1);
+		assertTrue(results.stream().anyMatch(s -> s.getName().equals("Pattern") && s.getContainerName().equals("java.util.regex")));
 	}
 
 	@Test


### PR DESCRIPTION
- A search term of 'foo.bar' where 'foo' is the qualifier should search for any qualifier matching '*foo*'