### PR TITLE
Create the default project only when it is necessary.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
@@ -266,6 +266,12 @@ public final class JDTUtils {
 			return null;
 		}
 
+		try {
+			ProjectsManager.createJavaProject(ProjectsManager.getDefaultProject(), new NullProgressMonitor());
+			ProjectsManager.cleanupResources(ProjectsManager.getDefaultProject());
+		} catch (Exception e) {
+			// continue
+		}
 		IProject project = JavaLanguageServerPlugin.getProjectsManager().getDefaultProject();
 		if (project == null || !project.isAccessible()) {
 			String fileName = path.getFileName().toString();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BuildWorkspaceHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BuildWorkspaceHandler.java
@@ -56,7 +56,9 @@ public class BuildWorkspaceHandler {
 			if (monitor.isCanceled()) {
 				return BuildWorkspaceStatus.CANCELLED;
 			}
-			projectsManager.cleanupResources(projectsManager.getDefaultProject());
+			if (ProjectUtils.getAllProjects(false).length == 0) {
+				ProjectsManager.cleanupResources(ProjectsManager.getDefaultProject());
+			}
 			if (forceReBuild) {
 				SubMonitor subMonitor = SubMonitor.convert(monitor, 100);
 				ResourcesPlugin.getWorkspace().build(IncrementalProjectBuilder.CLEAN_BUILD, subMonitor.split(50));
@@ -67,7 +69,7 @@ public class BuildWorkspaceHandler {
 			List<IMarker> problemMarkers = new ArrayList<>();
 			IProject[] projects = ProjectUtils.getAllProjects();
 			for (IProject project : projects) {
-				if (!project.equals(projectsManager.getDefaultProject())) {
+				if (!project.equals(ProjectsManager.getDefaultProject())) {
 					List<IMarker> markers = ResourceUtils.getErrorMarkers(project);
 					if (markers != null) {
 						problemMarkers.addAll(markers);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporter.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -51,15 +50,14 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.core.IClasspathEntry;
-import org.eclipse.jdt.core.IJavaModelStatus;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.jdt.internal.core.ClasspathEntry;
 import org.eclipse.jdt.ls.core.internal.AbstractProjectImporter;
 import org.eclipse.jdt.ls.core.internal.IConstants;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
@@ -101,6 +99,9 @@ public class InvisibleProjectImporter extends AbstractProjectImporter {
 		if (triggerFiles == null || triggerFiles.isEmpty()) {
 			return;
 		}
+
+		ProjectsManager.createJavaProject(ProjectsManager.getDefaultProject(), new NullProgressMonitor());
+		ProjectsManager.cleanupResources(ProjectsManager.getDefaultProject());
 
 		IPath rootPath = ResourceUtils.filePathFromURI(rootFolder.toPath().toUri().toString());
 		Optional<IPath> triggerJavaFile = triggerFiles.stream().filter(triggerFile -> rootPath.isPrefixOf(triggerFile)).findFirst();
@@ -201,7 +202,7 @@ public class InvisibleProjectImporter extends AbstractProjectImporter {
 			return Collections.emptySet();
 		}
 		Collection<IPath> triggerFiles = collectTriggerFiles(currentProject, foldersToSearch);
-		
+
 		Set<IPath> sourcePaths = new HashSet<>();
 		sourcePaths.add(triggerFolder.getFullPath());
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
@@ -116,8 +116,10 @@ public abstract class ProjectsManager implements ISaveParticipant, IProjectsMana
 		if (!preferenceManager.getClientPreferences().skipProjectConfiguration()) {
 			SubMonitor subMonitor = SubMonitor.convert(monitor, 100);
 			cleanInvalidProjects(rootPaths, subMonitor.split(20));
-			createJavaProject(getDefaultProject(), subMonitor.split(10));
-			cleanupResources(getDefaultProject());
+			if (rootPaths.isEmpty() && !ProjectsManager.getDefaultProject().exists()) {
+				ProjectsManager.createJavaProject(ProjectsManager.getDefaultProject(), subMonitor.split(10));
+				ProjectsManager.cleanupResources(ProjectsManager.getDefaultProject());
+			}
 			Collection<IPath> projectConfigurations = preferenceManager.getPreferences().getProjectConfigurations();
 			if (projectConfigurations == null) {
 				// old way to import project
@@ -336,7 +338,7 @@ public abstract class ProjectsManager implements ISaveParticipant, IProjectsMana
 		return job;
 	}
 
-	public void cleanupResources(IProject project) throws CoreException {
+	public static void cleanupResources(IProject project) throws CoreException {
 		IJavaProject javaProj = JavaCore.create(project);
 		if (javaProj == null) {
 			return;
@@ -724,7 +726,7 @@ public abstract class ProjectsManager implements ISaveParticipant, IProjectsMana
 			for (Entry<IBuildSupport, List<IProject>> entry : groupByBuildSupport(projects).entrySet()) {
 				IStatus onWillUpdateStatus = onWillConfigurationUpdate(entry.getKey(),
 						entry.getValue(), monitor);
-				
+
 				// if onWillUpdate() failed, skip updating the projects.
 				if (!onWillUpdateStatus.isOK()) {
 					status.add(onWillUpdateStatus);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
@@ -391,7 +391,7 @@ public class ProjectCommandTest extends AbstractInvisibleProjectBasedTest {
 	public void getAllJavaProject() throws Exception {
 		importProjects("maven/multimodule");
 		List<URI> projects = ProjectCommand.getAllJavaProjects();
-		assertEquals(4, projects.size());
+		assertEquals(3, projects.size());
 	}
 
 	private static Range START_OF_DOCUMENT = new Range(new Position(0, 0), new Position(0, 0));

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/filesystem/GradleProjectMetadataFileTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/filesystem/GradleProjectMetadataFileTest.java
@@ -121,7 +121,7 @@ public class GradleProjectMetadataFileTest extends AbstractGradleBasedTest {
 	@Test
 	public void testSettingsGradle() throws Exception {
 		List<IProject> projects = importProjects("gradle/sample");
-		assertEquals(3, projects.size());//default, app, sample
+		assertEquals(2, projects.size()); // app, sample
 		IProject root = WorkspaceHelper.getProject("sample");
 		assertIsGradleProject(root);
 		IProject project = WorkspaceHelper.getProject("app");

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/filesystem/MavenProjectMetadataFileTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/filesystem/MavenProjectMetadataFileTest.java
@@ -111,7 +111,7 @@ public class MavenProjectMetadataFileTest extends AbstractMavenBasedTest {
 	@Test
 	public void testInvalidProject() throws Exception {
 		List<IProject> projects = importProjects(MAVEN_INVALID);
-		assertEquals(2, projects.size());
+		assertEquals(1, projects.size());
 		IProject invalid = WorkspaceHelper.getProject(INVALID);
 		assertIsMavenProject(invalid);
 		IFile projectFile = invalid.getFile(IProjectDescription.DESCRIPTION_FILE_NAME);
@@ -123,7 +123,7 @@ public class MavenProjectMetadataFileTest extends AbstractMavenBasedTest {
 		file.delete();
 		assertFalse(file.exists());
 		projects = importProjects(MAVEN_INVALID);
-		assertEquals(2, projects.size());
+		assertEquals(1, projects.size());
 		invalid = WorkspaceHelper.getProject(INVALID);
 		assertIsMavenProject(invalid);
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/BuildWorkspaceHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/BuildWorkspaceHandlerTest.java
@@ -87,7 +87,7 @@ public class BuildWorkspaceHandlerTest extends AbstractProjectsManagerBasedTest 
 		preferences.setMaxBuildCount(4);
 
 		List<IProject> projects = importProjects("eclipse/multi");
-		assertEquals(3, projects.size());
+		assertEquals(2, projects.size());
 
 		BuildWorkspaceStatus result = handler.buildWorkspace(false, monitor);
 		assertEquals(String.format("BuildWorkspaceStatus is: %s.", result.toString()), result, BuildWorkspaceStatus.SUCCEED);
@@ -98,7 +98,7 @@ public class BuildWorkspaceHandlerTest extends AbstractProjectsManagerBasedTest 
 		preferences.setMaxBuildCount(4);
 
 		List<IProject> projects = importProjects("maven/multimodule");
-		assertEquals(6, projects.size());
+		assertEquals(5, projects.size());
 
 		BuildWorkspaceStatus result = handler.buildWorkspace(false, monitor);
 		assertEquals(String.format("BuildWorkspaceStatus is: %s.", result.toString()), result, BuildWorkspaceStatus.SUCCEED);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ImportNewProjectsTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ImportNewProjectsTest.java
@@ -72,7 +72,7 @@ public class ImportNewProjectsTest extends AbstractProjectsManagerBasedTest {
 		importProjects("maven/multimodule");
 		waitForJobs();
 		projects = workspace.getRoot().getProjects();
-		assertEquals(6, projects.length);
+		assertEquals(5, projects.length);
 
 		// Add new sub-module
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject("multimodule");
@@ -103,7 +103,7 @@ public class ImportNewProjectsTest extends AbstractProjectsManagerBasedTest {
 
 		// Verify no projects imported
 		projects = workspace.getRoot().getProjects();
-		assertEquals(6, projects.length);
+		assertEquals(5, projects.length);
 
 		// Verify import projects
 		projectsManager.setConnection(client);
@@ -112,7 +112,7 @@ public class ImportNewProjectsTest extends AbstractProjectsManagerBasedTest {
 		IProject newProject = workspace.getRoot().getProject("module4");
 		assertTrue(newProject.exists());
 		projects = workspace.getRoot().getProjects();
-		assertEquals(7, projects.length);
+		assertEquals(6, projects.length);
 
 		ArgumentCaptor<EventNotification> argument = ArgumentCaptor.forClass(EventNotification.class);
 		verify(client, times(1)).sendEventNotification(argument.capture());
@@ -130,7 +130,7 @@ public class ImportNewProjectsTest extends AbstractProjectsManagerBasedTest {
 		importProjects("maven/multimodule");
 		waitForJobs();
 		projects = workspace.getRoot().getProjects();
-		assertEquals(6, projects.length);
+		assertEquals(5, projects.length);
 
 		// Add new sub-module
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject("multimodule");
@@ -161,7 +161,7 @@ public class ImportNewProjectsTest extends AbstractProjectsManagerBasedTest {
 
 		// Verify no projects imported
 		projects = workspace.getRoot().getProjects();
-		assertEquals(6, projects.length);
+		assertEquals(5, projects.length);
 
 		// Verify import projects
 		projectsManager.setConnection(client);
@@ -173,7 +173,7 @@ public class ImportNewProjectsTest extends AbstractProjectsManagerBasedTest {
 		IProject newProject = workspace.getRoot().getProject("module4");
 		assertTrue("New module is imported", newProject.exists());
 		projects = workspace.getRoot().getProjects();
-		assertEquals(7, projects.length);
+		assertEquals(6, projects.length);
 
 		ArgumentCaptor<EventNotification> argument = ArgumentCaptor.forClass(EventNotification.class);
 		verify(client, times(1)).sendEventNotification(argument.capture());
@@ -192,7 +192,7 @@ public class ImportNewProjectsTest extends AbstractProjectsManagerBasedTest {
 		importProjects("gradle/multi-module");
 		waitForJobs();
 		projects = workspace.getRoot().getProjects();
-		assertEquals(4, projects.length);
+		assertEquals(3, projects.length);
 		// Add new sub-module
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject("multi-module");
 		File projectBasePath = project.getLocation().toFile();
@@ -207,7 +207,7 @@ public class ImportNewProjectsTest extends AbstractProjectsManagerBasedTest {
 
 		// Verify no projects imported
 		projects = workspace.getRoot().getProjects();
-		assertEquals(4, projects.length);
+		assertEquals(3, projects.length);
 
 		// Verify import projects
 		projectsManager.setConnection(client);
@@ -216,7 +216,7 @@ public class ImportNewProjectsTest extends AbstractProjectsManagerBasedTest {
 		IProject newProject = workspace.getRoot().getProject("test");
 		assertTrue(newProject.exists());
 		projects = workspace.getRoot().getProjects();
-		assertEquals(5, projects.length);
+		assertEquals(4, projects.length);
 
 		ArgumentCaptor<EventNotification> argument = ArgumentCaptor.forClass(EventNotification.class);
 		verify(client, times(1)).sendEventNotification(argument.capture());
@@ -231,7 +231,7 @@ public class ImportNewProjectsTest extends AbstractProjectsManagerBasedTest {
 		IProject[] projects = workspace.getRoot().getProjects();
 		assertEquals(0, projects.length);
 		importProjects("mixed");
-		assertEquals(4, wsRoot.getProjects().length);
+		assertEquals(3, wsRoot.getProjects().length);
 		IProject hello = wsRoot.getProject("hello");
 		assertNotNull(hello);
 		assertIsJavaProject(hello);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/NavigateToDefinitionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/NavigateToDefinitionHandlerTest.java
@@ -44,14 +44,12 @@ public class NavigateToDefinitionHandlerTest extends AbstractProjectsManagerBase
 
 	private NavigateToDefinitionHandler handler;
 	private IProject project;
-	private IProject defaultProject;
 
 	@Before
 	public void setUp() throws Exception {
 		handler = new NavigateToDefinitionHandler(preferenceManager);
 		importProjects("maven/salut");
 		project = WorkspaceHelper.getProject("salut");
-		defaultProject = linkFilesToDefaultProject("singlefile/Single.java").getProject();
 		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, monitor);
 		Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_BUILD, monitor);
 		Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, monitor);
@@ -144,6 +142,7 @@ public class NavigateToDefinitionHandlerTest extends AbstractProjectsManagerBase
 	public void testJdkClasses() throws Exception {
 		// because for test, we are using fake rt.jar(rtstubs.jar), the issue of issue https://bugs.eclipse.org/bugs/show_bug.cgi?id=541573 will
 		// never occur in test cases
+		IProject defaultProject = linkFilesToDefaultProject("singlefile/Single.java").getProject();
 		String uri = ClassFileUtil.getURI(defaultProject, "Single");
 		TextDocumentIdentifier identifier = new TextDocumentIdentifier(uri);
 		handler.definition(new TextDocumentPositionParams(identifier, new Position(1, 31)), monitor);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
@@ -78,7 +78,7 @@ public class WorkspaceSymbolHandlerTest extends AbstractProjectsManagerBasedTest
 		String query = "Array";
 		List<SymbolInformation> results = WorkspaceSymbolHandler.search(query, monitor);
 		assertNotNull(results);
-		assertEquals("Unexpected results", 22, results.size());
+		assertEquals("Unexpected results", 11, results.size());
 		Range defaultRange = JDTUtils.newRange();
 		for (SymbolInformation symbol : results) {
 			assertNotNull("Kind is missing", symbol.getKind());

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractProjectsManagerBasedTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractProjectsManagerBasedTest.java
@@ -56,6 +56,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IRegistryChangeEvent;
 import org.eclipse.core.runtime.IRegistryChangeListener;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.jobs.Job;
@@ -211,6 +212,12 @@ public abstract class AbstractProjectsManagerBasedTest {
 	}
 
 	protected IFile linkFilesToDefaultProject(String path) throws Exception {
+		try {
+			ProjectsManager.createJavaProject(ProjectsManager.getDefaultProject(), new NullProgressMonitor());
+			ProjectsManager.cleanupResources(ProjectsManager.getDefaultProject());
+		} catch (OperationCanceledException e) {
+		} catch (CoreException e) {
+		}
 		IProject testProject = ProjectsManager.getDefaultProject();
 		String fullpath = copyFiles(path, true).getAbsolutePath().replace('\\', '/');
 		String fileName = fullpath.substring(fullpath.lastIndexOf("/") + 1);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/EclipseProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/EclipseProjectImporterTest.java
@@ -94,7 +94,7 @@ public class EclipseProjectImporterTest extends AbstractProjectsManagerBasedTest
 	@Test
 	public void importMultipleJavaProject() throws Exception {
 		List<IProject> projects = importProjects("eclipse/multi");
-		assertEquals(3, projects.size());
+		assertEquals(2, projects.size());
 
 		IProject bar = getProject("bar");
 		assertIsJavaProject(bar);
@@ -123,7 +123,7 @@ public class EclipseProjectImporterTest extends AbstractProjectsManagerBasedTest
 		try {
 			javaImportExclusions.add(BAR_PATTERN);
 			List<IProject> projects = importProjects("eclipse/multi");
-			assertEquals(2, projects.size());
+			assertEquals(1, projects.size());
 			IProject bar = getProject("bar");
 			assertNull(bar);
 			IProject foo = getProject("foo");

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporterTest.java
@@ -107,7 +107,7 @@ public class GradleProjectImporterTest extends AbstractGradleBasedTest{
 	@Test
 	public void importNestedGradleProject() throws Exception {
 		List<IProject> projects = importProjects("gradle/nested");
-		assertEquals(4, projects.size());//default + 3 gradle projects
+		assertEquals(3, projects.size()); // 3 gradle projects
 		IProject gradle1 = WorkspaceHelper.getProject("gradle1");
 		assertIsGradleProject(gradle1);
 		IProject gradle2 = WorkspaceHelper.getProject("gradle2");
@@ -120,14 +120,14 @@ public class GradleProjectImporterTest extends AbstractGradleBasedTest{
 	@Test
 	public void testDeleteInvalidProjects() throws Exception {
 		List<IProject> projects = importProjects(Arrays.asList("gradle/nested/gradle1", "gradle/nested/gradle2"));
-		assertEquals(3, projects.size());//default + 2 gradle projects
+		assertEquals(2, projects.size()); // 2 gradle projects
 		IProject gradle1 = WorkspaceHelper.getProject("gradle1");
 		assertIsGradleProject(gradle1);
 		IProject gradle2 = WorkspaceHelper.getProject("gradle2");
 		assertIsGradleProject(gradle2);
 
 		projects = importProjects("gradle/nested/gradle1");
-		assertEquals(2, projects.size());
+		assertEquals(1, projects.size());
 		gradle1 = WorkspaceHelper.getProject("gradle1");
 		assertNotNull(gradle1);
 		gradle2 = WorkspaceHelper.getProject("gradle2");
@@ -140,7 +140,7 @@ public class GradleProjectImporterTest extends AbstractGradleBasedTest{
 		try {
 			javaImportExclusions.add(GRADLE1_PATTERN);
 			List<IProject> projects = importProjects("gradle/nested");
-			assertEquals(3, projects.size());//default + 2 gradle projects
+			assertEquals(2, projects.size()); // 2 gradle projects
 			IProject gradle1 = WorkspaceHelper.getProject("gradle1");
 			assertNull(gradle1);
 			IProject gradle2 = WorkspaceHelper.getProject("gradle2");
@@ -174,7 +174,7 @@ public class GradleProjectImporterTest extends AbstractGradleBasedTest{
 			assertEquals(distribution.getClass(), FixedVersionGradleDistribution.class);
 			assertEquals(((FixedVersionGradleDistribution) distribution).getVersion(), requiredVersion);
 			List<IProject> projects = importProjects("eclipse/eclipsegradle");
-			assertEquals(2, projects.size());//default + 1 eclipse projects
+			assertEquals(1, projects.size()); // 1 eclipse project
 			IProject eclipse = WorkspaceHelper.getProject("eclipsegradle");
 			assertNotNull(eclipse);
 			assertTrue(eclipse.getName() + " does not have the Gradle nature", ProjectUtils.isGradleProject(eclipse));
@@ -193,7 +193,7 @@ public class GradleProjectImporterTest extends AbstractGradleBasedTest{
 			gradleUserHome.deleteOnExit();
 			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setGradleUserHome(gradleUserHome.getAbsolutePath());
 			List<IProject> projects = importProjects("gradle/simple-gradle");
-			assertEquals(2, projects.size());//default + 1 eclipse projects
+			assertEquals(1, projects.size()); // 1 eclipse project
 			IProject project = WorkspaceHelper.getProject("simple-gradle");
 			assertNotNull(project);
 			assertTrue(project.getName() + " does not have the Gradle nature", ProjectUtils.isGradleProject(project));
@@ -267,7 +267,7 @@ public class GradleProjectImporterTest extends AbstractGradleBasedTest{
 		try {
 			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setImportGradleEnabled(false);
 			List<IProject> projects = importProjects("eclipse/eclipsegradle");
-			assertEquals(2, projects.size());//default + 1 eclipse projects
+			assertEquals(1, projects.size()); // 1 eclipse projects
 			IProject eclipse = WorkspaceHelper.getProject("eclipse");
 			assertNotNull(eclipse);
 			assertFalse(eclipse.getName() + " has the Gradle nature", ProjectUtils.isGradleProject(eclipse));
@@ -487,7 +487,7 @@ public class GradleProjectImporterTest extends AbstractGradleBasedTest{
 			// force overrideWorkspace
 			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setGradleArguments(List.of("--stacktrace"));
 			List<IProject> projects = importProjects("gradle/subprojects");
-			assertEquals(4, projects.size());//default + 3 gradle projects
+			assertEquals(3, projects.size()); // 3 gradle projects
 			IProject root = WorkspaceHelper.getProject("subprojects");
 			assertIsGradleProject(root);
 			IProject project1 = WorkspaceHelper.getProject("project1");
@@ -536,7 +536,7 @@ public class GradleProjectImporterTest extends AbstractGradleBasedTest{
 	@Test
 	public void importGradleKtsProject() throws Exception {
 		List<IProject> projects = importProjects("gradle/kradle");
-		assertEquals(2, projects.size());//default + gradle kts projects
+		assertEquals(1, projects.size()); // gradle kts projects
 		IProject kradle = WorkspaceHelper.getProject("kradle");
 		assertIsGradleProject(kradle);
 		assertNoErrors(kradle);
@@ -629,7 +629,7 @@ public class GradleProjectImporterTest extends AbstractGradleBasedTest{
 	@Test
 	public void testNameConflictProject() throws Exception {
 		List<IProject> projects = importProjects("gradle/nameConflict");
-		assertEquals(3, projects.size());
+		assertEquals(2, projects.size());
 		IProject root = WorkspaceHelper.getProject("nameConflict");
 		assertIsGradleProject(root);
 		IProject subProject = WorkspaceHelper.getProject("nameConflict-nameconflict");
@@ -641,7 +641,7 @@ public class GradleProjectImporterTest extends AbstractGradleBasedTest{
 		try {
 			this.preferences.setAndroidSupportEnabled(true);
 			List<IProject> projects = importProjects("gradle/android");
-			assertEquals(3, projects.size());
+			assertEquals(2, projects.size());
 			IProject androidAppProject = WorkspaceHelper.getProject("app");
 			assertNotNull(androidAppProject);
 			IJavaProject javaProject = JavaCore.create(androidAppProject);
@@ -684,7 +684,7 @@ public class GradleProjectImporterTest extends AbstractGradleBasedTest{
 		try {
 			this.preferences.setAndroidSupportEnabled(true);
 			List<IProject> projects = importProjects("gradle/android");
-			assertEquals(3, projects.size());
+			assertEquals(2, projects.size());
 			IProject androidAppProject = WorkspaceHelper.getProject("app");
 			assertNotNull(androidAppProject);
 			IJavaProject javaProject = JavaCore.create(androidAppProject);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupportTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupportTest.java
@@ -130,7 +130,7 @@ public class MavenBuildSupportTest extends AbstractMavenBasedTest {
 	@Test
 	public void testIgnoreInnerPomChanges() throws Exception {
 		IProject project = importMavenProject("archetyped");
-		assertEquals("The inner pom should not have been imported", 2, WorkspaceHelper.getAllProjects().size());
+		assertEquals("The inner pom should not have been imported", 1, WorkspaceHelper.getAllProjects().size());
 
 		IFile innerPom = project.getFile("src/main/resources/archetype-resources/pom.xml");
 
@@ -229,7 +229,7 @@ public class MavenBuildSupportTest extends AbstractMavenBasedTest {
 		waitForBackgroundJobs();
 		assertTrue(ProjectUtils.isMavenProject(project));
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-		assertEquals(root.getProjects().length, 14);
+		assertEquals(root.getProjects().length, 13);
 		project = root.getProject("batchchild");
 		assertTrue(ProjectUtils.isMavenProject(project));
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporterTest.java
@@ -92,7 +92,7 @@ public class MavenProjectImporterTest extends AbstractMavenBasedTest {
 		try {
 			javaImportExclusions.add(PROJECT1_PATTERN);
 			List<IProject> projects = importProjects("maven/multi");
-			assertEquals(2, projects.size());//default + project 2
+			assertEquals(1, projects.size()); // project 2
 			IProject project1 = WorkspaceHelper.getProject("project1");
 			assertNull(project1);
 			IProject project2 = WorkspaceHelper.getProject("project2");
@@ -134,7 +134,7 @@ public class MavenProjectImporterTest extends AbstractMavenBasedTest {
 	@Test
 	public void testUnzippedSourceImportExclusions() throws Exception {
 		List<IProject> projects = importProjects("maven/unzipped-sources");
-		assertEquals(Arrays.asList(ProjectsManager.getDefaultProject()), projects);
+		assertTrue(projects.isEmpty());
 	}
 
 	@Test
@@ -143,7 +143,7 @@ public class MavenProjectImporterTest extends AbstractMavenBasedTest {
 		try {
 			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setImportMavenEnabled(false);
 			List<IProject> projects = importProjects("eclipse/eclipsemaven");
-			assertEquals(2, projects.size());//default + 1 eclipse projects
+			assertEquals(1, projects.size()); // 1 eclipse projects
 			IProject eclipse = WorkspaceHelper.getProject("eclipse");
 			assertNotNull(eclipse);
 			assertFalse(eclipse.getName() + " has the Maven nature", ProjectUtils.isMavenProject(eclipse));

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MultiRootTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MultiRootTest.java
@@ -40,7 +40,7 @@ public class MultiRootTest extends AbstractProjectsManagerBasedTest {
 		{
 			Collection<String> folders = Arrays.asList(EclipseFolder, MavenFolder);
 			importProjects(folders);
-			assertEquals(3, WorkspaceHelper.getAllProjects().size()); // includes the default project
+			assertEquals(2, WorkspaceHelper.getAllProjects().size());
 			assertNotNull(WorkspaceHelper.getProject("hello"));
 			assertNotNull(WorkspaceHelper.getProject("salut"));
 		}
@@ -49,7 +49,7 @@ public class MultiRootTest extends AbstractProjectsManagerBasedTest {
 			Collection<String> folders = Arrays.asList(MavenMultiFolder, EclipseFolder);
 			importProjects(folders);
 
-			assertEquals(4, WorkspaceHelper.getAllProjects().size()); // includes the default project
+			assertEquals(3, WorkspaceHelper.getAllProjects().size());
 			assertNotNull(WorkspaceHelper.getProject("hello"));
 			assertNull(WorkspaceHelper.getProject("salut"));
 			assertNotNull(WorkspaceHelper.getProject("project1"));
@@ -62,7 +62,7 @@ public class MultiRootTest extends AbstractProjectsManagerBasedTest {
 		{
 			Collection<String> folders = Arrays.asList(EclipseFolder, MavenFolder);
 			importProjects(folders);
-			assertEquals(3, WorkspaceHelper.getAllProjects().size()); // includes the default project
+			assertEquals(2, WorkspaceHelper.getAllProjects().size());
 			assertNotNull(WorkspaceHelper.getProject("hello"));
 			assertNotNull(WorkspaceHelper.getProject("salut"));
 		}
@@ -72,7 +72,7 @@ public class MultiRootTest extends AbstractProjectsManagerBasedTest {
 			Collection<String> toRemove = Arrays.asList(MavenFolder);
 			updateProjects(toAdd, toRemove);
 
-			assertEquals(4, WorkspaceHelper.getAllProjects().size()); // includes the default project
+			assertEquals(3, WorkspaceHelper.getAllProjects().size());
 			assertNotNull(WorkspaceHelper.getProject("hello"));
 			assertNull(WorkspaceHelper.getProject("salut"));
 			assertNotNull(WorkspaceHelper.getProject("project1"));
@@ -85,7 +85,7 @@ public class MultiRootTest extends AbstractProjectsManagerBasedTest {
 			Collection<String> toRemove = Arrays.asList(MavenMultiFolder);
 			updateProjects(toAdd, toRemove);
 
-			assertEquals(3, WorkspaceHelper.getAllProjects().size()); // includes the default project
+			assertEquals(2, WorkspaceHelper.getAllProjects().size());
 			assertNotNull(WorkspaceHelper.getProject("hello"));
 			assertNotNull(WorkspaceHelper.getProject("salut"));
 			assertNull(WorkspaceHelper.getProject("project1"));
@@ -98,7 +98,7 @@ public class MultiRootTest extends AbstractProjectsManagerBasedTest {
 			Collection<String> toRemove = Arrays.asList(EclipseFolder, MavenFolder);
 			updateProjects(toAdd, toRemove);
 
-			assertEquals(2, WorkspaceHelper.getAllProjects().size()); // includes the default project
+			assertEquals(1, WorkspaceHelper.getAllProjects().size());
 			assertNull(WorkspaceHelper.getProject("hello"));
 			assertNull(WorkspaceHelper.getProject("salut"));
 			assertNotNull(WorkspaceHelper.getProject("simple-gradle"));

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManagerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManagerTest.java
@@ -242,10 +242,9 @@ public class ProjectsManagerTest extends AbstractProjectsManagerBasedTest {
 		IProject[] allProjects = ProjectUtils.getAllProjects();
 		Set<String> expectedProjects = new HashSet<>(Arrays.asList(
 			"module1",
-			"childmodule",
-			"jdt.ls-java-project"
+				"childmodule"
 		));
-		assertEquals(3, allProjects.length);
+		assertEquals(2, allProjects.length);
 		for (IProject project : allProjects) {
 			assertTrue(expectedProjects.contains(project.getName()));
 		}
@@ -268,10 +267,9 @@ public class ProjectsManagerTest extends AbstractProjectsManagerBasedTest {
 		Set<String> expectedProjects = new HashSet<>(Arrays.asList(
 			"module1",
 			"childmodule",
-			"module2",
-			"jdt.ls-java-project"
+				"module2"
 		));
-		assertEquals(4, allProjects.length);
+		assertEquals(3, allProjects.length);
 		for (IProject project : allProjects) {
 			assertTrue(expectedProjects.contains(project.getName()));
 		}
@@ -286,10 +284,9 @@ public class ProjectsManagerTest extends AbstractProjectsManagerBasedTest {
 		expectedProjects = new HashSet<>(Arrays.asList(
 			"module1",
 			"childmodule",
-			"module3",
-			"jdt.ls-java-project"
+			"module3"
 		));
-		assertEquals(4, allProjects.length);
+		assertEquals(3, allProjects.length);
 		for (IProject project : allProjects) {
 			assertTrue(expectedProjects.contains(project.getName()));
 		}
@@ -307,12 +304,11 @@ public class ProjectsManagerTest extends AbstractProjectsManagerBasedTest {
 		projectsManager.initializeProjects(Collections.singleton(new org.eclipse.core.runtime.Path(projectDir.getAbsolutePath())), monitor);
 		IProject[] allProjects = ProjectUtils.getAllProjects();
 		Set<String> expectedProjects = new HashSet<>(Arrays.asList(
-			"jdt.ls-java-project",
 			"hello",
 			"salut",
 			"simple-gradle"
 		));
-		assertEquals(4, allProjects.length);
+		assertEquals(3, allProjects.length);
 		for (IProject project : allProjects) {
 			assertTrue(expectedProjects.contains(project.getName()));
 		}
@@ -329,11 +325,10 @@ public class ProjectsManagerTest extends AbstractProjectsManagerBasedTest {
 		projectsManager.initializeProjects(Collections.singleton(new org.eclipse.core.runtime.Path(projectDir.getAbsolutePath())), monitor);
 		IProject[] allProjects = ProjectUtils.getAllProjects();
 		Set<String> expectedProjects = new HashSet<>(Arrays.asList(
-			"jdt.ls-java-project",
 			"salut",
 			"simple-gradle"
 		));
-		assertEquals(3, allProjects.length);
+		assertEquals(2, allProjects.length);
 		for (IProject project : allProjects) {
 			assertTrue(expectedProjects.contains(project.getName()));
 		}


### PR DESCRIPTION
- Default project is configured with a (default) JRE, that will produce
  unwanted symbols when other projects don't use the default JRE
- Place default project creation logic into the invisible project
  importer since that is the importer requiring it
- Continue to support some special cases where default project should be
  created (eg. Maven/Gradle project & opening a standalone file)
- Update testcases & add a testcase

- Fixes https://github.com/redhat-developer/vscode-java/issues/3452

@snjeza , let me know if the PR seems reasonable, or would break something.

The basic issue is when you have some Maven/Gradle project that sets a certain Java version, that is different from the default version (eg. `java.home` or from `java.configuration.runtimes` with `default` set to `true`), then you'll get duplicate symbols.

At first I wanted to avoid creating the default project when a Maven/Gradle project is used, but apparently we actually have support for opening external files through the default project in those cases.

My next solution was to just take into account the Java versions used by the projects and set that.

**Update:** Now I've polished up the original solution so the default project is created only when needed.