### PR TITLE
Fix deleting invisible projects when updating workspace folders.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
@@ -306,7 +306,7 @@ public abstract class ProjectsManager implements ISaveParticipant, IProjectsMana
 					long start = System.currentTimeMillis();
 					IProject[] projects = getWorkspaceRoot().getProjects();
 					for (IProject project : projects) {
-						if (ResourceUtils.isContainedIn(project.getLocation(), removedRootPaths)) {
+						if (ResourceUtils.isContainedIn(ProjectUtils.getProjectRealFolder(project), removedRootPaths)) {
 							try {
 								project.delete(false, true, subMonitor.split(1));
 							} catch (CoreException e) {


### PR DESCRIPTION
I noticed that when I removed a workspace folder through `workspace/didChangeWorkspaceFolders`, it wasn't being cleaned up. It seems like the workspace folders are being registered as invisible projects, but when it comes time to clean them up, invisible projects aren't handled properly.