### PR TITLE
Make use of new getters in superclass to override javadoc formatting

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/JavadocContentAccess2.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/JavadocContentAccess2.java
@@ -232,33 +232,33 @@ public class JavadocContentAccess2 {
 		@Override
 		protected void handleBlockTags(String title, List<TagElement> tags) {
 			super.handleBlockTags(title, tags);
-			fBuf.append(BlOCK_TAG_ENTRY_END);
+			fBuf.append(getBlockTagEntryEnd());
 		}
 
 		@Override
 		protected void handleSingleTag(TagElement tag) {
-			fBuf.append(BLOCK_TAG_START);
+			fBuf.append(getBlockTagStart());
 			super.handleSingleTag(tag);
-			fBuf.append(BLOCK_TAG_END);
+			fBuf.append(getBlockTagEnd());
 		}
 
 		@Override
 		protected void handleReturnTagBody(TagElement tag, CharSequence returnDescription) {
-			fBuf.append(BLOCK_TAG_START);
+			fBuf.append(getBlockTagStart());
 			super.handleReturnTagBody(tag, returnDescription);
-			fBuf.append(BLOCK_TAG_END);
-			fBuf.append(BlOCK_TAG_ENTRY_END);
+			fBuf.append(getBlockTagEnd());
+			fBuf.append(getBlockTagEntryStart());
 		}
 
 		@Override
 		protected void handleBlockTagBody(TagElement tag) {
 			List fragments = tag.fragments();
 			if (!fragments.isEmpty()) {
-				fBuf.append(BLOCK_TAG_START);
-				fBuf.append(BlOCK_TAG_ENTRY_START);
+				fBuf.append(getBlockTagStart());
+				fBuf.append(getBlockTagEntryStart());
 				super.handleContentElements(fragments);
-				fBuf.append(BlOCK_TAG_ENTRY_END);
-				fBuf.append(BLOCK_TAG_END);
+				fBuf.append(getBlockTagEntryEnd());
+				fBuf.append(getBlockTagEnd());
 			}
 		}
 
@@ -271,24 +271,24 @@ public class JavadocContentAccess2 {
 
 		@Override
 		protected void handleExceptionTagsBody(List<TagElement> tags, List<String> exceptionNames, CharSequence[] exceptionDescriptions) {
-			fBuf.append(BLOCK_TAG_START);
+			fBuf.append(getBlockTagStart());
 			super.handleExceptionTagsBody(tags, exceptionNames, exceptionDescriptions);
-			fBuf.append(BLOCK_TAG_END);
-			fBuf.append(BlOCK_TAG_ENTRY_END);
+			fBuf.append(getBlockTagEnd());
+			fBuf.append(getBlockTagEntryEnd());
 		}
 
 		@Override
 		protected void handleSingleParameterTag(TagElement tag) {
-			fBuf.append(BLOCK_TAG_START);
+			fBuf.append(getBlockTagStart());
 			super.handleSingleParameterTag(tag);
-			fBuf.append(BLOCK_TAG_END);
+			fBuf.append(getBlockTagEnd());
 		}
 
 		@Override
 		protected void handleSingleParameterDescription(String name, CharSequence description, boolean isTypeParameters) {
-			fBuf.append(BLOCK_TAG_START);
+			fBuf.append(getBlockTagStart());
 			super.handleSingleParameterDescription(name, description, isTypeParameters);
-			fBuf.append(BLOCK_TAG_END);
+			fBuf.append(getBlockTagEnd());
 		}
 
 		protected String markSnippet(String text, boolean isInSnippet) {
@@ -320,5 +320,26 @@ public class JavadocContentAccess2 {
 			}
 			return "";
 		}
+
+		@Override
+		protected String getBlockTagStart() {
+			return "<ul>";
+		}
+
+		@Override
+		protected String getBlockTagEnd() {
+			return "</ul>";
+		}
+
+		@Override
+		protected String getBlockTagEntryStart() {
+			return "<li>";
+		}
+
+		@Override
+		protected String getBlockTagEntryEnd() {
+			return "</li>";
+		}
+
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/JavadocContentAccess2.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/JavadocContentAccess2.java
@@ -247,7 +247,7 @@ public class JavadocContentAccess2 {
 			fBuf.append(getBlockTagStart());
 			super.handleReturnTagBody(tag, returnDescription);
 			fBuf.append(getBlockTagEnd());
-			fBuf.append(getBlockTagEntryStart());
+			fBuf.append(getBlockTagEntryEnd());
 		}
 
 		@Override

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -25,7 +25,7 @@
             <unit id="org.mockito.mockito-core" version="0.0.0"/>
             <unit id="org.apache.commons.commons-io" version="0.0.0"/>
             <unit id="org.eclipse.jdt.apt.pluggable.core" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.32-I-builds/I20240422-1800/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.32-I-builds/I20240502-1800/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.jdt.core.compiler.batch" version="0.0.0"/>


### PR DESCRIPTION
This PR will likely fail until https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/1386 is handled and we update to a TP that includes it. 

It is here for safe-keeping so we don't lose it or remain unsure of how to respond. 