### PR TITLE
codeActionKinds not sent when CodeActionClientCapabilities is not dynamic.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
@@ -64,6 +64,7 @@ import org.eclipse.jdt.ui.text.java.IProblemLocation;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionContext;
 import org.eclipse.lsp4j.CodeActionKind;
+import org.eclipse.lsp4j.CodeActionOptions;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.Diagnostic;
@@ -79,6 +80,19 @@ public class CodeActionHandler {
 	public static final ResponseStore<Either<ChangeCorrectionProposalCore, CodeActionProposal>> codeActionStore
 		= new ResponseStore<>(ForkJoinPool.commonPool().getParallelism());
 	public static final String COMMAND_ID_APPLY_EDIT = "java.apply.workspaceEdit";
+
+	public static CodeActionOptions createOptions(PreferenceManager preferenceManager) {
+		String[] kinds = { CodeActionKind.QuickFix, CodeActionKind.Refactor, CodeActionKind.RefactorExtract, CodeActionKind.RefactorInline, CodeActionKind.RefactorRewrite, CodeActionKind.Source, CodeActionKind.SourceOrganizeImports };
+		List<String> codeActionKinds = new ArrayList<>();
+		for (String kind : kinds) {
+			if (preferenceManager.getClientPreferences().isSupportedCodeActionKind(kind)) {
+				codeActionKinds.add(kind);
+			}
+		}
+		CodeActionOptions options = new CodeActionOptions(codeActionKinds);
+		options.setResolveProvider(Boolean.valueOf(preferenceManager.getClientPreferences().isResolveCodeActionSupported()));
+		return options;
+	}
 
 	private QuickFixProcessor quickFixProcessor;
 	private RefactorProcessor refactorProcessor;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -47,7 +47,6 @@ import org.eclipse.jdt.ls.core.internal.managers.TelemetryManager;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
 import org.eclipse.jdt.ls.internal.gradle.checksums.WrapperValidator;
-import org.eclipse.lsp4j.CodeActionOptions;
 import org.eclipse.lsp4j.CodeLensOptions;
 import org.eclipse.lsp4j.DocumentFilter;
 import org.eclipse.lsp4j.DocumentOnTypeFormattingOptions;
@@ -145,13 +144,7 @@ final public class InitHandler extends BaseInitHandler {
 			capabilities.setRenameProvider(RenameHandler.createOptions());
 		}
 		if (!preferenceManager.getClientPreferences().isCodeActionDynamicRegistered()) {
-			if (preferenceManager.getClientPreferences().isResolveCodeActionSupported()) {
-				CodeActionOptions codeActionOptions = new CodeActionOptions();
-				codeActionOptions.setResolveProvider(Boolean.TRUE);
-				capabilities.setCodeActionProvider(codeActionOptions);
-			} else {
-				capabilities.setCodeActionProvider(Boolean.TRUE);
-			}
+			capabilities.setCodeActionProvider(CodeActionHandler.createOptions(preferenceManager));
 		}
 		if (!preferenceManager.getClientPreferences().isExecuteCommandDynamicRegistrationSupported()) {
 			Set<String> commands = commandHandler.getAllCommands();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -90,8 +90,6 @@ import org.eclipse.lsp4j.CallHierarchyOutgoingCall;
 import org.eclipse.lsp4j.CallHierarchyOutgoingCallsParams;
 import org.eclipse.lsp4j.CallHierarchyPrepareParams;
 import org.eclipse.lsp4j.CodeAction;
-import org.eclipse.lsp4j.CodeActionKind;
-import org.eclipse.lsp4j.CodeActionOptions;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.CodeLens;
 import org.eclipse.lsp4j.CodeLensOptions;
@@ -418,7 +416,7 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 					new ExecuteCommandOptions(new ArrayList<>(commandHandler.getNonStaticCommands())));
 		}
 		if (preferenceManager.getClientPreferences().isCodeActionDynamicRegistered()) {
-			toggleCapability(preferenceManager.getClientPreferences().isCodeActionDynamicRegistered(), Preferences.CODE_ACTION_ID, Preferences.CODE_ACTION, getCodeActionOptions());
+			toggleCapability(preferenceManager.getClientPreferences().isCodeActionDynamicRegistered(), Preferences.CODE_ACTION_ID, Preferences.CODE_ACTION, CodeActionHandler.createOptions(preferenceManager));
 		}
 		if (preferenceManager.getClientPreferences().isFoldgingRangeDynamicRegistered()) {
 			toggleCapability(preferenceManager.getPreferences().isFoldingRangeEnabled(), Preferences.FOLDINGRANGE_ID, Preferences.FOLDINGRANGE, null);
@@ -452,19 +450,6 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 				JavaLanguageServerPlugin.logException(e);
 			}
 		}
-	}
-
-	private CodeActionOptions getCodeActionOptions() {
-		String[] kinds = { CodeActionKind.QuickFix, CodeActionKind.Refactor, CodeActionKind.RefactorExtract, CodeActionKind.RefactorInline, CodeActionKind.RefactorRewrite, CodeActionKind.Source, CodeActionKind.SourceOrganizeImports };
-		List<String> codeActionKinds = new ArrayList<>();
-		for (String kind : kinds) {
-			if (preferenceManager.getClientPreferences().isSupportedCodeActionKind(kind)) {
-				codeActionKinds.add(kind);
-			}
-		}
-		CodeActionOptions options = new CodeActionOptions(codeActionKinds);
-		options.setResolveProvider(Boolean.valueOf(preferenceManager.getClientPreferences().isResolveCodeActionSupported()));
-		return options;
 	}
 
 	/* (non-Javadoc)


### PR DESCRIPTION
When a client registers with `CodeActionClientCapabilities.dynamic` equal to `true`, the server will respond with:
```
capabilities: {
    ...
    codeActionProvider: {
        codeActionKinds: [...],
        resolveProvider: true,
    },
}
```
But if `CodeActionClientCapabilities.dynamic` is `false`, then the server responds with:
```
capabilities: {
    ...
    codeActionProvider: {
        resolveProvider: true,
    },
}
```
The server will never provide `codeActionKinds` when `CodeActionClientCapabilities` is not dynamic. I believe this behavior is a mistake (correct me if I'm wrong), and with this pull request, the server will always respond with `codeActionKinds`.