### PR TITLE
Improve order of operations when importing multi-module Maven projects.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -248,7 +248,9 @@ final public class InitHandler extends BaseInitHandler {
 		Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_AUTO_BUILD);
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		if (workspace instanceof Workspace workspaceImpl) {
-			workspaceImpl.getBuildManager().waitForAutoBuildOff();
+			if (!Job.getJobManager().isSuspended()) {
+				workspaceImpl.getBuildManager().waitForAutoBuildOff();
+			}
 		}
 		Job job = new WorkspaceJob("Initialize Workspace") {
 			@Override

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceEventsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceEventsHandler.java
@@ -57,6 +57,10 @@ public class WorkspaceEventsHandler {
 		Thread eventThread = new Thread(() -> {
 			while(true) {
 				try {
+					// https://github.com/redhat-developer/vscode-java/issues/3637
+					while (!pm.isBuildFinished()) {
+						Thread.sleep(200);
+					}
 					FileEvent event = queue.take();
 					handleFileEvent(event);
 				} catch (InterruptedException e) {
@@ -95,6 +99,11 @@ public class WorkspaceEventsHandler {
 		for (FileEvent fileEvent : fileEvents) {
 			handleFileEvent(fileEvent);
 		}
+	}
+
+	// for test only
+	public boolean isEmpty() {
+		return queue.isEmpty();
 	}
 
 	private void handleFileEvent(FileEvent fileEvent) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IProjectsManager.java
@@ -103,4 +103,27 @@ public interface IProjectsManager {
 	default void projectsImported(IProgressMonitor monitor) {
 		// do nothing
 	}
+
+	/**
+	 * Executed after the projects are imported and finished.
+	 */
+	default void projectsBuildFinished(IProgressMonitor monitor) {
+		// do nothing
+	}
+
+	/**
+	 * Check whether the build is finished
+	 */
+	default boolean isBuildFinished() {
+		return true;
+	};
+
+	default boolean shouldUpdateProjects() {
+		return false;
+	}
+
+	default void setShouldUpdateProjects(boolean update) {
+		// do nothing
+	}
+
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
@@ -505,14 +505,24 @@ public abstract class ProjectsManager implements ISaveParticipant, IProjectsMana
 				return status;
 			}
 		};
+		waitForUpdateJobs();
 		job.schedule();
 		return job;
+	}
+
+	private void waitForUpdateJobs() {
+		int maxThread = preferenceManager.getPreferences().getMaxConcurrentBuilds();
+		Job[] jobs = Job.getJobManager().find(IConstants.UPDATE_PROJECT_FAMILY);
+		if (jobs != null && jobs.length > maxThread) {
+			JobHelpers.waitForJobs(IConstants.UPDATE_PROJECT_FAMILY, null);
+		}
 	}
 
 	@Override
 	public Job updateProjects(Collection<IProject> projects, boolean force) {
 		JavaLanguageServerPlugin.sendStatus(ServiceStatus.Message, "Updating project configurations...");
 		UpdateProjectsWorkspaceJob job = new UpdateProjectsWorkspaceJob(projects, force);
+		waitForUpdateJobs();
 		job.schedule();
 		return job;
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
@@ -164,7 +164,9 @@ public class PreferenceManager {
 		// workaround for https://github.com/redhat-developer/vscode-java/issues/718
 		javaCoreOptions.put(JavaCore.CORE_CIRCULAR_CLASSPATH, JavaCore.WARNING);
 		javaCoreOptions.put(JavaCore.COMPILER_IGNORE_UNNAMED_MODULE_FOR_SPLIT_PACKAGE, JavaCore.ENABLED);
-		JavaCore.setOptions(javaCoreOptions);
+		if (!Objects.equals(javaCoreOptions, JavaCore.getOptions())) {
+			JavaCore.setOptions(javaCoreOptions);
+		}
 	}
 
 	private static void reloadTemplateStore() {
@@ -226,7 +228,9 @@ public class PreferenceManager {
 		}
 		Hashtable<String, String> options = JavaCore.getOptions();
 		preferences.updateTabSizeInsertSpaces(options);
-		JavaCore.setOptions(options);
+		if (!Objects.equals(options, JavaCore.getOptions())) {
+			JavaCore.setOptions(options);
+		}
 		List<String> resourceFilters = preferences.getResourceFilters();
 		IEclipsePreferences eclipsePreferences = InstanceScope.INSTANCE.getNode(IConstants.PLUGIN_ID);
 		// add the resourceFilters preference; the org.eclipse.jdt.ls.filesystem plugin uses it


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-java/issues/3637

Steps to reproduce:
1. exit VS Code
2. [Clean the workspace directory]( https://github.com/redhat-developer/vscode-java/wiki/Troubleshooting#clean-the-workspace-directory)
3. clone the repository [quarkus-langchain4j](https://github.com/quarkiverse/quarkus-langchain4j)
4. cd quarkus-langchain4j
5. code .
6. wait for the build to finish
7. reload the VS Code window (it freezes without the PR; takes several seconds with the PR or VS Code 1.32.0)

[Test vsix](https://github.com/snjeza/vscode-test/raw/master/java-1.32.0.vsix)