### PR TITLE
Update target platform to newer 4.32-I-builds (I20240507-0220)

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -25,7 +25,7 @@
             <unit id="org.mockito.mockito-core" version="0.0.0"/>
             <unit id="org.apache.commons.commons-io" version="0.0.0"/>
             <unit id="org.eclipse.jdt.apt.pluggable.core" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.32-I-builds/I20240502-1800/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.32-I-builds/I20240507-0220/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.jdt.core.compiler.batch" version="0.0.0"/>


### PR DESCRIPTION
Required due to upstream change: https://github.com/eclipse-jdt/eclipse.jdt.core/commit/ac81e89eca51bf80016e59e49fdc9fddbbead291 causing compilation failures

 


Signed-off-by: Fred Bricon <fbricon@gmail.com>
