### PR TITLE
[WIP] Return the uri of the parent class when the class file points to an inner class

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
@@ -854,11 +854,30 @@ public final class JDTUtils {
 			return null;
 		}
 
+		String classId = classFile.getHandleIdentifier();
+		String classFileName = classFile.getElementName();
+		// try to point to the parent class if this is an inner class, this avoid
+		// opening new tab for the actual same source file.
+		if (classFileName.contains("$")) {
+			String parentClassId = classId.substring(0, classId.lastIndexOf("$")) + ".class";
+			IJavaElement parentClass = JavaCore.create(parentClassId);
+			if (parentClass != null && parentClass instanceof IClassFile parentClassFile) {
+				try {
+					// they are from the same source file if the contents are the same.
+					if (Objects.equals(parentClassFile.getBuffer(), classFile.getBuffer())) {
+						classId = parentClassFile.getHandleIdentifier();
+						classFileName = parentClassFile.getElementName();
+					}
+				} catch (JavaModelException e) {
+					JavaLanguageServerPlugin.logException("Error get content of the class file", e);
+				}
+			}
+		}
 		String packageName = classFile.getParent().getElementName();
 		String jarName = classFile.getParent().getParent().getElementName();
 		String uriString = null;
 		try {
-			uriString = new URI(JDT_SCHEME, "contents", PATH_SEPARATOR + jarName + PATH_SEPARATOR + packageName + PATH_SEPARATOR + classFile.getElementName(), classFile.getHandleIdentifier(), null).toASCIIString();
+			uriString = new URI(JDT_SCHEME, "contents", PATH_SEPARATOR + jarName + PATH_SEPARATOR + packageName + PATH_SEPARATOR + classFileName, classId, null).toASCIIString();
 		} catch (URISyntaxException e) {
 			JavaLanguageServerPlugin.logException("Error generating URI for class ", e);
 		}


### PR DESCRIPTION
fix https://github.com/microsoft/vscode-java-dependency/issues/833

- When the class file name containing '$', we try to get its top-level class (remove the '$'' and its inner class name) from the Java model, if the top-level class do exist, we compare the content of the two classes and return the uri of the top-level class if the content is the same.

Before, navigate to a inner class will open a new tab:

https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/6193897/35d6957d-e437-4b9a-907f-7995040968b5



After, navigate to a inner class will go to the location in the current file:

https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/6193897/f280926f-3f5c-4ec6-85fe-81ec848c49aa

