### PR TITLE
Revalidate open files in project when classpath updates.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -303,7 +303,7 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 				try {
 					workspaceDiagnosticsHandler = new WorkspaceDiagnosticsHandler(JDTLanguageServer.this.client, pm, preferenceManager.getClientPreferences(), documentLifeCycleHandler);
 					workspaceDiagnosticsHandler.addResourceChangeListener();
-					classpathUpdateHandler = new ClasspathUpdateHandler(JDTLanguageServer.this.client);
+					classpathUpdateHandler = new ClasspathUpdateHandler(JDTLanguageServer.this.client, documentLifeCycleHandler);
 					classpathUpdateHandler.addElementChangeListener();
 					SourceAttachUpdateHandler attachListener = new SourceAttachUpdateHandler(client);
 					attachListener.addElementChangeListener();


### PR DESCRIPTION
Fixes #3155 

It now re-validates all open files in a project when the project's classpath is updated. This only happens when autobuild is turned off (I assume that when autobuild is on, projects are automatically rebuilt when the classpath changes and files are re-validated in the process).

I implemented this through `ClasspathUpdateHandler` and `DiagnosticsHandler` which is probably not a good idea (e.g. does this code belong in `ClasspathUpdateHandler`? should we re-validate files through `DocumentLifeCycleHandler` to take advantage of debouncing?). Let me know if I should do anything differently.