### PR TITLE
Support update Java project options.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
@@ -723,7 +723,7 @@ public class ProjectCommand {
 		IJavaProject javaProject = getJavaProjectFromUri(projectUri);
 		IProject project = javaProject.getProject();
 		Map<String, String> newOptions = new HashMap<>();
-		final Set<String> validOptionKeys = JavaCore.getDefaultOptions().keySet();
+		final Map<String, String> currentOptions = javaProject.getOptions(true);
 		for (Map.Entry<String, Object> entry : options.entrySet()) {
 			switch (entry.getKey()) {
 				case M2E_SELECTED_PROFILES:
@@ -747,16 +747,18 @@ public class ProjectCommand {
 					}
 					break;
 				default:
-					if (validOptionKeys.contains(entry.getKey())) {
+					String settingValue = currentOptions.get(entry.getKey());
+					// only update the options whose keys are valid and value are different from the current ones
+					if (settingValue != null && !settingValue.equals(entry.getValue().toString().trim())) {
 						newOptions.put(entry.getKey(), entry.getValue().toString());
 					}
 					break;
 			}
 		}
 		if (!newOptions.isEmpty()) {
-			Map<String, String> javaProjectOptions = javaProject.getOptions(false);
-			javaProjectOptions.putAll(newOptions);
-			javaProject.setOptions(javaProjectOptions);
+			Map<String, String> projectSpecificOptions = javaProject.getOptions(false);
+			projectSpecificOptions.putAll(newOptions);
+			javaProject.setOptions(projectSpecificOptions);
 		}
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
@@ -28,6 +28,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -721,6 +722,8 @@ public class ProjectCommand {
 	public static void updateProjectSettings(String projectUri, Map<String, Object> options) throws CoreException, URISyntaxException {
 		IJavaProject javaProject = getJavaProjectFromUri(projectUri);
 		IProject project = javaProject.getProject();
+		Map<String, String> newOptions = new HashMap<>();
+		final Set<String> validOptionKeys = JavaCore.getDefaultOptions().keySet();
 		for (Map.Entry<String, Object> entry : options.entrySet()) {
 			switch (entry.getKey()) {
 				case M2E_SELECTED_PROFILES:
@@ -744,8 +747,16 @@ public class ProjectCommand {
 					}
 					break;
 				default:
+					if (validOptionKeys.contains(entry.getKey())) {
+						newOptions.put(entry.getKey(), entry.getValue().toString());
+					}
 					break;
 			}
+		}
+		if (!newOptions.isEmpty()) {
+			Map<String, String> javaProjectOptions = javaProject.getOptions(false);
+			javaProjectOptions.putAll(newOptions);
+			javaProject.setOptions(javaProjectOptions);
 		}
 	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
@@ -467,6 +467,24 @@ public class ProjectCommandTest extends AbstractInvisibleProjectBasedTest {
 		assertEquals("my profile", options.get(KEY));
 	}
 
+	@Test
+	public void testUpdateProjectOptions() throws Exception {
+		importProjects("maven/salut");
+		IProject project = WorkspaceHelper.getProject("salut");
+		String uriString = project.getLocationURI().toString();
+		List<String> settingKeys = Arrays.asList(JavaCore.COMPILER_CODEGEN_METHOD_PARAMETERS_ATTR);
+		Map<String, Object> options = ProjectCommand.getProjectSettings(uriString, settingKeys);
+
+		assertEquals(JavaCore.DO_NOT_GENERATE, options.get(JavaCore.COMPILER_CODEGEN_METHOD_PARAMETERS_ATTR));
+
+		Map<String, Object> updateOptions = new HashMap<>();
+		updateOptions.put(JavaCore.COMPILER_CODEGEN_METHOD_PARAMETERS_ATTR, JavaCore.GENERATE);
+		ProjectCommand.updateProjectSettings(uriString, updateOptions);
+
+		options = ProjectCommand.getProjectSettings(uriString, settingKeys);
+		assertEquals(JavaCore.GENERATE, options.get(JavaCore.COMPILER_CODEGEN_METHOD_PARAMETERS_ATTR));
+	}
+
 	private SymbolInformation buildClassSymbol(IProject project, String fqClassName) throws Exception {
 		String uriString = buildClassfileUri(project, fqClassName);
 		SymbolInformation si = new SymbolInformation();


### PR DESCRIPTION
- All the options from JavaCore are supported via the delegate command 'java.project.updateSettings'.