### PR TITLE
Support using 'javac' as internal compiler.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,10 +39,10 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-    - name: Set up JDK 17
+    - name: Set up JDK 23
       uses: actions/setup-java@v3
       with:
-            java-version: '17'
+            java-version: '23'
             distribution: 'temurin'
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/SuppressWarningsSubProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/SuppressWarningsSubProcessor.java
@@ -18,11 +18,14 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ChildListPropertyDescriptor;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
-import org.eclipse.jdt.ui.text.java.IInvocationContext;
-import org.eclipse.jdt.ui.text.java.IProblemLocation;
+import org.eclipse.jdt.internal.corext.fix.IProposableFix;
 import org.eclipse.jdt.internal.ui.text.correction.SuppressWarningsBaseSubProcessor;
 import org.eclipse.jdt.internal.ui.text.correction.SuppressWarningsProposalCore;
+import org.eclipse.jdt.internal.ui.text.correction.proposals.FixCorrectionProposalCore;
 import org.eclipse.jdt.ls.core.internal.handlers.CodeActionHandler;
+import org.eclipse.jdt.ui.cleanup.ICleanUp;
+import org.eclipse.jdt.ui.text.java.IInvocationContext;
+import org.eclipse.jdt.ui.text.java.IProblemLocation;
 import org.eclipse.jdt.ui.text.java.correction.ASTRewriteCorrectionProposalCore;
 import org.eclipse.lsp4j.CodeActionKind;
 
@@ -48,6 +51,13 @@ public class SuppressWarningsSubProcessor extends SuppressWarningsBaseSubProcess
 	@Override
 	protected ProposalKindWrapper createASTRewriteCorrectionProposal(String name, ICompilationUnit cu, ASTRewrite rewrite, int relevance) {
 		return CodeActionHandler.wrap(new ASTRewriteCorrectionProposalCore(name, cu, rewrite, relevance), CodeActionKind.QuickFix);
+	}
+
+	@Override
+	protected ProposalKindWrapper createFixCorrectionProposal(IProposableFix fix, ICleanUp cleanUp, int relevance, IInvocationContext context) {
+		FixCorrectionProposalCore proposal = new FixCorrectionProposalCore(fix, cleanUp, relevance, context);
+		proposal.setCommandId("org.eclipse.jdt.ui.correction.addSuppressWarnings");
+		return CodeActionHandler.wrap(proposal, CodeActionKind.QuickFix);
 	}
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDiagnosticsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDiagnosticsHandler.java
@@ -20,7 +20,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.core.resources.IMarker;
@@ -33,6 +35,7 @@ import org.eclipse.jdt.core.IJavaModelMarker;
 import org.eclipse.jdt.core.IOpenable;
 import org.eclipse.jdt.core.IProblemRequestor;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.compiler.CategorizedProblem;
 import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.internal.compiler.problem.DefaultProblem;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
@@ -58,6 +61,10 @@ public abstract class BaseDiagnosticsHandler implements IProblemRequestor {
 
 	public static final int NON_PROJECT_JAVA_FILE = 0x10;
 	public static final int NOT_ON_CLASSPATH = 0x20;
+
+	public static final String DIAG_JAVAC_CODE = "javacCode";
+	public static final String DIAG_ECJ_PROBLEM_ID = "ecjProblemId";
+	public static final String DIAG_ARGUMENTS = "arguments";
 
 	public BaseDiagnosticsHandler(JavaClientConnection conn, ICompilationUnit cu) {
 		problems = new ArrayList<>();
@@ -248,11 +255,29 @@ public abstract class BaseDiagnosticsHandler implements IProblemRequestor {
 			diag.setCode(Integer.toString(problem.getID()));
 			diag.setSeverity(convertSeverity(problem));
 			diag.setRange(convertRange(openable, problem));
+			Map<String, Object> data = new HashMap<>();
 			if (problem.getID() == IProblem.UndefinedName || problem.getID() == IProblem.UndefinedType || problem.getID() == IProblem.UninitializedBlankFinalField) {
-				diag.setData(problem.getArguments());
+				data.put(DIAG_ARGUMENTS, problem.getArguments());
 			}
 			if (isDiagnosticTagSupported) {
 				diag.setTags(getDiagnosticTag(problem.getID()));
+			}
+			if (problem instanceof CategorizedProblem javaProblem) {
+				String[] extraAttributeNames = javaProblem.getExtraMarkerAttributeNames();
+				Object[] extraAttributeValues = javaProblem.getExtraMarkerAttributeValues();
+				if (extraAttributeNames != null && extraAttributeValues != null
+					&& extraAttributeNames.length == extraAttributeValues.length) {
+					for (int i = 0; i < extraAttributeNames.length; i++) {
+						if (DIAG_JAVAC_CODE.equals(extraAttributeNames[i])) {
+							diag.setCode(String.valueOf(extraAttributeValues[i]));
+							data.put(DIAG_ECJ_PROBLEM_ID, Integer.toString(problem.getID()));
+							break;
+						}
+					}
+				}
+			}
+			if (!data.isEmpty()) {
+				diag.setData(data);
 			}
 			array.add(diag);
 		}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
@@ -42,6 +42,7 @@ import org.eclipse.jdt.internal.ui.text.correction.proposals.NewMethodCorrection
 import org.eclipse.jdt.internal.ui.text.correction.proposals.NewVariableCorrectionProposalCore;
 import org.eclipse.jdt.ls.core.internal.ChangeUtil;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.JSONUtility;
 import org.eclipse.jdt.ls.core.internal.JavaCodeActionKind;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.corrections.DiagnosticsHelper;
@@ -349,14 +350,19 @@ public class CodeActionHandler {
 			boolean isError = diagnostic.getSeverity() == DiagnosticSeverity.Error;
 			int problemId = getProblemId(diagnostic);
 			List<String> arguments = new ArrayList<>();
-			if (diagnostic.getData() instanceof JsonArray data) {
-				for (JsonElement e : data) {
-					arguments.add(e.getAsString());
+			if (diagnostic.getData() != null) {
+				Map<String, Object> data = JSONUtility.toModel(diagnostic.getData(), Map.class);
+				Object args = data.get(BaseDiagnosticsHandler.DIAG_ARGUMENTS);
+				if (args instanceof JsonArray args1) {
+					for (JsonElement e : args1) {
+						arguments.add(e.getAsString());
+					}
+				} else if (args instanceof String[] args1) {
+					arguments = Arrays.asList(args1);
 				}
-			}
-			if (diagnostic.getData() instanceof String[] data) {
-				for (String s : data) {
-					arguments.add(s);
+				Object ecjProblemId = data.get(BaseDiagnosticsHandler.DIAG_ECJ_PROBLEM_ID);
+				if (ecjProblemId instanceof String id) {
+					problemId = Integer.valueOf(id);
 				}
 			}
 			locations[i] = new ProblemLocation(start, end - start, problemId, arguments.toArray(new String[0]), isError, IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandler.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -410,6 +411,17 @@ public final class WorkspaceDiagnosticsHandler implements IResourceChangeListene
 			d.setTags(DiagnosticsHandler.getDiagnosticTag(problemId));
 		}
 		d.setRange(range);
+		try {
+			if (marker.getAttribute(BaseDiagnosticsHandler.DIAG_JAVAC_CODE) != null) {
+				String javacCode = (String) marker.getAttribute(BaseDiagnosticsHandler.DIAG_JAVAC_CODE);
+				Map<String, Object> data = new HashMap<>();
+				data.put(BaseDiagnosticsHandler.DIAG_ECJ_PROBLEM_ID, String.valueOf(problemId));
+				d.setCode(javacCode);
+				d.setData(data);
+			}
+		} catch (CoreException e) {
+			// do nothing
+		}
 		return d;
 	}
 
@@ -458,6 +470,17 @@ public final class WorkspaceDiagnosticsHandler implements IResourceChangeListene
 		d.setRange(convertRange(document, marker));
 		if (isDiagnosticTagSupported) {
 			d.setTags(DiagnosticsHandler.getDiagnosticTag(problemId));
+		}
+		try {
+			if (marker.getAttribute(BaseDiagnosticsHandler.DIAG_JAVAC_CODE) != null) {
+				String javacCode = (String) marker.getAttribute(BaseDiagnosticsHandler.DIAG_JAVAC_CODE);
+				Map<String, Object> data = new HashMap<>();
+				data.put(BaseDiagnosticsHandler.DIAG_ECJ_PROBLEM_ID, String.valueOf(problemId));
+				d.setCode(javacCode);
+				d.setData(data);
+			}
+		} catch (CoreException e) {
+			// do nothing
 		}
 		return d;
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/TelemetryManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/TelemetryManager.java
@@ -171,6 +171,7 @@ public class TelemetryManager {
 			properties.add("buildFileNames", buildFileNamesList);
 		}
 		properties.addProperty("javaProjectCount", javaProjectCount);
+		properties.addProperty("javac.enabled", Boolean.toString(prefs.getPreferences().isJavacEnabled()));
 		if (sourceLevelMin != 0) {
 			properties.addProperty("compiler.source.min", Float.toString(sourceLevelMin));
 		}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -516,11 +516,13 @@ public class Preferences {
 
 	public static final String JAVA_JDT_LS_PROTOBUF_SUPPORT_ENABLED = "java.jdt.ls.protobufSupport.enabled";
 	public static final String JAVA_JDT_LS_ANDROID_SUPPORT_ENABLED = "java.jdt.ls.androidSupport.enabled";
+	public static final String JAVA_JDT_LS_JAVAC_ENABLED = "java.jdt.ls.javac.enabled";
 
 	public static final String JAVA_COMPILE_NULLANALYSIS_NONNULL = "java.compile.nullAnalysis.nonnull";
 	public static final String JAVA_COMPILE_NULLANALYSIS_NULLABLE = "java.compile.nullAnalysis.nullable";
 	public static final String JAVA_COMPILE_NULLANALYSIS_NONNULLBYDEFAULT = "java.compile.nullAnalysis.nonnullbydefault";
 	public static final String JAVA_COMPILE_NULLANALYSIS_MODE = "java.compile.nullAnalysis.mode";
+	public static final String JAVA_COMPLETION_ENGINE = "java.completion.engine";
 
 	public static final String LIFECYCLE_MAPPING_METADATA_SOURCE_NAME = "lifecycle-mapping-metadata.xml";
 
@@ -702,6 +704,7 @@ public class Preferences {
 	private ProjectEncodingMode projectEncoding;
 	private boolean avoidVolatileChanges;
 	private boolean protobufSupportEnabled;
+	private boolean javacEnabled;
 	private boolean androidSupportEnabled;
 	private List<String> nonnullTypes;
 	private List<String> nullableTypes;
@@ -958,6 +961,7 @@ public class Preferences {
 		inlayHintsParameterMode = InlayHintsParameterMode.LITERALS;
 		projectEncoding = ProjectEncodingMode.IGNORE;
 		avoidVolatileChanges = true;
+		javacEnabled = false;
 		nonnullTypes = new ArrayList<>();
 		nullableTypes = new ArrayList<>();
 		nonnullbydefaultTypes = new ArrayList<>();
@@ -1335,6 +1339,8 @@ public class Preferences {
 		prefs.setAvoidVolatileChanges(avoidVolatileChanges);
 		boolean protobufSupported = getBoolean(configuration, JAVA_JDT_LS_PROTOBUF_SUPPORT_ENABLED, false);
 		prefs.setProtobufSupportEnabled(protobufSupported);
+		boolean javacEnabled = getBoolean(configuration, JAVA_JDT_LS_JAVAC_ENABLED, false);
+		prefs.setJavacEnabled(javacEnabled);
 		boolean androidSupported = getBoolean(configuration, JAVA_JDT_LS_ANDROID_SUPPORT_ENABLED, false);
 		prefs.setAndroidSupportEnabled(androidSupported);
 		List<String> nonnullTypes = getList(configuration, JAVA_COMPILE_NULLANALYSIS_NONNULL, Collections.emptyList());
@@ -1379,10 +1385,10 @@ public class Preferences {
 			}
 		}
 		prefs.setFilesAssociations(new ArrayList<>(associations));
-		
+
 		String searchScope = getString(configuration, JAVA_SEARCH_SCOPE, null);
 		prefs.setSearchScope(SearchScope.fromString(searchScope, SearchScope.all));
-		
+
 		return prefs;
 	}
 
@@ -2379,6 +2385,14 @@ public class Preferences {
 
 	public void setAndroidSupportEnabled(boolean androidSupportEnabled) {
 		this.androidSupportEnabled = androidSupportEnabled;
+	}
+
+	public boolean isJavacEnabled() {
+		return this.javacEnabled;
+	}
+
+	public void setJavacEnabled(boolean javacEnabled) {
+		this.javacEnabled = javacEnabled;
 	}
 
 	public List<String> getNonnullTypes() {

--- a/org.eclipse.jdt.ls.product/languageServer.product
+++ b/org.eclipse.jdt.ls.product/languageServer.product
@@ -49,6 +49,7 @@
       <plugin id="org.eclipse.equinox.security.win32" fragment="true"/>
       <plugin id="org.eclipse.jdt.apt.pluggable.core"/>
       <plugin id="org.eclipse.jdt.core"/>
+	  <plugin id="org.eclipse.jdt.core.javac"/>
       <plugin id="org.eclipse.jdt.launching"/>
       <plugin id="org.eclipse.jdt.launching.macosx"/>
       <plugin id="org.eclipse.jdt.ls.core"/>

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -33,8 +33,9 @@
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.jdt.core.compiler.batch" version="0.0.0"/>
             <unit id="org.eclipse.jdt.core" version="0.0.0"/>
+			<unit id="org.eclipse.jdt.core.javac" version="0.0.0"/>
             <unit id="org.eclipse.jdt.apt.core" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/jdtls/jdt-core-incubator/snapshots/"/>
+            <repository location="https://ci.eclipse.org/ls/job/jdt-core-incubator/job/dom-with-javac/lastSuccessfulBuild/artifact/repository/target/repository/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.xtext.xbase.lib" version="0.0.0"/>

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -28,7 +28,7 @@
 			<unit id="org.eclipse.pde.junit.runtime" version="0.0.0" />
 			<unit id="org.eclipse.jdt.junit4.runtime" version="0.0.0" />
 			<unit id="org.eclipse.jdt.core.manipulation" version="0.0.0" />
-            <repository location="https://download.eclipse.org/eclipse/updates/4.34-I-builds/I20240919-1840/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.34-I-builds/I20241014-1810/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.jdt.core.compiler.batch" version="0.0.0"/>

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -71,5 +71,5 @@
 		    </dependencies>
 	    </location>
     </locations>
-    <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+    <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-23"/>
 </target>

--- a/org.eclipse.jdt.ls.tests/.classpath
+++ b/org.eclipse.jdt.ls.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-22"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-23"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/">
 		<attributes>

--- a/org.eclipse.jdt.ls.tests/.classpath
+++ b/org.eclipse.jdt.ls.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-22"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/">
 		<attributes>

--- a/org.eclipse.jdt.ls.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.jdt.ls.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,14 +1,14 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=22
-org.eclipse.jdt.core.compiler.compliance=22
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=23
+org.eclipse.jdt.core.compiler.compliance=23
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.discouragedReference=ignore
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=22
+org.eclipse.jdt.core.compiler.source=23
 org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines=2147483647
 org.eclipse.jdt.core.formatter.align_type_members_on_columns=false
 org.eclipse.jdt.core.formatter.alignment_for_additive_operator=16

--- a/org.eclipse.jdt.ls.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.jdt.ls.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,14 +1,14 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
-org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=22
+org.eclipse.jdt.core.compiler.compliance=22
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.discouragedReference=ignore
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=17
+org.eclipse.jdt.core.compiler.source=22
 org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines=2147483647
 org.eclipse.jdt.core.formatter.align_type_members_on_columns=false
 org.eclipse.jdt.core.formatter.alignment_for_additive_operator=16

--- a/org.eclipse.jdt.ls.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.tests/META-INF/MANIFEST.MF
@@ -5,8 +5,10 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.jdt.ls.tests;singleton:=true
 Bundle-Version: 1.41.0.qualifier
 Export-Package: org.eclipse.jdt.ls.core.internal;x-friends:="org.eclipse.jdt.ls.tests.syntaxserver"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
-Import-Package: org.osgi.framework;version="1.3.0"
+Bundle-RequiredExecutionEnvironment: JavaSE-22
+Import-Package: org.osgi.framework;version="1.3.0",
+ org.eclipse.jdt.internal.javac,
+ org.eclipse.jdt.internal.javac.dom
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.jdt.ls.core,

--- a/org.eclipse.jdt.ls.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.jdt.ls.tests;singleton:=true
 Bundle-Version: 1.41.0.qualifier
 Export-Package: org.eclipse.jdt.ls.core.internal;x-friends:="org.eclipse.jdt.ls.tests.syntaxserver"
-Bundle-RequiredExecutionEnvironment: JavaSE-22
+Bundle-RequiredExecutionEnvironment: JavaSE-23
 Import-Package: org.osgi.framework;version="1.3.0",
  org.eclipse.jdt.internal.javac,
  org.eclipse.jdt.internal.javac.dom

--- a/org.eclipse.jdt.ls.tests/pom.xml
+++ b/org.eclipse.jdt.ls.tests/pom.xml
@@ -41,7 +41,7 @@
 				</property>
 			</activation>
 			<properties>
-				<lombokArgs>-javaagent:${basedir}/lib/lombok-1.18.28.jar</lombokArgs>
+				<lombokArgs>-javaagent:${basedir}/lib/lombok-1.18.32.jar</lombokArgs>
 			</properties>
 			<build>
 				<plugins>
@@ -53,7 +53,7 @@
 								<artifactItem>
 									<groupId>org.projectlombok</groupId>
 									<artifactId>lombok</artifactId>
-									<version>1.18.28</version>
+									<version>1.18.32</version>
 								</artifactItem>
 							</artifactItems>
 						</configuration>

--- a/org.eclipse.jdt.ls.tests/pom.xml
+++ b/org.eclipse.jdt.ls.tests/pom.xml
@@ -17,6 +17,34 @@
 			<plugins>
 				<plugin>
 					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-compiler-plugin</artifactId>
+					<configuration>
+						<deriveReleaseCompilerArgumentFromTargetLevel>false</deriveReleaseCompilerArgumentFromTargetLevel>
+						<compilerId>javac</compilerId>
+						<compilerArgs combine.self="override">
+							<arg>--add-exports</arg>
+							<arg>java.base/java.lang=ALL-UNNAMED</arg>
+							<arg>--add-exports</arg>
+							<arg>jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+							<arg>--add-exports</arg>
+							<arg>jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+							<arg>--add-exports</arg>
+							<arg>jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+							<arg>--add-exports</arg>
+							<arg>jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+							<arg>--add-exports</arg>
+							<arg>jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+							<arg>--add-exports</arg>
+							<arg>jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+							<arg>--add-exports</arg>
+							<arg>jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+							<arg>--add-exports</arg>
+							<arg>jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+						</compilerArgs>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
 					<artifactId>tycho-surefire-plugin</artifactId>
 					<version>${tycho-version}</version>
 					<configuration>
@@ -64,7 +92,7 @@
 						<configuration>
 							<toolchains>
 								<jdk>
-									<id>JavaSE-22</id>
+									<id>JavaSE-23</id>
 								</jdk>
 							</toolchains>
 						</configuration>

--- a/org.eclipse.jdt.ls.tests/pom.xml
+++ b/org.eclipse.jdt.ls.tests/pom.xml
@@ -58,6 +58,17 @@
 							</artifactItems>
 						</configuration>
 					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-toolchains-plugin</artifactId>
+						<configuration>
+							<toolchains>
+								<jdk>
+									<id>JavaSE-22</id>
+								</jdk>
+							</toolchains>
+						</configuration>
+					</plugin>
 				</plugins>
 			</build>
 		</profile>

--- a/org.eclipse.jdt.ls.tests/projects/maven/mavenlombok/pom.xml
+++ b/org.eclipse.jdt.ls.tests/projects/maven/mavenlombok/pom.xml
@@ -12,7 +12,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.28</version>
+            <version>1.18.32</version>
         </dependency>
     </dependencies>
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/RenameHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/RenameHandlerTest.java
@@ -616,8 +616,7 @@ public class RenameHandlerTest extends AbstractProjectsManagerBasedTest {
 	// https://github.com/redhat-developer/vscode-java/issues/2805
 	@Test
 	public void testRenameMethodLombok() throws Exception {
-		boolean lombokDisabled = "true".equals(System.getProperty("jdt.ls.lombok.disabled"));
-		if (lombokDisabled) {
+		if (Boolean.getBoolean("jdt.ls.lombok.disabled")) {
 			return;
 		}
 		when(preferenceManager.getPreferences().isImportMavenEnabled()).thenReturn(true);

--- a/pom.xml
+++ b/pom.xml
@@ -349,7 +349,7 @@
 		<profile>
 			<id>javac</id>
 			<properties>
-				<tycho.testArgLine>--add-opens jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED -DICompilationUnitResolver=org.eclipse.jdt.core.dom.JavacCompilationUnitResolver -DCompilationUnit.DOM_BASED_OPERATIONS=true -DAbstractImageBuilder.compiler=org.eclipse.jdt.internal.javac.JavacCompiler</tycho.testArgLine>
+				<tycho.testArgLine>--add-opens jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED -DICompilationUnitResolver=org.eclipse.jdt.core.dom.JavacCompilationUnitResolver -DCompilationUnit.DOM_BASED_OPERATIONS=true -DAbstractImageBuilder.compiler=org.eclipse.jdt.internal.javac.JavacCompiler --add-opens jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.taglets.snippet=ALL-UNNAMED --add-opens jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.taglets=ALL-UNNAMED</tycho.testArgLine>
 			</properties>
 		</profile>
 	</profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,8 @@
 		<!-- skip for local builds, set it to true on Eclipse.org infrastructure -->
 		<cbi.jarsigner.skip>true</cbi.jarsigner.skip>
 		<generateSourceRef>true</generateSourceRef>
+		<cbi-jdt-repo.url>https://repo.eclipse.org/content/repositories/eclipse-staging/</cbi-jdt-repo.url>
+		<cbi-ecj-version>3.38.0.v20240524-2033</cbi-ecj-version>
 	</properties>
 	<modules>
 		<module>org.eclipse.jdt.ls.target</module>
@@ -187,6 +189,35 @@
 						</dependency-resolution>
 					</configuration>
 				</plugin>
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-compiler-plugin</artifactId>
+					<version>${tycho-version}</version>
+					<dependencies>
+						<dependency>
+							<groupId>org.eclipse.jdt</groupId>
+							<artifactId>ecj</artifactId>
+							<version>${cbi-ecj-version}</version>
+						</dependency>
+					</dependencies>
+					<configuration>
+						<compilerArgs>
+							<args>-verbose</args>
+							<args>-inlineJSR</args>
+							<args>-enableJavadoc</args>
+							<args>-encoding</args>
+							<args>${project.build.sourceEncoding}</args>
+							<args>-proceedOnError</args>
+						</compilerArgs>
+						<log>xml</log>
+						<logDirectory>${compileLogDir}</logDirectory>
+						<showWarnings>true</showWarnings>
+						<excludeResources>
+							<exclude>**/package.html</exclude>
+						</excludeResources>
+						<useProjectSettings>true</useProjectSettings>
+					</configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>
@@ -315,11 +346,27 @@
 				<generateSourceRef>false</generateSourceRef>
 			</properties>
 		</profile>
+		<profile>
+			<id>javac</id>
+			<properties>
+				<tycho.testArgLine>--add-opens jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED -DICompilationUnitResolver=org.eclipse.jdt.core.dom.JavacCompilationUnitResolver -DCompilationUnit.DOM_BASED_OPERATIONS=true -DAbstractImageBuilder.compiler=org.eclipse.jdt.internal.javac.JavacCompiler</tycho.testArgLine>
+			</properties>
+		</profile>
 	</profiles>
 	<pluginRepositories>
 		<pluginRepository>
 			<id>cbi-release</id>
 			<url>https://repo.eclipse.org/content/repositories/cbi-releases/</url>
+		</pluginRepository>
+		<pluginRepository>
+			<id>cbi-jdt</id>
+			<url>${cbi-jdt-repo.url}</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
 		</pluginRepository>
 	</pluginRepositories>
 	<distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 		<cbi.jarsigner.skip>true</cbi.jarsigner.skip>
 		<generateSourceRef>true</generateSourceRef>
 		<cbi-jdt-repo.url>https://repo.eclipse.org/content/repositories/eclipse-staging/</cbi-jdt-repo.url>
-		<cbi-ecj-version>3.38.0.v20240524-2033</cbi-ecj-version>
+		<cbi-ecj-version>3.39.0.v20240820-0604</cbi-ecj-version>
 	</properties>
 	<modules>
 		<module>org.eclipse.jdt.ls.target</module>


### PR DESCRIPTION
The idea is to run 

> mvn clean verify -Pjavac

But for some reason I run into:

> [ERROR] Failed to execute goal org.eclipse.tycho:tycho-compiler-plugin:4.0.8:validate-classpath (default-validate-classpath) on project org.eclipse.jdt.ls.tests: Execution default-validate-classpath of goal org.eclipse.tycho:tycho-compiler-plugin:4.0.8:validate-classpath failed: org.osgi.framework.BundleException: Bundle org.eclipse.jdt.ls.tests cannot be resolved:org.eclipse.jdt.ls.tests [293]
[ERROR]   Unresolved requirement: Require-Bundle: org.eclipse.jdt.core.javac

@akurtakov @mickaelistria what am I missing?
