### PR TITLE
fix(scripts): add windows checks for jdtls.py

### DIFF
--- a/org.eclipse.jdt.ls.product/scripts/jdtls.py
+++ b/org.eclipse.jdt.ls.product/scripts/jdtls.py
@@ -20,16 +20,20 @@ from pathlib import Path
 import tempfile
 
 def get_java_executable(known_args):
+	is_windows = platform.system() == 'Windows'
 	if known_args.java_executable is not None:
 		java_executable = known_args.java_executable
 	else:
 		java_executable = 'java'
 
 		if 'JAVA_HOME' in os.environ:
-			ext = '.exe' if platform.system()  == 'Windows' else ''
+			ext = '.exe' if is_windows else ''
 			java_exec_to_test = Path(os.environ['JAVA_HOME']) / 'bin' / f'java{ext}'
 			if java_exec_to_test.is_file():
 				java_executable = java_exec_to_test.resolve()
+
+	if is_windows:
+		java_executable = str(java_executable)
 
 	if not known_args.validate_java_version:
 		return java_executable
@@ -103,7 +107,7 @@ def main(args):
 			"--add-opens", "java.base/java.util=ALL-UNNAMED",
 			"--add-opens", "java.base/java.lang=ALL-UNNAMED"] \
 			+ known_args.jvm_arg \
-			+ ["-jar", jar_path,
+			+ ["-jar", str(jar_path),
 			"-data", known_args.data] \
 			+ args
 


### PR DESCRIPTION
This pull request addresses some python errors that occur when trying to run the jdtls.bat file on a Windows machine.

I've tried running on my machine (Windows 10 Version 22H2, Python 3.7.3) after building from source (clone the github repo and run `mvn clean verify`) and was met with the following errors (replaced my system-specific path fragment with %USERPROFILE%):
```sh
Traceback (most recent call last):
  File "%USERPROFILE%\eclipse.jdt.ls\org.eclipse.jdt.ls.product\target\repository\bin\/jdtls", line 17, in <module>
    jdtls.main(sys.argv[1:])
  File "%USERPROFILE%\eclipse.jdt.ls\org.eclipse.jdt.ls.product\target\repository\bin\jdtls.py", line 91, in main
    java_executable = get_java_executable(known_args)
  File "%USERPROFILE%\eclipse.jdt.ls\org.eclipse.jdt.ls.product\target\repository\bin\jdtls.py", line 41, in get_java_executable
    out = subprocess.check_output([java_executable, '-version'], stderr = subprocess.STDOUT, universal_newlines=True)
  File "%USERPROFILE%\AppData\Local\Programs\Python\Python37-32\lib\subprocess.py", line 395, in check_output
    **kwargs).stdout
  File "%USERPROFILE%\AppData\Local\Programs\Python\Python37-32\lib\subprocess.py", line 472, in run
    with Popen(*popenargs, **kwargs) as process:
  File "%USERPROFILE%\AppData\Local\Programs\Python\Python37-32\lib\subprocess.py", line 775, in __init__
    restore_signals, start_new_session)
  File "%USERPROFILE%\AppData\Local\Programs\Python\Python37-32\lib\subprocess.py", line 1119, in _execute_child
    args = list2cmdline(args)
  File "%USERPROFILE%\AppData\Local\Programs\Python\Python37-32\lib\subprocess.py", line 530, in list2cmdline
    needquote = (" " in arg) or ("\t" in arg) or not arg
TypeError: argument of type 'WindowsPath' is not iterable
```
Replacing the `java_executable` variable with `str(java_executable)` in the `get_java_executable()` function in the case of a Windows execution gives me the following error:

```sh
File "%USERPROFILE%\eclipse.jdt.ls\org.eclipse.jdt.ls.product\target\repository\bin\/jdtls", line 17, in <module>
    jdtls.main(sys.argv[1:])
  File "%USERPROFILE%\eclipse.jdt.ls\org.eclipse.jdt.ls.product\target\repository\bin\jdtls.py", line 117, in main
    subprocess.run([java_executable] + exec_args)
  File "%USERPROFILE%\AppData\Local\Programs\Python\Python37-32\lib\subprocess.py", line 472, in run
    with Popen(*popenargs, **kwargs) as process:
  File "%USERPROFILE%\AppData\Local\Programs\Python\Python37-32\lib\subprocess.py", line 775, in __init__
    restore_signals, start_new_session)
  File "%USERPROFILE%\AppData\Local\Programs\Python\Python37-32\lib\subprocess.py", line 1119, in _execute_child
    args = list2cmdline(args)
  File "%USERPROFILE%\AppData\Local\Programs\Python\Python37-32\lib\subprocess.py", line 530, in list2cmdline
    needquote = (" " in arg) or ("\t" in arg) or not arg
TypeError: argument of type 'WindowsPath' is not iterable
```

Surrounding `jvm_path` with a call to `str()`  in the definition of `exec_args` then allows me to launch the language server.