### PR TITLE
Expand "workspace/willRenameFiles" support to include folders.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -220,9 +220,14 @@ final public class InitHandler extends BaseInitHandler {
 
 		if (preferenceManager.getClientPreferences().isWorkspaceWillRenameFilesSupported()) {
 			FileOperationsServerCapabilities wsFileOperations = new FileOperationsServerCapabilities();
-			FileOperationPattern fileOpPattern = new FileOperationPattern("**/*.java");
-			fileOpPattern.setMatches(FileOperationPatternKind.File);
-			wsFileOperations.setWillRename(new FileOperationOptions(List.of(new FileOperationFilter(fileOpPattern, "file"))));
+			FileOperationPattern fileOpPatternJava = new FileOperationPattern("**/*.java");
+			fileOpPatternJava.setMatches(FileOperationPatternKind.File);
+			FileOperationPattern fileOpPatternPackage = new FileOperationPattern("**");
+			fileOpPatternPackage.setMatches(FileOperationPatternKind.Folder);
+			wsFileOperations.setWillRename(new FileOperationOptions(List.of(
+				new FileOperationFilter(fileOpPatternJava, "file"),
+				new FileOperationFilter(fileOpPatternPackage, "file")
+			)));
 			wsCapabilities.setFileOperations(wsFileOperations);
 		}
 


### PR DESCRIPTION
- Fixes #3183 
- Allow folder renames to trigger workspace/willRenameFiles since the
      language server can update source files during such an operation

```diff
--- old.txt	2024-06-12 15:50:40.782112655 -0400
+++ new.txt	2024-06-12 15:53:20.175658497 -0400
@@ -8,6 +8,13 @@
                         "matches": "file"
                     },
                     "scheme": "file"
+                },
+                {
+                    "pattern": {
+                        "glob": "**",
+                        "matches": "folder"
+                    },
+                    "scheme": "file"
                 }
             ]
         }

```