### PR TITLE
Add 'final' to 'Extract to local variable' result if requested

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/RefactorProposalUtility.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/RefactorProposalUtility.java
@@ -367,6 +367,8 @@ public class RefactorProposalUtility {
 		} else {
 			relevance = IProposalRelevance.EXTRACT_LOCAL_ALL;
 		}
+		String declsToFinal = JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getCodeGenerationAddFinalForNewDeclaration();
+		boolean setFinal = "all".equals(declsToFinal) || "variables".equals(declsToFinal);
 		if (inferSelectionSupport && context.getSelectionLength() == 0) {
 			ASTNode parent = context.getCoveringNode();
 			while (parent != null && parent instanceof Expression) {
@@ -375,6 +377,7 @@ public class RefactorProposalUtility {
 					continue;
 				}
 				ExtractTempRefactoring refactoring = new ExtractTempRefactoring(context.getASTRoot(), parent.getStartPosition(), parent.getLength());
+				refactoring.setDeclareFinal(setFinal);
 				if (refactoring.checkInitialConditions(new NullProgressMonitor()).isOK()) {
 					CUCorrectionCommandProposal proposal = new CUCorrectionCommandProposal(label, cu, relevance, APPLY_REFACTORING_COMMAND_ID, Arrays.asList(EXTRACT_VARIABLE_ALL_OCCURRENCE_COMMAND, params));
 					return CodeActionHandler.wrap(proposal, JavaCodeActionKind.REFACTOR_EXTRACT_VARIABLE);
@@ -384,6 +387,7 @@ public class RefactorProposalUtility {
 			return null;
 		}
 		ExtractTempRefactoring extractTempRefactoring = new ExtractTempRefactoring(context.getASTRoot(), context.getSelectionOffset(), context.getSelectionLength(), formatterOptions);
+		extractTempRefactoring.setDeclareFinal(setFinal);
 		if (extractTempRefactoring.checkInitialConditions(new NullProgressMonitor()).isOK()) {
 			if (returnAsCommand) {
 				CUCorrectionCommandProposal proposal = new CUCorrectionCommandProposal(label, cu, relevance, APPLY_REFACTORING_COMMAND_ID, Arrays.asList(EXTRACT_VARIABLE_ALL_OCCURRENCE_COMMAND, params));
@@ -424,6 +428,8 @@ public class RefactorProposalUtility {
 		} else {
 			relevance = IProposalRelevance.EXTRACT_LOCAL;
 		}
+		String declsToFinal = JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getCodeGenerationAddFinalForNewDeclaration();
+		boolean setFinal = "all".equals(declsToFinal) || "variables".equals(declsToFinal);
 		if (inferSelectionSupport && context.getSelectionLength() == 0) {
 			ASTNode parent = context.getCoveringNode();
 			while (parent != null && parent instanceof Expression) {
@@ -432,6 +438,7 @@ public class RefactorProposalUtility {
 					continue;
 				}
 				ExtractTempRefactoring refactoring = new ExtractTempRefactoring(context.getASTRoot(), parent.getStartPosition(), parent.getLength());
+				refactoring.setDeclareFinal(setFinal);
 				if (refactoring.checkInitialConditions(new NullProgressMonitor()).isOK()) {
 					CUCorrectionCommandProposal proposal = new CUCorrectionCommandProposal(label, cu, relevance, APPLY_REFACTORING_COMMAND_ID, Arrays.asList(EXTRACT_VARIABLE_COMMAND, params));
 					return CodeActionHandler.wrap(proposal, JavaCodeActionKind.REFACTOR_EXTRACT_VARIABLE);
@@ -442,6 +449,7 @@ public class RefactorProposalUtility {
 		}
 		ExtractTempRefactoring extractTempRefactoringSelectedOnly = new ExtractTempRefactoring(context.getASTRoot(), context.getSelectionOffset(), context.getSelectionLength(), formatterOptions);
 		extractTempRefactoringSelectedOnly.setReplaceAllOccurrences(false);
+		extractTempRefactoringSelectedOnly.setDeclareFinal(setFinal);
 		if (extractTempRefactoringSelectedOnly.checkInitialConditions(new NullProgressMonitor()).isOK()) {
 			if (returnAsCommand) {
 				CUCorrectionCommandProposal proposal = new CUCorrectionCommandProposal(label, cu, relevance, APPLY_REFACTORING_COMMAND_ID, Arrays.asList(EXTRACT_VARIABLE_COMMAND, params));

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/GetRefactorEditHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/GetRefactorEditHandlerTest.java
@@ -89,6 +89,45 @@ public class GetRefactorEditHandlerTest extends AbstractSelectionTest {
 	}
 
 	@Test
+	public void testExtractVariableFinal() throws Exception {
+		preferences.setCodeGenerationAddFinalForNewDeclaration("all");
+
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("class A{\n");
+		buf.append("	void m(int i){\n");
+		buf.append("		int x= /*]*/0/*[*/;\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+		Range selection = getRange(cu, null);
+		CodeActionParams params = CodeActionUtil.constructCodeActionParams(cu, selection);
+		GetRefactorEditParams editParams = new GetRefactorEditParams(RefactorProposalUtility.EXTRACT_VARIABLE_COMMAND, params);
+		RefactorWorkspaceEdit refactorEdit = GetRefactorEditHandler.getEditsForRefactor(editParams);
+		Assert.assertNotNull(refactorEdit);
+		Assert.assertNotNull(refactorEdit.edit);
+		String actual = AbstractQuickFixTest.evaluateWorkspaceEdit(refactorEdit.edit);
+
+		buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("class A{\n");
+		buf.append("	void m(int i){\n");
+		buf.append("		final int j = 0;\n");
+		buf.append("        int x= /*]*/j/*[*/;\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		AbstractSourceTestCase.compareSource(buf.toString(), actual);
+
+		Assert.assertNotNull(refactorEdit.command);
+		Assert.assertEquals(GetRefactorEditHandler.RENAME_COMMAND, refactorEdit.command.getCommand());
+		Assert.assertNotNull(refactorEdit.command.getArguments());
+		Assert.assertEquals(1, refactorEdit.command.getArguments().size());
+	}
+
+	@Test
 	public void testExtractVariableAllOccurrence() throws Exception {
 		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
 
@@ -114,6 +153,45 @@ public class GetRefactorEditHandlerTest extends AbstractSelectionTest {
 		buf.append("class A{\n");
 		buf.append("	void m(int i){\n");
 		buf.append("		int j = 0;\n");
+		buf.append("        int x= /*]*/j/*[*/;\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		AbstractSourceTestCase.compareSource(buf.toString(), actual);
+
+		Assert.assertNotNull(refactorEdit.command);
+		Assert.assertEquals(GetRefactorEditHandler.RENAME_COMMAND, refactorEdit.command.getCommand());
+		Assert.assertNotNull(refactorEdit.command.getArguments());
+		Assert.assertEquals(1, refactorEdit.command.getArguments().size());
+	}
+
+	@Test
+	public void testExtractVariableAllOccurrenceFinal() throws Exception {
+		preferences.setCodeGenerationAddFinalForNewDeclaration("all");
+
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("class A{\n");
+		buf.append("	void m(int i){\n");
+		buf.append("		int x= /*]*/0/*[*/;\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+		Range selection = getRange(cu, null);
+		CodeActionParams params = CodeActionUtil.constructCodeActionParams(cu, selection);
+		GetRefactorEditParams editParams = new GetRefactorEditParams(RefactorProposalUtility.EXTRACT_VARIABLE_ALL_OCCURRENCE_COMMAND, params);
+		RefactorWorkspaceEdit refactorEdit = GetRefactorEditHandler.getEditsForRefactor(editParams);
+		Assert.assertNotNull(refactorEdit);
+		Assert.assertNotNull(refactorEdit.edit);
+		String actual = AbstractQuickFixTest.evaluateWorkspaceEdit(refactorEdit.edit);
+
+		buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("class A{\n");
+		buf.append("	void m(int i){\n");
+		buf.append("		final int j = 0;\n");
 		buf.append("        int x= /*]*/j/*[*/;\n");
 		buf.append("	}\n");
 		buf.append("}\n");


### PR DESCRIPTION
Applies when the  `java.codeGeneration.addFinalForNewDeclaration` setting is set to `all` or `variables`. Also applicable for the 'replace all occurrences' extract proposal.

Closes https://github.com/redhat-developer/vscode-java/issues/3308

![extract-to-final-local-var](https://github.com/eclipse-jdtls/eclipse.jdt.ls/assets/115827695/6fca969b-0aa6-4171-853e-6ce427be1fbc)
