### PR TITLE
Add Gradle 8.8 to compatibility check

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleUtils.java
@@ -78,7 +78,9 @@ public class GradleUtils {
 		GradleVersion baseVersion = gradleVersion.getBaseVersion();
 		try {
 			// https://docs.gradle.org/current/userguide/compatibility.html
-			if (baseVersion.compareTo(GradleVersion.version("8.5")) >= 0) {
+			if (baseVersion.compareTo(GradleVersion.version("8.8")) >= 0) {
+				return JavaCore.VERSION_22;
+			} else if (baseVersion.compareTo(GradleVersion.version("8.5")) >= 0) {
 				return JavaCore.VERSION_21;
 			} else if (baseVersion.compareTo(GradleVersion.version("8.3")) >= 0) {
 				return JavaCore.VERSION_20;


### PR DESCRIPTION
Fixes imports with Java 22 and Gradle 8.8, analogous to #3044.