### PR TITLE
Fix package declaration in test file

### DIFF
--- a/org.eclipse.jdt.ls.tests/projects/eclipse/java16/src/main/java/foo/bar/Bar.java
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/java16/src/main/java/foo/bar/Bar.java
@@ -1,3 +1,5 @@
+package foo.bar;
+
 public class Bar {
 	record Edge(int fromNodeId,
 		int toNodeId,

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandlerTest.java
@@ -674,7 +674,7 @@ public class SignatureHelpHandlerTest extends AbstractCompilationUnitBasedTest {
 		IProject proj = WorkspaceHelper.getProject("java16");
 		IJavaProject javaProject = JavaCore.create(proj);
 		ICompilationUnit unit = (ICompilationUnit) javaProject.findElement(new Path("foo/bar/Bar.java"));
-		SignatureHelp help = getSignatureHelp(unit, 9, 10);
+		SignatureHelp help = getSignatureHelp(unit, 11, 10);
 		assertNotNull(help);
 		SignatureInformation signature = help.getSignatures().get(help.getActiveSignature());
 		assertTrue(signature.getLabel().equals("Edge(int fromNodeId, int toNodeId, Object fromPoint, Object toPoint, double length, Object profile)"));


### PR DESCRIPTION
This allows Javac-based JDT to go further and test the actual expected behavior without being interrupted because of missing package declaration.