### PR TITLE
Revert "Set o.e.j.c.compiler.problem.nullUncheckedConversion to ignore by default"

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -2546,7 +2546,6 @@ public class Preferences {
 			options.put(JavaCore.COMPILER_PB_NULL_SPECIFICATION_VIOLATION, defaultOptions.get(JavaCore.COMPILER_PB_NULL_SPECIFICATION_VIOLATION));
 			options.put(JavaCore.COMPILER_PB_NULL_ANNOTATION_INFERENCE_CONFLICT, defaultOptions.get(JavaCore.COMPILER_PB_NULL_ANNOTATION_INFERENCE_CONFLICT));
 			options.put(JavaCore.COMPILER_PB_SYNTACTIC_NULL_ANALYSIS_FOR_FIELDS, defaultOptions.get(JavaCore.COMPILER_PB_SYNTACTIC_NULL_ANALYSIS_FOR_FIELDS));
-			options.put(JavaCore.COMPILER_PB_NULL_UNCHECKED_CONVERSION, defaultOptions.get(JavaCore.COMPILER_PB_NULL_UNCHECKED_CONVERSION));
 		} else {
 			options.put(JavaCore.COMPILER_ANNOTATION_NULL_ANALYSIS, "enabled");
 			options.put(JavaCore.COMPILER_NONNULL_ANNOTATION_NAME, nonnullType != null ? nonnullType : "");
@@ -2558,7 +2557,6 @@ public class Preferences {
 			options.put(JavaCore.COMPILER_PB_NULL_ANNOTATION_INFERENCE_CONFLICT, "warning");
 			options.put(JavaCore.COMPILER_PB_MISSING_NONNULL_BY_DEFAULT_ANNOTATION, "ignore");
 			options.put(JavaCore.COMPILER_PB_SYNTACTIC_NULL_ANALYSIS_FOR_FIELDS, JavaCore.ENABLED);
-			options.put(JavaCore.COMPILER_PB_NULL_UNCHECKED_CONVERSION, JavaCore.IGNORE);
 		}
 		return options;
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/NullAnalysisTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/NullAnalysisTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.util.Collections;
-import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 
@@ -108,21 +107,12 @@ public class NullAnalysisTest extends AbstractGradleBasedTest {
 			assertTrue(marker.getResource() instanceof IFile);
 			assertEquals("TestJDT.java", ((IFile) marker1.getResource()).getFullPath().lastSegment());
 			IMarker marker2 = getWarningMarker(project, "The return type is incompatible with '@Nonnull String' returned from TestJavax.A.nonnullMethod() (mismatching null constraints)");
-			assertNotNull(marker2);
-			assertTrue(marker2.getResource() instanceof IFile);
+			assertNotNull(marker);
+			assertTrue(marker.getResource() instanceof IFile);
 			assertEquals("TestJavax.java", ((IFile) marker2.getResource()).getFullPath().lastSegment());
 			IMarker marker3 = getWarningMarker(project, "Null type safety: The expression of type 'List<String>' needs unchecked conversion to conform to '@Nonnull List<String>'");
-			assertNull(marker3);
-			IJavaProject javaProject = JavaCore.create(project);
-			Map<String, String> options = javaProject.getOptions(true);
-			assertEquals(JavaCore.IGNORE, options.get(JavaCore.COMPILER_PB_NULL_UNCHECKED_CONVERSION));
-			Hashtable<String, String> defaultOptions = JavaCore.getDefaultOptions();
-			options.put(JavaCore.COMPILER_PB_NULL_UNCHECKED_CONVERSION, defaultOptions.get(JavaCore.COMPILER_PB_NULL_UNCHECKED_CONVERSION));
-			javaProject.setOptions(options);
-			waitForBackgroundJobs();
-			marker3 = getWarningMarker(project, "Null type safety: The expression of type 'List<String>' needs unchecked conversion to conform to '@Nonnull List<String>'");
-			assertNotNull(marker3);
-			assertTrue(marker3.getResource() instanceof IFile);
+			assertNotNull(marker);
+			assertTrue(marker.getResource() instanceof IFile);
 			assertEquals("TestJavax.java", ((IFile) marker3.getResource()).getFullPath().lastSegment());
 			assertNoErrors(project);
 		} finally {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManagerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManagerTest.java
@@ -379,5 +379,4 @@ public class PreferenceManagerTest {
 			assertEquals(false, preferenceManager.getPreferences().isTelemetryEnabled());
 		}
 	}
-
 }


### PR DESCRIPTION
Hello! This pull request reverts commit 6d8eb7a3677d014fdcf3c4761706832a24f9e68c.

I don't fully understand the problem/solution in this area. What I know:

- You want to avoid a warning as @snjeza explains [here](https://github.com/redhat-developer/vscode-java/issues/3501#issuecomment-2231517166)

- But jdtls forcing this is overwriting Eclipse settings that are saved to the repo, as shown [here](https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/2655#issuecomment-2231376235)

I'm hoping to either get a better explanation of why it's okay to overwrite this setting, or if perhaps there is a better solution to the earlier problem. Thank you for your patience!