### PR TITLE
Update target platform to newer 4.33-I-builds (I20240728-1800).

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -25,7 +25,7 @@
             <unit id="org.mockito.mockito-core" version="0.0.0"/>
             <unit id="org.apache.commons.commons-io" version="0.0.0"/>
             <unit id="org.eclipse.jdt.apt.pluggable.core" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.33-I-builds/I20240716-1800/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.33-I-builds/I20240728-1800/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.jdt.core.compiler.batch" version="0.0.0"/>

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/eclipsemaven/pom.xml
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/eclipsemaven/pom.xml
@@ -10,8 +10,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.5.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/org.eclipse.jdt.ls.tests/projects/gradle/nested/gradle1/build.gradle
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/nested/gradle1/build.gradle
@@ -10,7 +10,7 @@
 // Apply the java plugin to add support for Java
 apply plugin: 'java'
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 
 // In this section you declare where to find the dependencies of your project
 repositories {

--- a/org.eclipse.jdt.ls.tests/projects/gradle/nested/gradle2/build.gradle
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/nested/gradle2/build.gradle
@@ -10,7 +10,7 @@
 // Apply the java plugin to add support for Java
 apply plugin: 'java'
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 
 // In this section you declare where to find the dependencies of your project
 repositories {

--- a/org.eclipse.jdt.ls.tests/projects/gradle/simple-gradle/build.gradle
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/simple-gradle/build.gradle
@@ -11,7 +11,7 @@
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 
 // In this section you declare where to find the dependencies of your project
 repositories {

--- a/org.eclipse.jdt.ls.tests/projects/maven/buildhelped/pom.xml
+++ b/org.eclipse.jdt.ls.tests/projects/maven/buildhelped/pom.xml
@@ -10,8 +10,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.5.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/org.eclipse.jdt.ls.tests/projects/maven/salut/pom.xml
+++ b/org.eclipse.jdt.ls.tests/projects/maven/salut/pom.xml
@@ -10,8 +10,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.5.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/org.eclipse.jdt.ls.tests/projects/maven/salut2/pom.xml
+++ b/org.eclipse.jdt.ls.tests/projects/maven/salut2/pom.xml
@@ -10,8 +10,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.5.1</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>11</source>
+					<target>11</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/org.eclipse.jdt.ls.tests/projects/mixed/simple-gradle/build.gradle
+++ b/org.eclipse.jdt.ls.tests/projects/mixed/simple-gradle/build.gradle
@@ -11,7 +11,7 @@
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 
 // In this section you declare where to find the dependencies of your project
 repositories {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
@@ -81,8 +81,8 @@ public class ProjectCommandTest extends AbstractInvisibleProjectBasedTest {
 		Map<String, Object> options = ProjectCommand.getProjectSettings(uriString, settingKeys);
 
 		assertEquals(settingKeys.size(), options.size());
-		assertEquals("1.7", options.get("org.eclipse.jdt.core.compiler.compliance"));
-		assertEquals("1.7", options.get("org.eclipse.jdt.core.compiler.source"));
+		assertEquals("1.8", options.get("org.eclipse.jdt.core.compiler.compliance"));
+		assertEquals("1.8", options.get("org.eclipse.jdt.core.compiler.source"));
 	}
 
 	@Test
@@ -94,8 +94,8 @@ public class ProjectCommandTest extends AbstractInvisibleProjectBasedTest {
 		Map<String, Object> options = ProjectCommand.getProjectSettings(uriString, settingKeys);
 
 		assertEquals(settingKeys.size(), options.size());
-		assertEquals("1.8", options.get("org.eclipse.jdt.core.compiler.compliance"));
-		assertEquals("1.8", options.get("org.eclipse.jdt.core.compiler.source"));
+		assertEquals("11", options.get("org.eclipse.jdt.core.compiler.compliance"));
+		assertEquals("11", options.get("org.eclipse.jdt.core.compiler.source"));
 	}
 
 	@Test

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/JavadocQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/JavadocQuickFixTest.java
@@ -989,53 +989,6 @@ public class JavadocQuickFixTest extends AbstractQuickFixTest {
 
 	@Test
 	public void testInvalidQualification1() throws Exception {
-		Map<String, String> original = fJProject1.getOptions(false);
-		HashMap<String, String> newOptions = new HashMap<>(original);
-		JavaCore.setComplianceOptions(JavaCore.VERSION_1_4, newOptions);
-		fJProject1.setOptions(newOptions);
-
-		IPackageFragment pack1 = fSourceFolder.createPackageFragment("pack", false, null);
-		StringBuilder buf = new StringBuilder();
-		buf.append("package pack;\n");
-		buf.append("\n");
-		buf.append("public class A {\n");
-		buf.append("    public static class B {\n");
-		buf.append("        public static class C {\n");
-		buf.append("            \n");
-		buf.append("        }\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		pack1.createCompilationUnit("A.java", buf.toString(), false, null);
-
-		IPackageFragment pack2 = fSourceFolder.createPackageFragment("pack2", false, null);
-		buf = new StringBuilder();
-		buf.append("package pack2;\n");
-		buf.append("\n");
-		buf.append("import pack.A.B.C;\n");
-		buf.append("\n");
-		buf.append("/**\n");
-		buf.append(" * {@link C} \n");
-		buf.append(" */\n");
-		buf.append("public class E {\n");
-		buf.append("}\n");
-		ICompilationUnit cu = pack2.createCompilationUnit("E.java", buf.toString(), false, null);
-
-		buf = new StringBuilder();
-		buf.append("package pack2;\n");
-		buf.append("\n");
-		buf.append("import pack.A.B.C;\n");
-		buf.append("\n");
-		buf.append("/**\n");
-		buf.append(" * {@link pack.A.B.C} \n");
-		buf.append(" */\n");
-		buf.append("public class E {\n");
-		buf.append("}\n");
-		Expected e1 = new Expected("Qualify inner type name", buf.toString());
-		assertCodeActions(cu, e1);
-	}
-
-	@Test
-	public void testInvalidQualification2() throws Exception {
 		IPackageFragment pack1 = fSourceFolder.createPackageFragment("pack", false, null);
 		StringBuilder buf = new StringBuilder();
 		buf.append("package pack;\n");
@@ -1074,7 +1027,7 @@ public class JavadocQuickFixTest extends AbstractQuickFixTest {
 	}
 
 	@Test
-	public void testInvalidQualification3() throws Exception {
+	public void testInvalidQualification2() throws Exception {
 		IPackageFragment pack1 = fSourceFolder.createPackageFragment("pack", false, null);
 		StringBuilder buf = new StringBuilder();
 		buf.append("package pack;\n");

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/StringConcatenationQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/StringConcatenationQuickFixTest.java
@@ -137,7 +137,7 @@ public class StringConcatenationQuickFixTest extends AbstractQuickFixTest {
 	@Test
 	public void testConvertToStringBuffer() throws Exception {
 		Map<String, String> options1_4 = new HashMap<>(fJProject.getOptions(false));
-		JavaModelUtil.setComplianceOptions(options1_4, JavaCore.VERSION_1_4);
+		JavaModelUtil.setComplianceOptions(options1_4, JavaCore.VERSION_1_8);
 		fJProject.setOptions(options1_4);
 
 		try {
@@ -157,17 +157,17 @@ public class StringConcatenationQuickFixTest extends AbstractQuickFixTest {
 					package test;
 					public class Test {
 						private void print(String name, int age) {
-						  StringBuffer stringBuffer = new StringBuffer();
-							stringBuffer.append("User name: ");
-							stringBuffer.append(name);
-							stringBuffer.append(", age: ");
-							stringBuffer.append(age);
-						String value = stringBuffer.toString();
+						  StringBuilder stringBuilder = new StringBuilder();
+							stringBuilder.append("User name: ");
+							stringBuilder.append(name);
+							stringBuilder.append(", age: ");
+							stringBuilder.append(age);
+						String value = stringBuilder.toString();
 						}
 					}
 					""";
 
-			Expected e = new Expected(MessageFormat.format(CorrectionMessages.QuickAssistProcessor_convert_to_string_buffer_description, "StringBuffer"), expected);
+			Expected e = new Expected(MessageFormat.format(CorrectionMessages.QuickAssistProcessor_convert_to_string_buffer_description, "StringBuilder"), expected);
 			Range selection = CodeActionUtil.getRange(cu, "User name:");
 			assertCodeActions(cu, selection, e);
 		} finally {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/TypeMismatchQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/TypeMismatchQuickFixTest.java
@@ -26,7 +26,6 @@ import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
-import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -1067,43 +1066,6 @@ public class TypeMismatchQuickFixTest extends AbstractQuickFixTest {
 		buf.append("    }\n");
 		buf.append("}\n");
 		Expected e1 = new Expected("Change return type of 'getAnnotation(..)' to 'T'", buf.toString());
-
-		assertCodeActions(cu, e1);
-	}
-
-	@Test
-	public void testMismatchingReturnTypeOnGenericMethod14() throws Exception {
-		Map<String, String> options14 = new HashMap<>(fJProject1.getOptions(false));
-		JavaModelUtil.setComplianceOptions(options14, JavaCore.VERSION_1_4);
-		fJProject1.setOptions(options14);
-		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
-
-		StringBuilder buf = new StringBuilder();
-		buf.append("package test1;\n");
-		buf.append("import java.lang.reflect.AccessibleObject;\n");
-		buf.append("public class E {\n");
-		buf.append("    void m() {\n");
-		buf.append("        new AccessibleObject() {\n");
-		buf.append("            public void getAnnotation(Class annotationClass) {\n");
-		buf.append("            }\n");
-		buf.append("        };\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
-
-		buf = new StringBuilder();
-		buf.append("package test1;\n");
-		buf.append("import java.lang.annotation.Annotation;\n");
-		buf.append("import java.lang.reflect.AccessibleObject;\n");
-		buf.append("public class E {\n");
-		buf.append("    void m() {\n");
-		buf.append("        new AccessibleObject() {\n");
-		buf.append("            public Annotation getAnnotation(Class annotationClass) {\n");
-		buf.append("            }\n");
-		buf.append("        };\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		Expected e1 = new Expected("Change return type of 'getAnnotation(..)' to 'Annotation'", buf.toString());
 
 		assertCodeActions(cu, e1);
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -1713,22 +1713,22 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 
 	@Test
 	public void testCompletion_classMethodOverrideJava4() throws Exception {
-		testCompletion_classMethodOverride("java4", true, false);
+		testCompletion_classMethodOverride("java11", true, true);
 	}
 
 	@Test
 	public void testCompletion_interfaceMethodOverrideJava4() throws Exception {
-		testCompletion_interfaceMethodOverride("java4", true, false);
+		testCompletion_interfaceMethodOverride("java11", true, true);
 	}
 
 	@Test
 	public void testCompletion_classMethodOverrideJava5() throws Exception {
-		testCompletion_classMethodOverride("java5", true, true);
+		testCompletion_classMethodOverride("java11", true, true);
 	}
 
 	@Test
 	public void testCompletion_interfaceMethodOverrideJava5() throws Exception {
-		testCompletion_interfaceMethodOverride("java5", true, false);
+		testCompletion_interfaceMethodOverride("java11", true, true);
 	}
 
 	private void testCompletion_classMethodOverride(String projectName, boolean supportSnippets,

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandlerTest.java
@@ -411,7 +411,7 @@ public class WorkspaceDiagnosticsHandlerTest extends AbstractProjectsManagerBase
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject("salut");
 		IFile pom = project.getFile("/pom.xml");
 		assertTrue(pom.exists());
-		ResourceUtils.setContent(pom, ResourceUtils.getContent(pom).replaceAll("1.7", "1.8"));
+		ResourceUtils.setContent(pom, ResourceUtils.getContent(pom).replaceAll("1.8", "11"));
 
 		ResourcesPlugin.getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, monitor);
 		assertNoErrors(project);
@@ -427,11 +427,9 @@ public class WorkspaceDiagnosticsHandlerTest extends AbstractProjectsManagerBase
 		projectsManager.setConnection(client);
 		Optional<PublishDiagnosticsParams>projectDiags=allCalls.stream().filter(p->(p.getUri().endsWith("maven/salut"))||p.getUri().endsWith("maven/salut/")).findFirst();
 		assertTrue("No maven/salut errors were found", projectDiags.isPresent());
-		List<Diagnostic> diags = projectDiags.get().getDiagnostics();
-		assertEquals(diags.toString(), 2, diags.size());
 		Optional<PublishDiagnosticsParams> pomDiags = allCalls.stream().filter(p -> p.getUri().endsWith("pom.xml")).findFirst();
 		assertTrue("No pom.xml errors were found", pomDiags.isPresent());
-		diags = pomDiags.get().getDiagnostics();
+		List<Diagnostic> diags = pomDiags.get().getDiagnostics();
 		assertEquals(diags.toString(), 1, diags.size());
 		Diagnostic diag = diags.get(0);
 		assertTrue(diag.getMessage().equals(WorkspaceDiagnosticsHandler.PROJECT_CONFIGURATION_IS_NOT_UP_TO_DATE_WITH_POM_XML));

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractGradleBasedTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractGradleBasedTest.java
@@ -30,7 +30,7 @@ public abstract class AbstractGradleBasedTest extends AbstractProjectsManagerBas
 	protected IProject importSimpleJavaProject() throws Exception {
 		IProject project = importGradleProject("simple-gradle");
 		assertIsJavaProject(project);
-		assertEquals("1.7", getJavaSourceLevel(project));
+		assertEquals("1.8", getJavaSourceLevel(project));
 		return project;
 	}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractMavenBasedTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractMavenBasedTest.java
@@ -45,7 +45,7 @@ public abstract class AbstractMavenBasedTest extends AbstractProjectsManagerBase
 		String name = "salut";
 		IProject project = importMavenProject(name);
 		assertIsJavaProject(project);
-		assertEquals("1.7", getJavaSourceLevel(project));
+		assertEquals("1.8", getJavaSourceLevel(project));
 		assertNoErrors(project);
 		return project;
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupportTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupportTest.java
@@ -59,7 +59,7 @@ public class GradleBuildSupportTest extends AbstractGradleBasedTest {
 		projectsManager.updateProject(project, false);
 		waitForBackgroundJobs();
 		assertNoErrors(project);
-		assertEquals("1.7", ProjectUtils.getJavaSourceLevel(project));
+		assertEquals("1.8", ProjectUtils.getJavaSourceLevel(project));
 	}
 
 }


### PR DESCRIPTION
- Tests requiring a compiler compliance of Java 1.7 or below cannot be supported