### PR TITLE
Fix NPE when sending 'java/getRefactorEdit' request in nvim-jdtls client

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GetRefactorEditHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GetRefactorEditHandler.java
@@ -74,8 +74,12 @@ public class GetRefactorEditHandler {
 			return null;
 		}
 		context.setASTRoot(ast);
-		IProblemLocation[] locations = CodeActionHandler.getProblemLocationCores(unit, params.context.getContext().getDiagnostics());
-		boolean problemsAtLocation = locations.length != 0;
+		IProblemLocation[] locations = null;
+		boolean problemsAtLocation = false;
+		if (params.context.getContext() != null && params.context.getContext().getDiagnostics() != null) {
+			locations = CodeActionHandler.getProblemLocationCores(unit, params.context.getContext().getDiagnostics());
+			problemsAtLocation = locations.length != 0;
+		}
 		String positionKey = DEFAULT_POSITION_KEY;
 
 		try {


### PR DESCRIPTION
Error Log
```log
[DEBUG][2024-08-05 20:57:22] .../vim/lsp/rpc.lua:286	"rpc.send"	{ id = 11, jsonrpc = "2.0", method = "java/getRefactorEdit", params = { command = "extractVariable", commandArguments = { { length = 2, name = '""', offset = 248 } }, context = { range = { ["end"] = <1>{ character = 19, line = 16 }, start = <table 1> }, textDocument = { uri = "file:///home/luokai/workspace/JavaProjects/demo/src/main/java/com/example/demo/Demo.java" } }, options = { insertSpaces = true, tabSize = 4 } } }
[ERROR][2024-08-05 20:57:22] .../vim/lsp/rpc.lua:772	"rpc"	"/etc/java-config-2/current-system-vm/bin/java"	"stderr"	'Aug 05, 2024 8:57:22 PM org.eclipse.lsp4j.jsonrpc.RemoteEndpoint fallbackResponseError
SEVERE: Internal error: java.lang.NullPointerException: Cannot invoke "org.eclipse.lsp4j.CodeActionContext.getDiagnostics()" because the return value of "org.eclipse.lsp4j.CodeActionParams.getContext()" is null
java.util.concurrent.CompletionException: java.lang.NullPointerException: Cannot invoke "org.eclipse.lsp4j.CodeActionContext.getDiagnostics()" because the return value of "org.eclipse.lsp4j.CodeActionParams.getContext()" is null
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:320)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:649)
	at java.base/java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:483)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
Caused by: java.lang.NullPointerException: Cannot invoke "org.eclipse.lsp4j.CodeActionContext.getDiagnostics()" because the return value of "org.eclipse.lsp4j.CodeActionParams.getContext()" is null
	at org.eclipse.jdt.ls.core.internal.handlers.GetRefactorEditHandler.getEditsForRefactor(GetRefactorEditHandler.java:77)
	at org.eclipse.jdt.ls.core.internal.handlers.JDTLanguageServer.lambda$47(JDTLanguageServer.java:1131)
	at org.eclipse.jdt.ls.core.internal.BaseJDTLanguageServer.lambda$0(BaseJDTLanguageServer.java:87)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:646)
	... 6 more

'

```
