### PR TITLE
Fix failed cast to TypeDeclaration in file paste event

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/PasteEventHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/PasteEventHandler.java
@@ -367,7 +367,7 @@ public class PasteEventHandler {
 			}
 
 			String possibleFileName = "Untitled";
-			if (!root.types().isEmpty()) {
+			if (!root.types().isEmpty() && root.types().get(0) instanceof TypeDeclaration) {
 				possibleFileName = ((TypeDeclaration) root.types().get(0)).getName().getIdentifier();
 			}
 			if (Files.exists(Paths.get(desiredPath, possibleFileName + ".java"))) {


### PR DESCRIPTION
Fixes issues pasting text with implicitly declared classes into the file explorer.