### PR TITLE
Fix AbstractQuickFixTest's evaluateCodeActions(..) logic.

### DIFF
--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/AbstractSelectionTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/AbstractSelectionTest.java
@@ -26,7 +26,7 @@ public class AbstractSelectionTest extends AbstractQuickFixTest {
 	}
 
 	@Override
-	protected Range getRange(ICompilationUnit cu, IProblem[] problems) throws JavaModelException {
+	protected Range getRange(ICompilationUnit cu, IProblem problem) throws JavaModelException {
 		return CodeActionUtil.getRange(cu);
 	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/ExtractFieldTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/ExtractFieldTest.java
@@ -537,7 +537,7 @@ public class ExtractFieldTest extends AbstractSelectionTest {
 	protected void failHelper(ICompilationUnit cu) throws OperationCanceledException, CoreException {
 		CompilationUnit astRoot = CoreASTProvider.getInstance().getAST(cu, CoreASTProvider.WAIT_YES, null);
 		IProblem[] problems = astRoot.getProblems();
-		Range range = getRange(cu, problems);
+		Range range = getRange(cu, problems.length > 0 ? problems[0] : null);
 		int start = DiagnosticsHelper.getStartOffset(cu, range);
 		int end = DiagnosticsHelper.getEndOffset(cu, range);
 		ExtractFieldRefactoring refactoring = new ExtractFieldRefactoring(astRoot, start, end - start);
@@ -549,7 +549,7 @@ public class ExtractFieldTest extends AbstractSelectionTest {
 	protected boolean helper(ICompilationUnit cu, InitializeScope initializeIn, String expected) throws Exception {
 		CompilationUnit astRoot = CoreASTProvider.getInstance().getAST(cu, CoreASTProvider.WAIT_YES, null);
 		IProblem[] problems = astRoot.getProblems();
-		Range range = getRange(cu, problems);
+		Range range = getRange(cu, problems.length > 0 ? problems[0] : null);
 		int start = DiagnosticsHelper.getStartOffset(cu, range);
 		int end = DiagnosticsHelper.getEndOffset(cu, range);
 		ExtractFieldRefactoring refactoring = new ExtractFieldRefactoring(astRoot, start, end - start);


### PR DESCRIPTION
- Code actions belonging to diagnostics need to be resolved by setting the invocation range for the particular diagnostic in the evalutation request