### PR TITLE
Import Gradle project via Buildship if Gradle Build Server is not available

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
@@ -169,7 +169,7 @@ public class GradleProjectImporter extends AbstractProjectImporter {
 				// If code goes here, it means that the project cannot be imported by gradle build server.
 				// The buildship should try to import it if it can. And the buildship importer should clean
 				// up the configurations of the gradle build server in the project description if it has.
-				if (!ProjectUtils.isGradleProject(project) && !project.hasNature(GRADLE_BUILD_SERVER_NATURE)) {
+				if (!ProjectUtils.isGradleProject(project) && !ProjectUtils.hasNature(project, GRADLE_BUILD_SERVER_NATURE)) {
 					String path = project.getLocation().toOSString();
 					gradleDetector.addExclusions(path.replace("\\", "\\\\"));
 				}
@@ -731,7 +731,7 @@ public class GradleProjectImporter extends AbstractProjectImporter {
 	private static void eliminateBuildServerFootprint(IProgressMonitor monitor) {
 		for (IProject project : ProjectUtils.getAllProjects()) {
 			try {
-				if (project.hasNature(GRADLE_BUILD_SERVER_NATURE)) {
+				if (ProjectUtils.hasNature(project, GRADLE_BUILD_SERVER_NATURE)) {
 					GradleUtils.removeConfigurationFromProjectDescription(
 						project,
 						new HashSet<>(Arrays.asList(GRADLE_BUILD_SERVER_NATURE)),

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
@@ -114,6 +114,19 @@ public class GradleProjectImporter extends AbstractProjectImporter {
 	public static final String GRADLE_MARKER_COLUMN_START = "gradleColumnStart";
 	public static final String GRADLE_MARKER_COLUMN_END = "gradleColumnEnd";
 
+	/**
+	 * Nature id of the gradle build server project.
+	 */
+	public static final String GRADLE_BUILD_SERVER_NATURE = "com.microsoft.gradle.bs.importer.GradleBuildServerProjectNature";
+	/**
+	 * Builder id of the gradle build server.
+	 */
+	public static final String GRADLE_BUILD_SERVER_BUILDER_ID = "com.microsoft.gradle.bs.importer.builder.BuildServerBuilder";
+	/**
+	 * Builder id of the java problem checker, it's used to provide diagnostics during auto build for gradle build server projects.
+	 */
+	public static final String JAVA_PROBLEM_CHECKER_ID = "java.bs.JavaProblemChecker";
+
 	private static final int GRADLE_RELATED = 0x00080000;
 	private static final int INVALID_TYPE_CODE_ID = GRADLE_RELATED + 1;
 
@@ -152,7 +165,11 @@ public class GradleProjectImporter extends AbstractProjectImporter {
 					.addExclusions("**/build")//default gradle build dir
 					.addExclusions("**/bin");
 			for (IProject project : ProjectUtils.getAllProjects()) {
-				if (!ProjectUtils.isGradleProject(project)) {
+				// The gradle build server has higher priority than buildship when importing gradle projects.
+				// If code goes here, it means that the project cannot be imported by gradle build server.
+				// The buildship should try to import it if it can. And the buildship importer should clean
+				// up the configurations of the gradle build server in the project description if it has.
+				if (!ProjectUtils.isGradleProject(project) && !project.hasNature(GRADLE_BUILD_SERVER_NATURE)) {
 					String path = project.getLocation().toOSString();
 					gradleDetector.addExclusions(path.replace("\\", "\\\\"));
 				}
@@ -301,7 +318,7 @@ public class GradleProjectImporter extends AbstractProjectImporter {
 		}
 
 		GradleUtils.synchronizeAnnotationProcessingConfiguration(subMonitor);
-
+		eliminateBuildServerFootprint(monitor);
 		subMonitor.done();
 	}
 
@@ -705,6 +722,27 @@ public class GradleProjectImporter extends AbstractProjectImporter {
 
 	public static boolean isFailedStatus(IStatus status) {
 		return status != null && !status.isOK() && status.getException() != null;
+	}
+
+	/**
+	 * Eliminate the footprint of the Gradle build server projects. This is necessary
+	 * cleanup in case that user uninstalls/disables the gradle extension.
+	 */
+	private static void eliminateBuildServerFootprint(IProgressMonitor monitor) {
+		for (IProject project : ProjectUtils.getAllProjects()) {
+			try {
+				if (project.hasNature(GRADLE_BUILD_SERVER_NATURE)) {
+					GradleUtils.removeConfigurationFromProjectDescription(
+						project,
+						new HashSet<>(Arrays.asList(GRADLE_BUILD_SERVER_NATURE)),
+						new HashSet<>(Arrays.asList(GRADLE_BUILD_SERVER_BUILDER_ID, JAVA_PROBLEM_CHECKER_ID)),
+						monitor
+					);
+				}
+			} catch (CoreException e) {
+				JavaLanguageServerPlugin.logException("Failed to remove Gradle build server configuration from project description", e);
+			}
+		}
 	}
 
 	public class GradleCompatibilityStatus extends Status {

--- a/org.eclipse.jdt.ls.tests/projects/gradle/gradle-build-server/.project
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/gradle-build-server/.project
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>gradle-build-server</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>java.bs.JavaProblemChecker</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>com.microsoft.gradle.bs.importer.builder.BuildServerBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>com.microsoft.gradle.bs.importer.GradleBuildServerProjectNature</nature>
+	</natures>
+</projectDescription>

--- a/org.eclipse.jdt.ls.tests/projects/gradle/gradle-build-server/build.gradle
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/gradle-build-server/build.gradle
@@ -1,0 +1,1 @@
+apply plugin: 'java'

--- a/org.eclipse.jdt.ls.tests/projects/gradle/gradle-build-server/gradle/wrapper/gradle-wrapper.properties
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/gradle-build-server/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+#Wed Aug 10 11:28:36 CST 2022
+distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionPath=wrapper/dists
+zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/org.eclipse.jdt.ls.tests/projects/gradle/gradle-build-server/gradlew
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/gradle-build-server/gradlew
@@ -1,0 +1,183 @@
+#!/usr/bin/env sh
+
+#
+# Copyright 2015 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##############################################################################
+##
+##  Gradle start up script for UN*X
+##
+##############################################################################
+
+# Attempt to set APP_HOME
+# Resolve links: $0 may be a link
+PRG="$0"
+# Need this for relative symlinks.
+while [ -h "$PRG" ] ; do
+    ls=`ls -ld "$PRG"`
+    link=`expr "$ls" : '.*-> \(.*\)$'`
+    if expr "$link" : '/.*' > /dev/null; then
+        PRG="$link"
+    else
+        PRG=`dirname "$PRG"`"/$link"
+    fi
+done
+SAVED="`pwd`"
+cd "`dirname \"$PRG\"`/" >/dev/null
+APP_HOME="`pwd -P`"
+cd "$SAVED" >/dev/null
+
+APP_NAME="Gradle"
+APP_BASE_NAME=`basename "$0"`
+
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+
+# Use the maximum available, or set MAX_FD != -1 to use that value.
+MAX_FD="maximum"
+
+warn () {
+    echo "$*"
+}
+
+die () {
+    echo
+    echo "$*"
+    echo
+    exit 1
+}
+
+# OS specific support (must be 'true' or 'false').
+cygwin=false
+msys=false
+darwin=false
+nonstop=false
+case "`uname`" in
+  CYGWIN* )
+    cygwin=true
+    ;;
+  Darwin* )
+    darwin=true
+    ;;
+  MINGW* )
+    msys=true
+    ;;
+  NONSTOP* )
+    nonstop=true
+    ;;
+esac
+
+CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
+
+# Determine the Java command to use to start the JVM.
+if [ -n "$JAVA_HOME" ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+        # IBM's JDK on AIX uses strange locations for the executables
+        JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+        JAVACMD="$JAVA_HOME/bin/java"
+    fi
+    if [ ! -x "$JAVACMD" ] ; then
+        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+    fi
+else
+    JAVACMD="java"
+    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+fi
+
+# Increase the maximum file descriptors if we can.
+if [ "$cygwin" = "false" -a "$darwin" = "false" -a "$nonstop" = "false" ] ; then
+    MAX_FD_LIMIT=`ulimit -H -n`
+    if [ $? -eq 0 ] ; then
+        if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ] ; then
+            MAX_FD="$MAX_FD_LIMIT"
+        fi
+        ulimit -n $MAX_FD
+        if [ $? -ne 0 ] ; then
+            warn "Could not set maximum file descriptor limit: $MAX_FD"
+        fi
+    else
+        warn "Could not query maximum file descriptor limit: $MAX_FD_LIMIT"
+    fi
+fi
+
+# For Darwin, add options to specify how the application appears in the dock
+if $darwin; then
+    GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
+fi
+
+# For Cygwin or MSYS, switch paths to Windows format before running java
+if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
+    APP_HOME=`cygpath --path --mixed "$APP_HOME"`
+    CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
+    JAVACMD=`cygpath --unix "$JAVACMD"`
+
+    # We build the pattern for arguments to be converted via cygpath
+    ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`
+    SEP=""
+    for dir in $ROOTDIRSRAW ; do
+        ROOTDIRS="$ROOTDIRS$SEP$dir"
+        SEP="|"
+    done
+    OURCYGPATTERN="(^($ROOTDIRS))"
+    # Add a user-defined pattern to the cygpath arguments
+    if [ "$GRADLE_CYGPATTERN" != "" ] ; then
+        OURCYGPATTERN="$OURCYGPATTERN|($GRADLE_CYGPATTERN)"
+    fi
+    # Now convert the arguments - kludge to limit ourselves to /bin/sh
+    i=0
+    for arg in "$@" ; do
+        CHECK=`echo "$arg"|egrep -c "$OURCYGPATTERN" -`
+        CHECK2=`echo "$arg"|egrep -c "^-"`                                 ### Determine if an option
+
+        if [ $CHECK -ne 0 ] && [ $CHECK2 -eq 0 ] ; then                    ### Added a condition
+            eval `echo args$i`=`cygpath --path --ignore --mixed "$arg"`
+        else
+            eval `echo args$i`="\"$arg\""
+        fi
+        i=`expr $i + 1`
+    done
+    case $i in
+        0) set -- ;;
+        1) set -- "$args0" ;;
+        2) set -- "$args0" "$args1" ;;
+        3) set -- "$args0" "$args1" "$args2" ;;
+        4) set -- "$args0" "$args1" "$args2" "$args3" ;;
+        5) set -- "$args0" "$args1" "$args2" "$args3" "$args4" ;;
+        6) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" ;;
+        7) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" ;;
+        8) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" ;;
+        9) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" "$args8" ;;
+    esac
+fi
+
+# Escape application args
+save () {
+    for i do printf %s\\n "$i" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/' \\\\/" ; done
+    echo " "
+}
+APP_ARGS=`save "$@"`
+
+# Collect all arguments for the java command, following the shell quoting and substitution rules
+eval set -- $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS "\"-Dorg.gradle.appname=$APP_BASE_NAME\"" -classpath "\"$CLASSPATH\"" org.gradle.wrapper.GradleWrapperMain "$APP_ARGS"
+
+exec "$JAVACMD" "$@"

--- a/org.eclipse.jdt.ls.tests/projects/gradle/gradle-build-server/gradlew.bat
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/gradle-build-server/gradlew.bat
@@ -1,0 +1,100 @@
+@rem
+@rem Copyright 2015 the original author or authors.
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem      https://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+@rem
+
+@if "%DEBUG%" == "" @echo off
+@rem ##########################################################################
+@rem
+@rem  Gradle startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if "%ERRORLEVEL%" == "0" goto init
+
+echo.
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto init
+
+echo.
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:init
+@rem Get command-line arguments, handling Windows variants
+
+if not "%OS%" == "Windows_NT" goto win9xME_args
+
+:win9xME_args
+@rem Slurp the command line arguments.
+set CMD_LINE_ARGS=
+set _SKIP=2
+
+:win9xME_args_slurp
+if "x%~1" == "x" goto execute
+
+set CMD_LINE_ARGS=%*
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+
+@rem Execute Gradle
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+
+:end
+@rem End local scope for the variables with windows NT shell
+if "%ERRORLEVEL%"=="0" goto mainEnd
+
+:fail
+rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
+exit /b 1
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega

--- a/org.eclipse.jdt.ls.tests/projects/gradle/gradle-build-server/src/main/java/Library.java
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/gradle-build-server/src/main/java/Library.java
@@ -1,0 +1,5 @@
+public class Library {
+    public boolean someLibraryMethod() {
+        return true;
+    }
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporterTest.java
@@ -766,7 +766,7 @@ public class GradleProjectImporterTest extends AbstractGradleBasedTest{
 	@Test
 	public void testCleanUpBuildServerFootprint() throws Exception {
 		IProject project = importGradleProject("gradle-build-server");
-		assertFalse(project.hasNature(GradleProjectImporter.GRADLE_BUILD_SERVER_NATURE));
+		assertFalse(ProjectUtils.hasNature(project, GradleProjectImporter.GRADLE_BUILD_SERVER_NATURE));
 		for (ICommand command : project.getDescription().getBuildSpec()) {
 			if (Objects.equals(command.getBuilderName(), GradleProjectImporter.GRADLE_BUILD_SERVER_BUILDER_ID) ||
 					Objects.equals(command.getBuilderName(), GradleProjectImporter.JAVA_PROBLEM_CHECKER_ID)) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporterTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -30,6 +31,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 
 import org.eclipse.buildship.core.BuildConfiguration;
@@ -39,6 +41,7 @@ import org.eclipse.buildship.core.LocalGradleDistribution;
 import org.eclipse.buildship.core.WrapperGradleDistribution;
 import org.eclipse.buildship.core.internal.CorePlugin;
 import org.eclipse.buildship.core.internal.configuration.ProjectConfiguration;
+import org.eclipse.core.resources.ICommand;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspaceRoot;
@@ -757,6 +760,19 @@ public class GradleProjectImporterTest extends AbstractGradleBasedTest{
 		File projectRoot = new File(getSourceProjectDirectory(), "gradle/no-gradlew");
 		GradleDistribution distribution = GradleProjectImporter.getGradleDistribution(projectRoot.toPath());
 		assertTrue(distribution instanceof WrapperGradleDistribution);
+	}
+	
+
+	@Test
+	public void testCleanUpBuildServerFootprint() throws Exception {
+		IProject project = importGradleProject("gradle-build-server");
+		assertFalse(project.hasNature(GradleProjectImporter.GRADLE_BUILD_SERVER_NATURE));
+		for (ICommand command : project.getDescription().getBuildSpec()) {
+			if (Objects.equals(command.getBuilderName(), GradleProjectImporter.GRADLE_BUILD_SERVER_BUILDER_ID) ||
+					Objects.equals(command.getBuilderName(), GradleProjectImporter.JAVA_PROBLEM_CHECKER_ID)) {
+				fail("Build server builders should have been removed");
+			}
+		}
 	}
 
 	private ProjectConfiguration getProjectConfiguration(IProject project) {


### PR DESCRIPTION
There will be the case when user has imported the gradle project by build server. Then, the user disable/uninstall the gradle extension.

In this case, the build server project should not be excluded when gradle importer scans the folder to import.

But, so far I cannot figure out a perfect way to do that. The nature id for build server is hard coded. @snjeza @rgrunber Do you know if we can have better approach than this?