### PR TITLE
Update target platform to newer 4.33-I-builds (I20240820-1800).

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -25,7 +25,7 @@
             <unit id="org.mockito.mockito-core" version="0.0.0"/>
             <unit id="org.apache.commons.commons-io" version="0.0.0"/>
             <unit id="org.eclipse.jdt.apt.pluggable.core" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.33-I-builds/I20240728-1800/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.33-I-builds/I20240820-1800/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.jdt.core.compiler.batch" version="0.0.0"/>

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/TypeMismatchQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/TypeMismatchQuickFixTest.java
@@ -947,7 +947,7 @@ public class TypeMismatchQuickFixTest extends AbstractQuickFixTest {
 		buf.append("        return null;\n");
 		buf.append("    }\n");
 		buf.append("}\n");
-		Expected e1 = new Expected("Change return type of 'getCollection(..)' to 'List'", buf.toString());
+		Expected e1 = new Expected("Change return type of 'getCollection(..)' to 'List<E>'", buf.toString());
 
 		buf = new StringBuilder();
 		buf.append("package test1;\n");


### PR DESCRIPTION
Small improvement due to https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/1559 .