### PR TITLE
Improve rename tests so they can work with Javac too

### DIFF
--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/PrepareRenameHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/PrepareRenameHandlerTest.java
@@ -214,7 +214,7 @@ public class PrepareRenameHandlerTest extends AbstractProjectsManagerBasedTest {
 				"package test1;\n",
 				"public class B<T> {\n",
 				"	private T t;\n",
-				"	public <U|* extends Number> inspect(U u) { return u; }\n",
+				"	public <U|* extends Number> U inspect(U u) { return u; }\n",
 				"}\n"
 		};
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/RenameHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/RenameHandlerTest.java
@@ -775,7 +775,7 @@ public class RenameHandlerTest extends AbstractProjectsManagerBasedTest {
 				"package test1;\n",
 				"public class B<T> {\n",
 				"	private T t;\n",
-				"	public <U|* extends Number> inspect(U u) { return u; }\n",
+				"	public <U|* extends Number> U inspect(U u) { return u; }\n",
 				"}\n"
 		};
 
@@ -791,7 +791,7 @@ public class RenameHandlerTest extends AbstractProjectsManagerBasedTest {
 				"package test1;\n" +
 				"public class B<T> {\n" +
 				"	private T t;\n" +
-				"	public <UU extends Number> inspect(UU u) { return u; }\n" +
+				"	public <UU extends Number> UU inspect(UU u) { return u; }\n" +
 				"}\n"
 				);
 	}


### PR DESCRIPTION
The current code being tested has syntax errors. Those errors prevents Javac from properly setting up bindings (and it's not obvious that Javac is more wrong than ECJ, so there are little chance Javac gets changed to behave like ECJ).
Those syntax errors do not seem so relevant for the case being covered. So we get rid of them to focus on the "correct" case and allow Javac to work with it.