### PR TITLE
Fix license check workflow after repository move

### DIFF
--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -16,7 +16,7 @@ jobs:
   call-license-check:
     permissions:
       pull-requests: write
-    uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
+    uses: eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
     with:
       projectId: eclipse.jdt.ls
       submodules: recursive


### PR DESCRIPTION
Currently, the [licensecheck workflow](https://github.com/eclipse-jdtls/eclipse.jdt.ls/actions/workflows/licensecheck.yml) is failing every time someone makes a push or even comments on an issue (I got an automated email from GitHub about it after posting a comment). It seems like this is caused by the Eclipse Dash License Tool repository being moved to a new organization, see eclipse-dash/dash-licenses#302 and in particular the last couple of comments on that issue. Basically, the GitHub workflow doesn't follow the redirect, so the workflow has to be updated to use the new repository in order for it to work again.