### PR TITLE
Update supported Java versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and can be used with any editor that supports the protocol, to offer good suppor
 
 Features
 --------------
-* Supports compiling projects from Java 1.5 through 19
+* Supports compiling projects from Java 1.8 through 22
 * Maven pom.xml project support
 * Gradle project support (with experimental Android project import support)
 * Standalone Java files support


### PR DESCRIPTION
Updates the supported Java versions in accordance with #3227 and #3111.

***NOTE*** that this PR is meant as a testing environment for automated license checking, see https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3264#issuecomment-2329183621. However, the PR may still be merged afterwards as I believe the README information should be updated either way.