### PR TITLE
Use parser statement recovery for String pasting where errors exist.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/PasteEventHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/PasteEventHandler.java
@@ -224,6 +224,7 @@ public class PasteEventHandler {
 		ASTParser parser = ASTParser.newParser(AST.getJLSLatest());
 		parser.setSource(cu);
 		parser.setResolveBindings(false);
+		parser.setStatementsRecovery(true);
 		CompilationUnit ast = (CompilationUnit) parser.createAST(monitor);
 		DocumentPasteEdit edit = handleStringPasteEvent(params, cu, ast, monitor);
 		if (edit == null) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/PasteEventHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/PasteEventHandlerTest.java
@@ -67,6 +67,28 @@ public class PasteEventHandlerTest extends AbstractSourceTestCase {
 	}
 
 	@Test
+	public void testPasteWithErrorOnLine() throws CoreException {
+		ICompilationUnit unit = fPackageTest.createCompilationUnit("A.java", //
+				"package test;\n" + //
+						"public class A {\n" + //
+						"public void test() {\n" + //
+						"\tString asdf = \"\"\n" + //
+						"}\n" + //
+						"}\n",
+				false, monitor);
+
+		var params = new PasteEventParams( //
+				createLocation(JDTUtils.toUri(unit), 3, 16, 3, 16), //
+				"aaa\naaa", //
+				null, //
+				new FormattingOptions(4, false));
+
+		DocumentPasteEdit actual = PasteEventHandler.handlePasteEvent(params, null);
+
+		Assert.assertEquals(new DocumentPasteEdit("aaa\\n\" + //\n\t\t\t\"aaa"), actual);
+	}
+
+	@Test
 	public void testPasteWindowsNewlineInCopiedText() throws CoreException {
 		ICompilationUnit unit = fPackageTest.createCompilationUnit("A.java", //
 				"package test;\n" + //


### PR DESCRIPTION
- Add testcase
- Fixes https://github.com/redhat-developer/vscode-java/issues/3761