### PR TITLE
Add Organize Imports as a clean up.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/AddDeprecatedAnnotationCleanUp.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/AddDeprecatedAnnotationCleanUp.java
@@ -17,10 +17,10 @@ import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
-import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.Java50FixCore;
+import org.eclipse.jdt.ui.cleanup.CleanUpContext;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
 
 /**
  * A cleanup that adds the deprecated annotation to classes/fields/methods that
@@ -36,7 +36,7 @@ public class AddDeprecatedAnnotationCleanUp implements ISimpleCleanUp {
 	}
 
 	@Override
-	public ICleanUpFixCore createFix(CleanUpContextCore context) {
+	public ICleanUpFix createFix(CleanUpContext context) {
 		return Java50FixCore.createCleanUp(context.getAST(), false, false, true, false);
 	}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/AddOverrideAnnotationCleanUp.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/AddOverrideAnnotationCleanUp.java
@@ -17,10 +17,10 @@ import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
-import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.Java50FixCore;
+import org.eclipse.jdt.ui.cleanup.CleanUpContext;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
 
 /**
  * A cleanup that adds the override annotation to all methods that override any
@@ -36,7 +36,7 @@ public class AddOverrideAnnotationCleanUp implements ISimpleCleanUp {
 	}
 
 	@Override
-	public ICleanUpFixCore createFix(CleanUpContextCore context) {
+	public ICleanUpFix createFix(CleanUpContext context) {
 		return Java50FixCore.createCleanUp(context.getAST(), true, true, false, false);
 	}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpRegistry.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpRegistry.java
@@ -54,7 +54,8 @@ public class CleanUpRegistry {
 			new InstanceofPatternMatch(),
 			new LambdaExpressionCleanup(),
 			new TryWithResourceCleanUp(),
-			new LambdaExpressionAndMethodRefCleanUp());
+			new LambdaExpressionAndMethodRefCleanUp(),
+			new OrganizeImportsCleanup());
 
 		// Store in a Map so that they can be accessed by ID quickly
 		cleanUps = new HashMap<>();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpRegistry.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpRegistry.java
@@ -27,9 +27,9 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ui.cleanup.CleanUpContext;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextEdit;
 
@@ -111,7 +111,7 @@ public class CleanUpRegistry {
 		}
 
 		// build the context after setting the compiler options so that the built AST has all the required markers
-		CleanUpContextCore context = CleanUpUtils.getCleanUpContext(textDocumentId, opts, monitor);
+		CleanUpContext context = CleanUpUtils.getCleanUpContext(textDocumentId, opts, monitor);
 		List<TextEdit> textEdits = new ArrayList<>();
 		ICompilationUnit cu = context.getCompilationUnit();
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpUtils.java
@@ -19,12 +19,12 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.CompilationUnit;
-import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
-import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
 import org.eclipse.jdt.core.refactoring.CompilationUnitChange;
 import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ui.cleanup.CleanUpContext;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.text.edits.TextEdit;
 
@@ -44,14 +44,14 @@ public class CleanUpUtils {
 	 *            the progress monitor
 	 * @return the clean up context for the given text document
 	 */
-	public static CleanUpContextCore getCleanUpContext(TextDocumentIdentifier textDocumentId, Map<String, String> compilerOpts, IProgressMonitor monitor) {
+	public static CleanUpContext getCleanUpContext(TextDocumentIdentifier textDocumentId, Map<String, String> compilerOpts, IProgressMonitor monitor) {
 		ICompilationUnit unit = JDTUtils.resolveCompilationUnit(textDocumentId.getUri());
 		return getCleanUpContext(unit, compilerOpts, monitor);
 	}
 
-	public static CleanUpContextCore getCleanUpContext(ICompilationUnit unit, Map<String, String> compilerOpts, IProgressMonitor monitor) {
+	public static CleanUpContext getCleanUpContext(ICompilationUnit unit, Map<String, String> compilerOpts, IProgressMonitor monitor) {
 		CompilationUnit ast = createASTWithOpts(unit, compilerOpts, monitor);
-		return new CleanUpContextCore(unit, ast);
+		return new CleanUpContext(unit, ast);
 	}
 
 	/**
@@ -65,10 +65,10 @@ public class CleanUpUtils {
 	 *            the progress monitor
 	 * @return a non-null list of text edits for the given clean up
 	 */
-	public static TextEdit getTextEditFromCleanUp(ISimpleCleanUp cleanUp, CleanUpContextCore context, IProgressMonitor monitor) {
+	public static TextEdit getTextEditFromCleanUp(ISimpleCleanUp cleanUp, CleanUpContext context, IProgressMonitor monitor) {
 
 		try {
-			ICleanUpFixCore fix = cleanUp != null ? cleanUp.createFix(context) : null;
+			ICleanUpFix fix = cleanUp != null ? cleanUp.createFix(context) : null;
 			if (fix == null) {
 				return null;
 			}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/ISimpleCleanUp.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/ISimpleCleanUp.java
@@ -16,8 +16,8 @@ import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
-import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
+import org.eclipse.jdt.ui.cleanup.CleanUpContext;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
 
 /**
  * Represents a cleanup change that doesn't need any further configuration (eg.
@@ -39,7 +39,7 @@ public interface ISimpleCleanUp {
 	 *            the context for the clean up (the compilation unit and the AST)
 	 * @return the cleanup fix for the given source file
 	 */
-	ICleanUpFixCore createFix(CleanUpContextCore context) throws CoreException;
+	ICleanUpFix createFix(CleanUpContext context) throws CoreException;
 
 	/**
 	 * Returns a list of all compiler markers (i.e. info, warning, error) that are

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/InstanceofPatternMatch.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/InstanceofPatternMatch.java
@@ -17,10 +17,10 @@ import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.dom.CompilationUnit;
-import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
-import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.PatternMatchingForInstanceofFixCore;
+import org.eclipse.jdt.ui.cleanup.CleanUpContext;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
 
 /**
  * Represents a cleanup that uses pattern matching for 'instanceof' cast checks
@@ -33,7 +33,7 @@ public class InstanceofPatternMatch implements ISimpleCleanUp {
 	}
 
 	@Override
-	public ICleanUpFixCore createFix(CleanUpContextCore context) throws CoreException {
+	public ICleanUpFix createFix(CleanUpContext context) throws CoreException {
 		CompilationUnit unit = context.getAST();
 		if (unit == null) {
 			return null;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/InvertEqualsCleanUp.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/InvertEqualsCleanUp.java
@@ -17,10 +17,10 @@ import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.dom.CompilationUnit;
-import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
-import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.InvertEqualsFixCore;
+import org.eclipse.jdt.ui.cleanup.CleanUpContext;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
 
 /**
  * Represents a clean up that inverts calls to Object.equals(Object) and
@@ -34,7 +34,7 @@ public class InvertEqualsCleanUp implements ISimpleCleanUp {
 	}
 
 	@Override
-	public ICleanUpFixCore createFix(CleanUpContextCore context) throws CoreException {
+	public ICleanUpFix createFix(CleanUpContext context) throws CoreException {
 		CompilationUnit unit = context.getAST();
 		if (unit == null) {
 			return null;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/LambdaExpressionAndMethodRefCleanUp.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/LambdaExpressionAndMethodRefCleanUp.java
@@ -18,10 +18,10 @@ import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.dom.CompilationUnit;
-import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
-import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.LambdaExpressionAndMethodRefFixCore;
+import org.eclipse.jdt.ui.cleanup.CleanUpContext;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
 
 /**
  * Represents a cleanup that does several actions to clean up lambda expression
@@ -34,7 +34,7 @@ public class LambdaExpressionAndMethodRefCleanUp implements ISimpleCleanUp {
 	}
 
 	@Override
-	public ICleanUpFixCore createFix(CleanUpContextCore context) throws CoreException {
+	public ICleanUpFix createFix(CleanUpContext context) throws CoreException {
 		CompilationUnit unit = context.getAST();
 		if (unit == null) {
 			return null;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/LambdaExpressionCleanup.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/LambdaExpressionCleanup.java
@@ -18,10 +18,10 @@ import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.dom.CompilationUnit;
-import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
-import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.LambdaExpressionsFixCore;
+import org.eclipse.jdt.ui.cleanup.CleanUpContext;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
 
 /**
  * Represents a cleanup that converts an anonymous class creation to a lambda expression
@@ -34,7 +34,7 @@ public class LambdaExpressionCleanup implements ISimpleCleanUp {
 	}
 
 	@Override
-	public ICleanUpFixCore createFix(CleanUpContextCore context) throws CoreException {
+	public ICleanUpFix createFix(CleanUpContext context) throws CoreException {
 		CompilationUnit unit = context.getAST();
 		if (unit == null) {
 			return null;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/MemberAccessUsesThisCleanUp.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/MemberAccessUsesThisCleanUp.java
@@ -18,9 +18,9 @@ import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.dom.CompilationUnit;
-import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
-import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
 import org.eclipse.jdt.internal.corext.fix.CodeStyleFixCore;
+import org.eclipse.jdt.ui.cleanup.CleanUpContext;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
 
 /**
  * Represents a clean up that prefixes all (non-static) field and method
@@ -34,7 +34,7 @@ public class MemberAccessUsesThisCleanUp implements ISimpleCleanUp {
 	}
 
 	@Override
-	public ICleanUpFixCore createFix(CleanUpContextCore context) throws CoreException {
+	public ICleanUpFix createFix(CleanUpContext context) throws CoreException {
 		CompilationUnit unit = context.getAST();
 		if (unit == null) {
 			return null;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/OrganizeImportsCleanup.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/OrganizeImportsCleanup.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.cleanup;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.manipulation.OrganizeImportsOperation;
+import org.eclipse.jdt.core.refactoring.CompilationUnitChange;
+import org.eclipse.jdt.ui.cleanup.CleanUpContext;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
+import org.eclipse.text.edits.TextEdit;
+
+public class OrganizeImportsCleanup implements ISimpleCleanUp {
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#getIdentifier()
+	 */
+	@Override
+	public Collection<String> getIdentifiers() {
+		return List.of("organizeImports");
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#createFix(org.eclipse.jdt.core.manipulation.CleanUpContextCore)
+	 */
+	@Override
+	public ICleanUpFix createFix(CleanUpContext context) throws CoreException {
+		CompilationUnit unit = context.getAST();
+		if (unit == null) {
+			return null;
+		}
+		OrganizeImportsOperation op = new OrganizeImportsOperation(context.getCompilationUnit(), unit,
+				false, false, true,
+				null,
+				false);
+		TextEdit te = op.createTextEdit(new NullProgressMonitor());
+		return new ICleanUpFix() {
+			@Override
+			public CompilationUnitChange createChange(IProgressMonitor progressMonitor) throws CoreException {
+				CompilationUnitChange change = new CompilationUnitChange("", context.getCompilationUnit());
+				change.setEdit(te);
+				return change;
+			}
+		};
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#getRequiredCompilerMarkers()
+	 */
+	@Override
+	public List<String> getRequiredCompilerMarkers() {
+		return Collections.emptyList();
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/StaticAccessUsesClassNameCleanUp.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/StaticAccessUsesClassNameCleanUp.java
@@ -18,9 +18,9 @@ import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.dom.CompilationUnit;
-import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
-import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
 import org.eclipse.jdt.internal.corext.fix.CodeStyleFixCore;
+import org.eclipse.jdt.ui.cleanup.CleanUpContext;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
 
 /**
  * Represents a clean up that prefixes all static member accesses with the
@@ -34,7 +34,7 @@ public class StaticAccessUsesClassNameCleanUp implements ISimpleCleanUp {
 	}
 
 	@Override
-	public ICleanUpFixCore createFix(CleanUpContextCore context) throws CoreException {
+	public ICleanUpFix createFix(CleanUpContext context) throws CoreException {
 		CompilationUnit unit = context.getAST();
 		if (unit == null) {
 			return null;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/StringConcatToTextBlockCleanUp.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/StringConcatToTextBlockCleanUp.java
@@ -18,10 +18,10 @@ import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.dom.CompilationUnit;
-import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
-import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.StringConcatToTextBlockFixCore;
+import org.eclipse.jdt.ui.cleanup.CleanUpContext;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
 
 /**
  * Represents a clean up that converts string concatenaton to Text Blocks
@@ -34,7 +34,7 @@ public class StringConcatToTextBlockCleanUp implements ISimpleCleanUp {
 	}
 
 	@Override
-	public ICleanUpFixCore createFix(CleanUpContextCore context) throws CoreException {
+	public ICleanUpFix createFix(CleanUpContext context) throws CoreException {
 		CompilationUnit unit = context.getAST();
 		if (unit == null) {
 			return null;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/SwitchExpressionCleanup.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/SwitchExpressionCleanup.java
@@ -18,10 +18,10 @@ import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.dom.CompilationUnit;
-import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
-import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.SwitchExpressionsFixCore;
+import org.eclipse.jdt.ui.cleanup.CleanUpContext;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
 
 /**
  * Represents a cleanup that converts a switch statement to a switch expression
@@ -34,7 +34,7 @@ public class SwitchExpressionCleanup implements ISimpleCleanUp {
 	}
 
 	@Override
-	public ICleanUpFixCore createFix(CleanUpContextCore context) throws CoreException {
+	public ICleanUpFix createFix(CleanUpContext context) throws CoreException {
 		CompilationUnit unit = context.getAST();
 		if (unit == null) {
 			return null;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/TryWithResourceCleanUp.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/TryWithResourceCleanUp.java
@@ -18,10 +18,10 @@ import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.dom.CompilationUnit;
-import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
-import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.TryWithResourceFixCore;
+import org.eclipse.jdt.ui.cleanup.CleanUpContext;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
 
 /**
  * Represents a clean up that simplifies the finally block to using a
@@ -35,7 +35,7 @@ public class TryWithResourceCleanUp implements ISimpleCleanUp {
 	}
 
 	@Override
-	public ICleanUpFixCore createFix(CleanUpContextCore context) throws CoreException {
+	public ICleanUpFix createFix(CleanUpContext context) throws CoreException {
 		CompilationUnit unit = context.getAST();
 		if (unit == null) {
 			return null;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/VariableDeclarationFixCleanup.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/VariableDeclarationFixCleanup.java
@@ -18,10 +18,10 @@ import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.dom.CompilationUnit;
-import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
-import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.VariableDeclarationFixCore;
+import org.eclipse.jdt.ui.cleanup.CleanUpContext;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
 
 /**
  * Represents a cleanup that adds the 'final' modifier where possible
@@ -34,7 +34,7 @@ public class VariableDeclarationFixCleanup implements ISimpleCleanUp {
 	}
 
 	@Override
-	public ICleanUpFixCore createFix(CleanUpContextCore context) throws CoreException {
+	public ICleanUpFix createFix(CleanUpContext context) throws CoreException {
 		CompilationUnit unit = context.getAST();
 		if (unit == null) {
 			return null;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/ReorgCorrectionsSubProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/ReorgCorrectionsSubProcessor.java
@@ -24,7 +24,6 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.manipulation.CUCorrectionProposalCore;
 import org.eclipse.jdt.core.manipulation.ChangeCorrectionProposalCore;
-import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
 import org.eclipse.jdt.core.refactoring.CompilationUnitChange;
 import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.corext.fix.IProposableFix;
@@ -41,6 +40,7 @@ import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.corrections.CorrectionMessages;
 import org.eclipse.jdt.ls.core.internal.corrections.ProposalKindWrapper;
 import org.eclipse.jdt.ls.core.internal.handlers.CodeActionHandler;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
 import org.eclipse.jdt.ui.text.java.IInvocationContext;
 import org.eclipse.jdt.ui.text.java.IProblemLocation;
 import org.eclipse.lsp4j.CodeActionKind;
@@ -112,7 +112,7 @@ public class ReorgCorrectionsSubProcessor extends ReorgCorrectionsBaseSubProcess
 	@Override
 	public void addRemoveImportStatementProposals(IInvocationContext context, IProblemLocation problem, Collection<ProposalKindWrapper> proposals) {
 		super.addRemoveImportStatementProposals(context, problem, proposals);
-		ICleanUpFixCore removeAllUnusedImportsFix = UnusedCodeFixCore.createCleanUp(context.getASTRoot(), false, false, false, false, false, true, false, false);
+		ICleanUpFix removeAllUnusedImportsFix = UnusedCodeFixCore.createCleanUp(context.getASTRoot(), false, false, false, false, false, true, false, false);
 		if (removeAllUnusedImportsFix != null) {
 			try {
 				CompilationUnitChange change = removeAllUnusedImportsFix.createChange(null);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpsTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpsTest.java
@@ -579,4 +579,65 @@ public class CleanUpsTest extends AbstractMavenBasedTest {
 		assertEquals(expected, actual);
 	}
 
+	@Test
+	public void testOrganizeImportsCleanup() throws Exception {
+		String contents = """
+			package test1;
+			public class A {
+			    public void test() {
+			        List<String> a1;
+				    Iterator<String> a2;
+				    Map<String, String> a3;
+				    Set<String> a4;
+				    JarFile a5;
+				    StringTokenizer a6;
+				    Path a7;
+				    URI a8;
+				    HttpURLConnection a9;
+				    InputStream a10;
+				    Field a11;
+				    Parser a12;
+			    }
+			}
+			""";
+
+		ICompilationUnit unit = pack1.createCompilationUnit("A.java", contents, false, monitor);
+		String uri = unit.getUnderlyingResource().getLocationURI().toString();
+
+		String expected = """
+			package test1;
+
+			import java.io.InputStream;
+			import java.net.HttpURLConnection;
+			import java.net.URI;
+			import java.nio.file.Path;
+			import java.util.Iterator;
+			import java.util.List;
+			import java.util.Map;
+			import java.util.Set;
+			import java.util.StringTokenizer;
+			import java.util.jar.JarFile;
+
+			public class A {
+			    public void test() {
+			        List<String> a1;
+				    Iterator<String> a2;
+				    Map<String, String> a3;
+				    Set<String> a4;
+				    JarFile a5;
+				    StringTokenizer a6;
+				    Path a7;
+				    URI a8;
+				    HttpURLConnection a9;
+				    InputStream a10;
+				    Field a11;
+				    Parser a12;
+			    }
+			}
+			""";
+		List<TextEdit> textEdits = registry.getEditsForAllActiveCleanUps(new TextDocumentIdentifier(uri), Arrays.asList("organizeImports"), monitor);
+		String actual = TextEditUtil.apply(unit, textEdits);
+		assertEquals(expected, actual);
+	}
+
 }


### PR DESCRIPTION
- 'organizeImports' becomes recognized through the cleanup registry
- Also migrate away from deprecated ICleanUpFixCore & CleanUpContextCore.