### PR TITLE
Add missing 'Test' annotation on testJava23Project.

### DIFF
--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporterTest.java
@@ -373,6 +373,7 @@ public class MavenProjectImporterTest extends AbstractMavenBasedTest {
 		assertHasErrors(project, "Preview features enabled at an invalid source release level");
 	}
 
+	@Test
 	public void testJava23Project() throws Exception {
 		IProject project = importMavenProject("salut-java23");
 		assertIsJavaProject(project);


### PR DESCRIPTION
Fixing https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3279 .