### PR TITLE
Add Markdown support (JEP 467) for Java 23.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/JavadocContentAccess2.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/JavadocContentAccess2.java
@@ -35,6 +35,7 @@ import org.eclipse.jdt.core.manipulation.internal.javadoc.CoreJavaDocSnippetStri
 import org.eclipse.jdt.core.manipulation.internal.javadoc.CoreJavadocAccess;
 import org.eclipse.jdt.core.manipulation.internal.javadoc.CoreJavadocAccessImpl;
 import org.eclipse.jdt.core.manipulation.internal.javadoc.CoreJavadocContentAccessUtility;
+import org.eclipse.jdt.core.manipulation.internal.javadoc.CoreMarkdownAccessImpl;
 import org.eclipse.jdt.core.manipulation.internal.javadoc.IJavadocContentFactory;
 import org.eclipse.jdt.core.manipulation.internal.javadoc.JavadocLookup;
 import org.eclipse.jdt.internal.ui.viewsupport.CoreJavaElementLinks;
@@ -120,7 +121,23 @@ public class JavadocContentAccess2 {
 		};
 	}
 
-	public static final IJavadocContentFactory JDT_LS_JAVADOC_CONTENT_FACTORY=new IJavadocContentFactory(){@Override public IJavadocAccess createJavadocAccess(IJavaElement element,Javadoc javadoc,String source,JavadocLookup lookup){if(lookup==null){return new JdtLsJavadocAccessImpl(element,javadoc,source);}else{return new JdtLsJavadocAccessImpl(element,javadoc,source,lookup);}}};
+	public static final IJavadocContentFactory JDT_LS_JAVADOC_CONTENT_FACTORY = new IJavadocContentFactory() {
+		@Override
+		public IJavadocAccess createJavadocAccess(IJavaElement element, Javadoc javadoc, String source, JavadocLookup lookup) {
+			if (source.startsWith("///")) { //$NON-NLS-1$
+				if (lookup == null) {
+					return new CoreMarkdownAccessImpl(element, javadoc, source);
+				} else {
+					return new CoreMarkdownAccessImpl(element, javadoc, source, lookup);
+				}
+			}
+			if (lookup == null) {
+				return new JdtLsJavadocAccessImpl(element, javadoc, source);
+			} else {
+				return new JdtLsJavadocAccessImpl(element, javadoc, source, lookup);
+			}
+		}
+	};
 
 	private static class JdtLsJavadocAccessImpl extends CoreJavadocAccessImpl {
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HoverHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HoverHandlerTest.java
@@ -745,6 +745,53 @@ public class HoverHandlerTest extends AbstractProjectsManagerBasedTest {
 		assertEquals("Unexpected hover " + signature, "ENUM1", signature.getValue());
 	}
 
+	@Test
+	public void testHoverMarkdownComment() throws Exception {
+		String name = "java23";
+		importProjects("eclipse/" + name);
+		IProject project = getProject(name);
+		IJavaProject javaProject = JavaCore.create(project);
+		IPackageFragmentRoot packageFragmentRoot = javaProject.getPackageFragmentRoot(project.getFolder("src/main/java"));
+		IPackageFragment pack1 = packageFragmentRoot.createPackageFragment("test", false, null);
+		StringBuilder buf = new StringBuilder();
+		//@formatter:off
+		buf.append("package test;\n"
+				+ "/// ## TestClass\n"
+				+ "///\n"
+				+ "/// Paragraph\n"
+				+ "///\n"
+				+ "/// - item 1\n"
+				+ "/// - _item 2_\n"
+				+ "    public class Test {\n"
+				+ "    /// ### m()\n"
+				+ "    ///\n"
+				+ "    /// Paragraph with _emphasis_\n"
+				+ "    /// - item 1\n"
+				+ "    /// - item 2\n"
+				+ "    /// @param i an _integer_ !\n"
+				+ "    void m(int i) {\n"
+				+ "    }\n"
+				+ "}\n"
+				+ "");
+		//@formatter:on
+		ICompilationUnit cu = pack1.createCompilationUnit("Test.java", buf.toString(), false, null);
+		Hover hover = getHover(cu, 7, 18);
+		assertNotNull(hover);
+		assertEquals(2, hover.getContents().getLeft().size());
+
+		//@formatter:off
+		String expectedJavadoc = "## TestClass ##\n"
+				+ "\n"
+				+ "Paragraph\n"
+				+ "\n"
+				+ " *  item 1\n"
+				+ " *  *item 2*";
+		//@formatter:on
+		String actual = hover.getContents().getLeft().get(1).getLeft();
+		actual = ResourceUtils.dos2Unix(actual);
+		assertEquals("Unexpected hover ", expectedJavadoc, actual);
+	}
+
 	private String getTitleHover(ICompilationUnit cu, int line, int character) {
 		// when
 		Hover hover = getHover(cu, line, character);


### PR DESCRIPTION
- Delegate to markdown content access when javadoc node starts with '///'
- Add basic testcase

A continuation of https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/3278 .

Note : Links currently don't work. I did try to define a `private static class JdtLsMarkdownAccessImpl extends CoreMarkdownAccessImpl` that copies over the link creation from https://github.com/eclipse-jdtls/eclipse.jdt.ls/blob/12b4cbce0a33f9fa3e81e574fc7fe34873bc84f0/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/JavadocContentAccess2.java#L308-L322 . It doesn't seem to work because markdown links seem to be converted to the form `<code><a href="[url]">[label]</a></code>` and Remark doesn't seem to like preserving links within `<code>` blocks.