### PR TITLE
Remove unnecessary newText field from the SnippetTextEdit.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/lsp4j/extended/SnippetTextEdit.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/lsp4j/extended/SnippetTextEdit.java
@@ -20,7 +20,7 @@ public class SnippetTextEdit extends TextEdit {
 	StringValue snippet;
 
 	public SnippetTextEdit(Range range, String snippet) {
-		super(range, "");
+		setRange(range);
 		this.snippet = new StringValue(snippet);
 	}
 


### PR DESCRIPTION
- SnippetTextEdit inherits from TextEdit, but it should not initialize 'newText' to an empty String when the 'snippet' field will have the text defined
- Fixes https://github.com/redhat-developer/vscode-java/issues/3780