### PR TITLE
java.diagnostic.filter is broken on Windows

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -1869,8 +1870,13 @@ public final class JDTUtils {
 		java.nio.file.Path[] path = new java.nio.file.Path[1];
 		try {
 			path[0] = Paths.get(uri.toURL().getPath());
-		} catch (MalformedURLException e) {
-			path[0] = Paths.get(uri);
+		} catch (MalformedURLException | InvalidPathException e) {
+			try {
+				path[0] = Paths.get(uri);
+			} catch (Exception e1) {
+				JavaLanguageServerPlugin.logException(e1);
+				return false;
+			}
 		}
 		FileSystem fileSystems = path[0].getFileSystem();
 		return !patterns.stream().filter(pattern -> fileSystems.getPathMatcher("glob:" + pattern).matches(path[0])).collect(Collectors.toList()).isEmpty();


### PR DESCRIPTION
Fixes #3290 
Without the PR, the `WorkspaceDiagnosticsHandlerTest.testDiagnosticFiltering()` test fails on Windows.
The fix has been based on https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/3290#issue-2552110655
@Kamii0909 Thanks!