### PR TITLE
Remove unnecessary ECJ compiler override.

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -28,7 +28,7 @@
 			<unit id="org.eclipse.pde.junit.runtime" version="0.0.0" />
 			<unit id="org.eclipse.jdt.junit4.runtime" version="0.0.0" />
 			<unit id="org.eclipse.jdt.core.manipulation" version="0.0.0" />
-            <repository location="https://download.eclipse.org/eclipse/updates/4.34-I-builds/I20241014-1810/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.34-I-builds/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.jdt.core.compiler.batch" version="0.0.0"/>

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,6 @@
 		<!-- skip for local builds, set it to true on Eclipse.org infrastructure -->
 		<cbi.jarsigner.skip>true</cbi.jarsigner.skip>
 		<generateSourceRef>true</generateSourceRef>
-		<cbi-jdt-repo.url>https://repo.eclipse.org/content/repositories/eclipse-staging/</cbi-jdt-repo.url>
-		<cbi-ecj-version>3.39.0.v20240820-0604</cbi-ecj-version>
 	</properties>
 	<modules>
 		<module>org.eclipse.jdt.ls.target</module>
@@ -193,13 +191,6 @@
 					<groupId>org.eclipse.tycho</groupId>
 					<artifactId>tycho-compiler-plugin</artifactId>
 					<version>${tycho-version}</version>
-					<dependencies>
-						<dependency>
-							<groupId>org.eclipse.jdt</groupId>
-							<artifactId>ecj</artifactId>
-							<version>${cbi-ecj-version}</version>
-						</dependency>
-					</dependencies>
 					<configuration>
 						<compilerArgs>
 							<args>-verbose</args>
@@ -357,16 +348,6 @@
 		<pluginRepository>
 			<id>cbi-release</id>
 			<url>https://repo.eclipse.org/content/repositories/cbi-releases/</url>
-		</pluginRepository>
-		<pluginRepository>
-			<id>cbi-jdt</id>
-			<url>${cbi-jdt-repo.url}</url>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
 		</pluginRepository>
 	</pluginRepositories>
 	<distributionManagement>


### PR DESCRIPTION
- Where 'javac' compiler not specified (defaulting to ECJ), the version specified by Tycho should be used
- Use 4.34-I-builds "latest" repo to keep up to date with the jdt-core-incubator Jenkins generated repo