### PR TITLE
Fix o.e.jdt.ls.repository so that it may be reused to build JDT-LS.

### DIFF
--- a/org.eclipse.jdt.ls.repository/category.xml
+++ b/org.eclipse.jdt.ls.repository/category.xml
@@ -6,6 +6,9 @@
    <bundle id="org.eclipse.jdt.ls.tests" version="0.0.0">
     <category name="jdt.ls.sdk" />
    </bundle>
+   <bundle id="org.eclipse.jdt.ls.filesystem" version="0.0.0">
+    <category name="jdt.ls" />
+   </bundle>
    <bundle id="org.eclipse.jdt.ls.logback.appender" version="0.0.0">
     <category name="jdt.ls" />
    </bundle>
@@ -15,9 +18,24 @@
    <bundle id="org.eclipse.jdt.ls.tests.source" version="0.0.0">
    	<category name="jdt.ls.sdk" />
    </bundle>
+   <bundle id="org.eclipse.jdt.ls.filesystem.source" version="0.0.0">
+    <category name="jdt.ls.sdk" />
+   </bundle>
    <bundle id="org.eclipse.jdt.ls.logback.appender.source" version="0.0.0">
     <category name="jdt.ls.sdk" />
    </bundle>
+
+   <feature id="org.eclipse.equinox.executable" version="0.0.0"/>
+   <bundle id="jakarta.servlet-api" version="0.0.0"/>
+   <bundle id="org.apache.felix.scr" version="0.0.0"/>
+   <bundle id="org.eclipse.ant.core" version="0.0.0"/>
+   <bundle id="org.eclipse.compare.core" version="0.0.0"/>
+   <bundle id="org.eclipse.equinox.security.linux" version="0.0.0" os="linux"/>
+   <bundle id="org.eclipse.equinox.security.macosx" version="0.0.0" os="macosx"/>
+   <bundle id="org.eclipse.equinox.security.win32" version="0.0.0" os="win32"/>
+   <bundle id="org.eclipse.osgi.compatibility.state" version="0.0.0"/>
+   <bundle id="org.eclipse.osgi.services" version="0.0.0"/>
+
    <category-def name="jdt.ls" label="JDT Language Server"/>
    <category-def name="jdt.ls.sdk" label="JDT Language Server (Developer Resources)"/>
 </site>


### PR DESCRIPTION
Should make https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/3001 possible.

This is more of a convenience for those wishing to reproduce the builds.

I've added some bundles that, while not required to compile the JDT-LS bundles, are used in the language server product. As a result, they need to be in the generated repository, or other consumes would not be able to build the products module.