### PR TITLE
Add code action for unused pattern variable / unused lambda parameter.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpRegistry.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpRegistry.java
@@ -55,7 +55,8 @@ public class CleanUpRegistry {
 			new LambdaExpressionCleanup(),
 			new TryWithResourceCleanUp(),
 			new LambdaExpressionAndMethodRefCleanUp(),
-			new OrganizeImportsCleanup());
+			new OrganizeImportsCleanup(),
+			new RenameUnusedLocalVariableCleanup());
 
 		// Store in a Map so that they can be accessed by ID quickly
 		cleanUps = new HashMap<>();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/RenameUnusedLocalVariableCleanup.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/RenameUnusedLocalVariableCleanup.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.cleanup;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
+import org.eclipse.jdt.internal.corext.fix.RenameUnusedVariableFixCore;
+import org.eclipse.jdt.ui.cleanup.CleanUpContext;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
+
+/**
+ * Represents a clean up that renames unused lambda parameter identifier to an
+ * underscore (_)
+ */
+public class RenameUnusedLocalVariableCleanup implements ISimpleCleanUp {
+
+	private static final List<String> COMPILER_OPTS = Arrays.asList(JavaCore.COMPILER_PB_UNUSED_LAMBDA_PARAMETER, JavaCore.COMPILER_PB_UNUSED_LOCAL);
+
+	@Override
+	public Collection<String> getIdentifiers() {
+		return List.of("removeUnusedLambdaParameters", CleanUpConstants.REMOVE_UNUSED_CODE_LOCAL_VARIABLES);
+	}
+
+	@Override
+	public ICleanUpFix createFix(CleanUpContext context) throws CoreException {
+		return RenameUnusedVariableFixCore.createCleanUp(context.getAST(), true);
+	}
+
+	@Override
+	public List<String> getRequiredCompilerMarkers() {
+		return COMPILER_OPTS;
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
@@ -342,6 +342,7 @@ public class QuickFixProcessor {
 			case IProblem.UnusedPrivateType:
 			case IProblem.LocalVariableIsNeverUsed:
 			case IProblem.ArgumentIsNeverUsed:
+			case IProblem.LambdaParameterIsNeverUsed:
 			case IProblem.UnusedPrivateField:
 				LocalCorrectionsSubProcessor.addUnusedMemberProposal(context, problem, proposals);
 				break;


### PR DESCRIPTION
- Based on https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1701
- [x] Add it to the cleanup registry
- [x] Maybe add some testcases