### PR TITLE
Restore JavaSE-17 as the BREE for org.eclipse.jdt.ls.tests.

### DIFF
--- a/org.eclipse.jdt.ls.tests/.classpath
+++ b/org.eclipse.jdt.ls.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-23"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/">
 		<attributes>

--- a/org.eclipse.jdt.ls.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.tests/META-INF/MANIFEST.MF
@@ -5,10 +5,8 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.jdt.ls.tests;singleton:=true
 Bundle-Version: 1.42.0.qualifier
 Export-Package: org.eclipse.jdt.ls.core.internal;x-friends:="org.eclipse.jdt.ls.tests.syntaxserver"
-Bundle-RequiredExecutionEnvironment: JavaSE-23
-Import-Package: org.osgi.framework;version="1.3.0",
- org.eclipse.jdt.internal.javac,
- org.eclipse.jdt.internal.javac.dom
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Import-Package: org.osgi.framework;version="1.3.0"
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.jdt.ls.core,

--- a/org.eclipse.jdt.ls.tests/pom.xml
+++ b/org.eclipse.jdt.ls.tests/pom.xml
@@ -61,6 +61,33 @@
 	</build>
 	<profiles>
 		<profile>
+			<id>javac</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-toolchains-plugin</artifactId>
+						<version>3.2.0</version>
+						<executions>
+							<execution>
+								<phase>validate</phase>
+								<goals>
+									<goal>toolchain</goal>
+								</goals>
+								<configuration>
+									<toolchains>
+										<jdk>
+											<id>JavaSE-23</id>
+										</jdk>
+									</toolchains>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
 			<id>lombok</id>
 			<activation>
 				<property>
@@ -84,17 +111,6 @@
 									<version>1.18.32</version>
 								</artifactItem>
 							</artifactItems>
-						</configuration>
-					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-toolchains-plugin</artifactId>
-						<configuration>
-							<toolchains>
-								<jdk>
-									<id>JavaSE-23</id>
-								</jdk>
-							</toolchains>
 						</configuration>
 					</plugin>
 				</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -342,6 +342,26 @@
 			<properties>
 				<tycho.testArgLine>-DICompilationUnitResolver=org.eclipse.jdt.core.dom.JavacCompilationUnitResolver -DCompilationUnit.DOM_BASED_OPERATIONS=true -DAbstractImageBuilder.compiler=org.eclipse.jdt.internal.javac.JavacCompiler --add-opens jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-opens jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.taglets.snippet=ALL-UNNAMED --add-opens jdk.javadoc/jdk.javadoc.internal.doclets.formats.html.taglets=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.platform=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.resources=ALL-UNNAMED</tycho.testArgLine>
 			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>target-platform-configuration</artifactId>
+						<version>${tycho-version}</version>
+						<configuration>
+							<dependency-resolution>
+								<extraRequirements>
+									<requirement>
+										<type>eclipse-plugin</type>
+										<id>org.eclipse.jdt.core.javac</id>
+										<versionRange>0.0.0</versionRange>
+									</requirement>
+								</extraRequirements>
+							</dependency-resolution>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
 		</profile>
 	</profiles>
 	<pluginRepositories>


### PR DESCRIPTION
- Remove dependency from o.e.jdt.ls.tests to org.eclipse.jdt.core.javac
- Use extraRequirements in the target platform configuration to ensure org.eclipse.jdt.core.javac ends up in the test target platform
- Fixes https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/3326

@mickaelistria , let me know if this makes sense. It seems to be working.