### PR TITLE
Rename 'removeUnusedLambdaParameters' to 'renameUnusedLocalVariables'.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/RenameUnusedLocalVariableCleanup.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/RenameUnusedLocalVariableCleanup.java
@@ -33,7 +33,7 @@ public class RenameUnusedLocalVariableCleanup implements ISimpleCleanUp {
 
 	@Override
 	public Collection<String> getIdentifiers() {
-		return List.of("removeUnusedLambdaParameters", CleanUpConstants.REMOVE_UNUSED_CODE_LOCAL_VARIABLES);
+		return List.of("renameUnusedLocalVariables", CleanUpConstants.REMOVE_UNUSED_CODE_LOCAL_VARIABLES);
 	}
 
 	@Override

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpsTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpsTest.java
@@ -670,7 +670,7 @@ public class CleanUpsTest extends AbstractMavenBasedTest {
 				    }
 				}
 				""";
-		List<TextEdit> textEdits = registry.getEditsForAllActiveCleanUps(new TextDocumentIdentifier(uri), Arrays.asList("removeUnusedLambdaParameters"), monitor);
+		List<TextEdit> textEdits = registry.getEditsForAllActiveCleanUps(new TextDocumentIdentifier(uri), Arrays.asList("renameUnusedLocalVariables"), monitor);
 		String actual = TextEditUtil.apply(unit, textEdits);
 		assertEquals(expected, actual);
 	}


### PR DESCRIPTION
- The clean up now supports additional cases from upstream.
- Continuing from https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3319
- See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1762