### PR TITLE
Update JDT core preferences for the o.e.jdt.ls.tests bundle.

### DIFF
--- a/org.eclipse.jdt.ls.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.jdt.ls.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,14 +1,14 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=23
-org.eclipse.jdt.core.compiler.compliance=23
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.discouragedReference=ignore
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=23
+org.eclipse.jdt.core.compiler.source=17
 org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines=2147483647
 org.eclipse.jdt.core.formatter.align_type_members_on_columns=false
 org.eclipse.jdt.core.formatter.alignment_for_additive_operator=16


### PR DESCRIPTION
- Project resolution fails to resolve the '23' references now that we have set the tests back to '17'
- Continuation of https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3327 .