### PR TITLE
Bypass AST model -> HTML Conversion for Markdown Comments

### DIFF
--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HoverHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HoverHandlerTest.java
@@ -780,12 +780,10 @@ public class HoverHandlerTest extends AbstractProjectsManagerBasedTest {
 		assertEquals(2, hover.getContents().getLeft().size());
 
 		//@formatter:off
-		String expectedJavadoc = "## TestClass ##\n"
-				+ "\n"
-				+ "Paragraph\n"
-				+ "\n"
-				+ " *  item 1\n"
-				+ " *  *item 2*";
+		String expectedJavadoc = "## TestClass  \n"
+				+ "Paragraph  \n"
+				+ "- item 1\n"
+				+ "- _item 2_";
 		//@formatter:on
 		String actual = hover.getContents().getLeft().get(1).getLeft();
 		actual = ResourceUtils.dos2Unix(actual);


### PR DESCRIPTION
- For JEP 467, JDT parses the markdown comments into the AST Model as a Javadoc node (TagElement & TextElement and Name/MemberRef/MethodRef for links), converting to HTML. JDT-LS converts the HTML back to Markdown using Remark.
- This bypasses the AST model -> HTML conversion by attempting to render the Javadoc comments directly as Markdown, in part because the content is already (mostly) Markdown

**Before**
![Screenshot from 2024-11-22 16-21-15](https://github.com/user-attachments/assets/a990536c-9cdd-4173-b41c-47a00e6abda3)

**After**
![image](https://github.com/user-attachments/assets/22811c75-7f2b-4639-9f01-2b10dce6b26e)

Things left to address :
- [ ] ~~As seen from the screenshot, we introduce a newline after each new `/// ...`, while I think we should treat consecutive text elements as a continuation. An empty `///` is meant to signify a newline IIRC.~~ **Update:** This can't be done because the AST model doesn't include empty `///` lines currently. At least we no longer insert a newline for every now `///` line.
- [ ] For some reason links to package declarations don't resolve (eg. `java.util` but I'm not sure why. Seems a corner case
- [x] Certain javadoc tags (eg. `@see`, `@throws`/`@exception` are meant to be combined under a single heading, and not listed separately (see screenshot).
