### PR TITLE
Guard against snippet position groups with undefined (-1) offsets.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetUtils.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.IBuffer;
@@ -118,6 +119,11 @@ public class SnippetUtils {
 			LinkedProposalPositionGroupCore group = it.next();
 			ProposalCore[] proposalList = group.getProposals();
 			PositionInformation[] positionList = group.getPositions();
+			// Some positions might be undefined offset = -1
+			// eg. AST Nodes created but not applied to model
+			positionList = Arrays.asList(positionList).stream()
+					.filter(pi -> pi.getOffset() >= 0)
+					.collect(Collectors.toList()).toArray(new PositionInformation[0]);
 			// Sorts in ascending order to ensure first position in list has the smallest offset
 			Arrays.sort(positionList, (p1, p2) -> {
 				return p1.getOffset() - p2.getOffset();


### PR DESCRIPTION
- A linked correction proposal group may refer to positions whose offset cannot be resolved
- Add testcase
- Fixes redhat-developer/vscode-java#3905

@hopehadfield , if you're interested, it'd be good to know if you agree that this would have always been an issue (I did notice the exact same quick-fix has the exact same problem in Eclipse). I could have sworn there was a case where we discussed how to translate to relative offsets within the edit, but can't really see where we do that. Maybe when we considered splitting up the edits so it wasn't just one giant thing ?

Either way, the issue here is that we want to sync up 2 or more positions inside the actual edit, but we can't because the edit hasn't been applied so there wouldn't be an offset in the sources.