### PR TITLE
React to removal of 'is60orHigher' from JDT.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/ParameterGuesser.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/ParameterGuesser.java
@@ -212,7 +212,7 @@ public class ParameterGuesser {
 		if (code != null) {
 			return code;
 		}
-		if (fEnclosingElement != null && JavaModelUtil.is50OrHigher(fEnclosingElement.getJavaProject())) {
+		if (fEnclosingElement != null) {
 			if (code == PrimitiveType.SHORT) {
 				if ("java.lang.Short".equals(type)) { //$NON-NLS-1$
 					return code;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
@@ -40,7 +40,6 @@ import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.manipulation.CUCorrectionProposalCore;
 import org.eclipse.jdt.core.manipulation.ChangeCorrectionProposalCore;
-import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.jdt.internal.ui.text.correction.IProposalRelevance;
 import org.eclipse.jdt.internal.ui.text.correction.UnInitializedFinalFieldBaseSubProcessor;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.AddImportCorrectionProposalCore;
@@ -683,9 +682,7 @@ public class QuickFixProcessor {
 				String str = problem.toString();
 				System.out.println(str);
 		}
-		if (JavaModelUtil.is50OrHigher(context.getCompilationUnit().getJavaProject())) {
-			SuppressWarningsSubProcessor.addSuppressWarningsProposals(context, problem, proposals);
-		}
+		SuppressWarningsSubProcessor.addSuppressWarningsProposals(context, problem, proposals);
 		// ConfigureProblemSeveritySubProcessor.addConfigureProblemSeverityProposal(context,
 		// problem, proposals);
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateToStringHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateToStringHandler.java
@@ -26,7 +26,6 @@ import org.eclipse.jdt.core.IField;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.IType;
-import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -41,7 +40,6 @@ import org.eclipse.jdt.internal.corext.codemanipulation.tostringgeneration.Gener
 import org.eclipse.jdt.internal.corext.codemanipulation.tostringgeneration.ToStringGenerationSettingsCore;
 import org.eclipse.jdt.internal.corext.codemanipulation.tostringgeneration.ToStringGenerationSettingsCore.CustomBuilderSettings;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
-import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.corrections.DiagnosticsHelper;
 import org.eclipse.jdt.ls.core.internal.handlers.JdtDomModels.BindingComparator;
@@ -199,10 +197,6 @@ public class GenerateToStringHandler {
 		settings.limitElements = preferences.getGenerateToStringLimitElements() > 0;
 		settings.limitValue = Math.max(preferences.getGenerateToStringLimitElements(), 0);
 		settings.customBuilderSettings = new CustomBuilderSettings();
-		if (type.getCompilationUnit().getJavaProject() != null) {
-			String version = type.getCompilationUnit().getJavaProject().getOption(JavaCore.COMPILER_SOURCE, true);
-			settings.is60orHigher = !JavaModelUtil.isVersionLessThan(version, JavaCore.VERSION_1_6);
-		}
 
 		return generateToString(type, fields, settings, insertPosition, monitor);
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateToStringHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateToStringHandlerTest.java
@@ -218,7 +218,6 @@ public class GenerateToStringHandlerTest extends AbstractSourceTestCase {
 		settings.limitElements = true;
 		settings.limitValue = 10;
 		settings.customBuilderSettings = new CustomBuilderSettings();
-		settings.is60orHigher = true;
 		generateToString(unit.findPrimaryType(), settings);
 
 		/* @formatter:off */


### PR DESCRIPTION
- JavaModelUtil.is50OrHigher has also been removed
- Assume such expressions are always true as a lower compliance is no longer supported