### PR TITLE
Implementation code lens for non interface/abstract base types/methods.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeLensHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeLensHandler.java
@@ -22,7 +22,6 @@ import java.util.List;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
@@ -233,17 +232,15 @@ public class CodeLensHandler {
 				}
 			}
 			String implementationsPreference = preferenceManager.getPreferences().getImplementationsCodeLens();
-			if (("all".equals(implementationsPreference) || "types".equals(implementationsPreference)) && element instanceof IType type) {
-				if (type.isInterface() || Flags.isAbstract(type.getFlags())) {
-					CodeLens lens = getCodeLens(IMPLEMENTATION_TYPE, element, typeRoot);
-					if (lens != null) {
-						lenses.add(lens);
-					}
+			if (("all".equals(implementationsPreference) || "types".equals(implementationsPreference)) && element instanceof IType) {
+				CodeLens lens = getCodeLens(IMPLEMENTATION_TYPE, element, typeRoot);
+				if (lens != null) {
+					lenses.add(lens);
 				}
 			}
 
 			if (("all".equals(implementationsPreference) || "methods".equals(implementationsPreference)) && element instanceof IMethod methodElement) {
-				if ((methodElement.getParent() instanceof IType parentType && parentType.isInterface()) || Flags.isAbstract(methodElement.getFlags())) {
+				if (methodElement.getParent() instanceof IType) {
 					CodeLens lens = getCodeLens(IMPLEMENTATION_TYPE, element, typeRoot);
 					if (lens != null) {
 						lenses.add(lens);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeLensHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeLensHandlerTest.java
@@ -237,6 +237,28 @@ public class CodeLensHandlerTest extends AbstractProjectsManagerBasedTest {
 	}
 
 	@Test
+	public void testEnableImplementationsCodeLensSymbolsForBaseTypes() throws Exception {
+		Preferences implementationsCodeLenses = Preferences.createFrom(Collections.singletonMap(Preferences.IMPLEMENTATIONS_CODE_LENS_KEY, "all"));
+		Mockito.reset(preferenceManager);
+		when(preferenceManager.getPreferences()).thenReturn(implementationsCodeLenses);
+		handler = new CodeLensHandler(preferenceManager);
+
+		String payload = createCodeLensSymbolsRequest("src/java/Foo.java");
+		CodeLensParams codeLensParams = getParams(payload);
+		String uri = codeLensParams.getTextDocument().getUri();
+		assertFalse(uri.isEmpty());
+
+		//when
+		List<CodeLens> result = handler.getCodeLensSymbols(uri, monitor);
+
+		//then
+		assertEquals(6, result.size());
+		@SuppressWarnings("unchecked")
+		long implementations = result.stream().filter(cl -> "implementations".equals(((List<Object>) cl.getData()).get(2))).count();
+		assertEquals(3, implementations);
+	}
+
+	@Test
 	public void testDisableImplementationsCodeLensSymbols() throws Exception {
 		Preferences noImplementationsCodeLenses = Preferences.createFrom(Collections.singletonMap(Preferences.IMPLEMENTATIONS_CODE_LENS_KEY, "types"));
 		Mockito.reset(preferenceManager);


### PR DESCRIPTION
**Before**
![Screenshot from 2025-01-03 00-11-29](https://github.com/user-attachments/assets/3ff8fa6e-c4ce-4bee-b0d1-b56601954703)

**After**
![Screenshot from 2025-01-03 00-15-50](https://github.com/user-attachments/assets/5f35f225-4b37-4028-be6a-2e47a4487914)

- A base type/method that that is not an interface/abstract (or a member of an interface/abstract class) may still be inherited and that information should be indicated in the implementation code lens
- Add testcase

CC'ing @fbricon & @snjeza .

From https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/301#issuecomment-314597718 , it almost seems like you were aware of this and fine with it. I mean sure, clients might have "Go To Implementations" / "Find All Implementations" which will get you those 6 locations, but might be confusing for users to see implementations work via. code lens for interfaces, and abstract classes but not regular classes. Was there some performance consideration ?