### PR TITLE
Avoid duplicate suppress warning suggestions through new API method.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/SuppressWarningsSubProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/SuppressWarningsSubProcessor.java
@@ -60,4 +60,14 @@ public class SuppressWarningsSubProcessor extends SuppressWarningsBaseSubProcess
 		return CodeActionHandler.wrap(proposal, CodeActionKind.QuickFix);
 	}
 
+	@Override
+	protected boolean alreadyHasProposal(Collection<ProposalKindWrapper> proposals, String warningToken) {
+		for (ProposalKindWrapper element : proposals) {
+			if (element.getProposal() instanceof SuppressWarningsProposalCore swp && warningToken.equals(swp.getWarningToken())) {
+				return true; // only one at a time
+			}
+		}
+		return false;
+	}
+
 }


### PR DESCRIPTION
- See https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/1942/
- Implement alreadyHasProposal to avoid duplicates

I don't think we are seeing these duplicate entries, so it's worth me having a quick look to see why that is.

**Update:**

It's because of https://github.com/eclipse-jdtls/eclipse.jdt.ls/blob/78d72ee9b4e5007248f156efa934cc78173ddc7f/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java#L192-L194

https://github.com/eclipse-jdtls/eclipse.jdt.ls/blob/78d72ee9b4e5007248f156efa934cc78173ddc7f/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java#L406-L425

We remove duplicates on our end also