### PR TITLE
Reuse quick fixes from LocalCorrectionsBaseSubProcessor.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
@@ -232,11 +232,17 @@ public class QuickFixProcessor {
 			case IProblem.SealedNotDirectSuperInterface:
 			case IProblem.SealedNotDirectSuperClass:
 				LocalCorrectionsSubProcessor.addSealedAsDirectSuperTypeProposal(context, problem, proposals);
+				break;
 			case IProblem.SealedSuperClassDoesNotPermit:
 			case IProblem.SealedSuperInterfaceDoesNotPermit:
 				LocalCorrectionsSubProcessor.addTypeAsPermittedSubTypeProposal(context, problem, proposals);
+				break;
 			case IProblem.StaticMethodRequested:
 			case IProblem.NonStaticFieldFromStaticInvocation:
+				LocalCorrectionsSubProcessor.addObjectReferenceProposal(context, problem, proposals);
+				LocalCorrectionsSubProcessor.addVariableReferenceProposal(context, problem, proposals);
+				LocalCorrectionsSubProcessor.addNewObjectProposal(context, problem, proposals);
+				//$FALL-THROUGH$
 			case IProblem.InstanceMethodDuringConstructorInvocation:
 			case IProblem.InstanceFieldDuringConstructorInvocation:
 				ModifierCorrectionSubProcessor.addNonAccessibleReferenceProposal(context, problem, proposals, ModifierCorrectionSubProcessor.TO_STATIC, IProposalRelevance.CHANGE_MODIFIER_TO_STATIC);
@@ -353,29 +359,24 @@ public class QuickFixProcessor {
 			// problem, proposals, ModifierCorrectionSubProcessor.TO_NON_PRIVATE,
 			// IProposalRelevance.CHANGE_VISIBILITY_TO_NON_PRIVATE);
 			// break;
-			// case IProblem.SuperfluousSemicolon:
-			// LocalCorrectionsSubProcessor.addSuperfluousSemicolonProposal(context,
-			// problem, proposals);
-			// break;
+			case IProblem.SuperfluousSemicolon:
+				LocalCorrectionsSubProcessor.addSuperfluousSemicolonProposal(context, problem, proposals);
+				break;
 			case IProblem.UnnecessaryCast:
 				LocalCorrectionsSubProcessor.addUnnecessaryCastProposal(context, problem, proposals);
 				break;
-			// case IProblem.UnnecessaryInstanceof:
-			// LocalCorrectionsSubProcessor.addUnnecessaryInstanceofProposal(context,
-			// problem, proposals);
-			// break;
+			case IProblem.UnnecessaryInstanceof:
+				LocalCorrectionsSubProcessor.addUnnecessaryInstanceofProposal(context, problem, proposals);
+				break;
 			// case IProblem.UnusedMethodDeclaredThrownException:
 			// case IProblem.UnusedConstructorDeclaredThrownException:
 			// LocalCorrectionsSubProcessor.addUnnecessaryThrownExceptionProposal(context,
 			// problem, proposals);
 			// break;
-			// case IProblem.UnqualifiedFieldAccess:
-			// GetterSetterCorrectionSubProcessor.addGetterSetterProposal(context,
-			// problem, proposals,
-			// IProposalRelevance.GETTER_SETTER_UNQUALIFIED_FIELD_ACCESS);
-			// LocalCorrectionsSubProcessor.addUnqualifiedFieldAccessProposal(context,
-			// problem, proposals);
-			// break;
+			case IProblem.UnqualifiedFieldAccess:
+				// GetterSetterCorrectionSubProcessor.addGetterSetterProposal(context, problem, proposals, IProposalRelevance.GETTER_SETTER_UNQUALIFIED_FIELD_ACCESS);
+				LocalCorrectionsSubProcessor.addUnqualifiedFieldAccessProposal(context, problem, proposals);
+				break;
 			// case IProblem.Task:
 			// proposals.add(new TaskMarkerProposal(context.getCompilationUnit(),
 			// problem, 10));
@@ -429,14 +430,12 @@ public class QuickFixProcessor {
 			case IProblem.MissingSerialVersion:
 				SerialVersionSubProcessor.getSerialVersionProposals(context, problem, proposals);
 				break;
-			// case IProblem.UnnecessaryElse:
-			// LocalCorrectionsSubProcessor.getUnnecessaryElseProposals(context,
-			// problem, proposals);
-			// break;
-			// case IProblem.SuperclassMustBeAClass:
-			// LocalCorrectionsSubProcessor.getInterfaceExtendsClassProposals(context,
-			// problem, proposals);
-			// break;
+			case IProblem.UnnecessaryElse:
+				LocalCorrectionsSubProcessor.addUnnecessaryElseProposals(context, problem, proposals);
+				break;
+			case IProblem.SuperclassMustBeAClass:
+				LocalCorrectionsSubProcessor.addInterfaceExtendsClassProposals(context, problem, proposals);
+				break;
 			case IProblem.CodeCannotBeReached:
 			case IProblem.DeadCode:
 				LocalCorrectionsSubProcessor.getUnreachableCodeProposals(context, problem, proposals);
@@ -513,15 +512,14 @@ public class QuickFixProcessor {
 			// ReorgCorrectionsSubProcessor.getAccessRulesProposals(context,
 			// problem, proposals);
 			// break;
-			// case IProblem.AssignmentHasNoEffect:
-			// LocalCorrectionsSubProcessor.getAssignmentHasNoEffectProposals(context,
-			// problem, proposals);
-			// break;
-			// case IProblem.UnsafeTypeConversion:
-			// case IProblem.RawTypeReference:
-			// case IProblem.UnsafeRawMethodInvocation:
-			// LocalCorrectionsSubProcessor.addDeprecatedFieldsToMethodsProposals(context,
-			// problem, proposals);
+			case IProblem.AssignmentHasNoEffect:
+				LocalCorrectionsSubProcessor.addAssignmentHasNoEffectProposals(context, problem, proposals);
+				break;
+			case IProblem.UnsafeTypeConversion:
+			case IProblem.RawTypeReference:
+			case IProblem.UnsafeRawMethodInvocation:
+				LocalCorrectionsSubProcessor.addDeprecatedFieldsToMethodsProposals(context, problem, proposals);
+				break;
 			// //$FALL-THROUGH$
 			// case IProblem.UnsafeElementTypeConversion:
 			// LocalCorrectionsSubProcessor.addTypePrametersToRawTypeReference(context,
@@ -531,10 +529,9 @@ public class QuickFixProcessor {
 			// LocalCorrectionsSubProcessor.addRemoveRedundantTypeArgumentsProposals(context,
 			// problem, proposals);
 			// break;
-			// case IProblem.FallthroughCase:
-			// LocalCorrectionsSubProcessor.addFallThroughProposals(context,
-			// problem, proposals);
-			// break;
+			case IProblem.FallthroughCase:
+				LocalCorrectionsSubProcessor.addFallThroughProposals(context, problem, proposals);
+				break;
 			// case IProblem.UnhandledWarningToken:
 			// SuppressWarningsSubProcessor.addUnknownSuppressWarningProposals(context, problem, proposals);
 			// break;
@@ -554,6 +551,12 @@ public class QuickFixProcessor {
 			case IProblem.MissingDefaultCase:
 				LocalCorrectionsSubProcessor.addMissingDefaultCaseProposal(context, problem, proposals);
 				break;
+			case IProblem.IllegalTotalPatternWithDefault:
+				LocalCorrectionsSubProcessor.addRemoveDefaultCaseProposal(context, problem, proposals);
+				break;
+			case IProblem.IllegalFallthroughToPattern:
+				LocalCorrectionsSubProcessor.addFallThroughProposals(context, problem, proposals);
+				break;
 			case IProblem.MissingEnumConstantCaseDespiteDefault:
 				LocalCorrectionsSubProcessor.getMissingEnumConstantCaseProposals(context, problem, proposals);
 				LocalCorrectionsSubProcessor.addCasesOmittedProposals(context, problem, proposals);
@@ -564,6 +567,12 @@ public class QuickFixProcessor {
 				break;
 			case IProblem.NotAccessibleType:
 				GradleCompatibilityProcessor.getGradleCompatibilityProposals(context, problem, proposals);
+				break;
+			case IProblem.AbstractServiceImplementation:
+			case IProblem.ProviderMethodOrConstructorRequiredForServiceImpl:
+			case IProblem.ServiceImplDefaultConstructorNotPublic:
+				// LocalCorrectionsSubProcessor.addServiceProviderProposal(context, problem, proposals);
+				LocalCorrectionsSubProcessor.addServiceProviderConstructorProposals(context, problem, proposals);
 				break;
 			// case IProblem.MissingSynchronizedModifierInInheritedMethod:
 			// ModifierCorrectionSubProcessor.addSynchronizedMethodProposal(context,
@@ -652,10 +661,9 @@ public class QuickFixProcessor {
 			// NullAnnotationsCorrectionProcessor.addReturnAndArgumentTypeProposal(context,
 			// problem, ChangeKind.OVERRIDDEN, proposals);
 			// break;
-			// case IProblem.IllegalQualifiedEnumConstantLabel:
-			// LocalCorrectionsSubProcessor.addIllegalQualifiedEnumConstantLabelProposal(context,
-			// problem, proposals);
-			// break;
+			case IProblem.IllegalQualifiedEnumConstantLabel:
+				LocalCorrectionsSubProcessor.addIllegalQualifiedEnumConstantLabelProposal(context, problem, proposals);
+				break;
 			// case IProblem.DuplicateInheritedDefaultMethods:
 			// case IProblem.InheritedDefaultMethodConflictsWithOtherInherited:
 			// LocalCorrectionsSubProcessor.addOverrideDefaultMethodProposal(context,

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/NewCUProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/NewCUProposal.java
@@ -399,7 +399,8 @@ public class NewCUProposal extends ChangeCorrectionProposalCore {
 		}
 
 		IType cuType = fCompilationUnit.findPrimaryType();
-		String[] permittedNames = cuType.getPermittedSubtypeNames();
+		String[] permittedNames = cuType != null ? cuType.getPermittedSubtypeNames() : new String[0];
+		boolean isInterface = cuType != null ? cuType.isInterface() : false;
 		boolean isPermitted = Arrays.asList(permittedNames).stream().anyMatch(p -> name.equals(p));
 		if (isPermitted) {
 			buf.append("final ");
@@ -412,7 +413,7 @@ public class NewCUProposal extends ChangeCorrectionProposalCore {
 			case K_CLASS:
 				type = "class "; //$NON-NLS-1$
 				templateID = CodeGeneration.CLASS_BODY_TEMPLATE_ID;
-				superType = cuType.isInterface() ? "implements " : "extends ";
+				superType = isInterface ? "implements " : "extends ";
 				break;
 			case K_INTERFACE:
 				type = "interface "; //$NON-NLS-1$

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/LocalCorrectionQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/LocalCorrectionQuickFixTest.java
@@ -725,11 +725,14 @@ public class LocalCorrectionQuickFixTest extends AbstractQuickFixTest {
 		buf.append("package test1;\n");
 		buf.append("import java.io.IOException;\n");
 		buf.append("public class E {\n");
+		buf.append("    public void throwIOException () throws IOException {\n");
+		buf.append("        throw new IOException();\n");
+		buf.append("    }\n");
 		buf.append("    void foo() {\n");
 		buf.append("        try {\n");
-		buf.append("            throw new IOException();\n");
+		buf.append("            throwIOException();\n");
 		buf.append("        } catch (IOException e) {\n");
-		buf.append("            throw new IOException();\n");
+		buf.append("            throwIOException();\n");
 		buf.append("        }\n");
 		buf.append("    }\n");
 		buf.append("}\n");
@@ -739,11 +742,14 @@ public class LocalCorrectionQuickFixTest extends AbstractQuickFixTest {
 		buf.append("package test1;\n");
 		buf.append("import java.io.IOException;\n");
 		buf.append("public class E {\n");
+		buf.append("    public void throwIOException () throws IOException {\n");
+		buf.append("        throw new IOException();\n");
+		buf.append("    }\n");
 		buf.append("    void foo() throws IOException {\n");
 		buf.append("        try {\n");
-		buf.append("            throw new IOException();\n");
+		buf.append("            throwIOException();\n");
 		buf.append("        } catch (IOException e) {\n");
-		buf.append("            throw new IOException();\n");
+		buf.append("            throwIOException();\n");
 		buf.append("        }\n");
 		buf.append("    }\n");
 		buf.append("}\n");
@@ -754,12 +760,15 @@ public class LocalCorrectionQuickFixTest extends AbstractQuickFixTest {
 		buf.append("package test1;\n");
 		buf.append("import java.io.IOException;\n");
 		buf.append("public class E {\n");
+		buf.append("    public void throwIOException () throws IOException {\n");
+		buf.append("        throw new IOException();\n");
+		buf.append("    }\n");
 		buf.append("    void foo() {\n");
 		buf.append("        try {\n");
-		buf.append("            throw new IOException();\n");
+		buf.append("            throwIOException();\n");
 		buf.append("        } catch (IOException e) {\n");
 		buf.append("            try {\n");
-		buf.append("                throw new IOException();\n");
+		buf.append("                throwIOException();\n");
 		buf.append("            } catch (IOException e1) {\n");
 		buf.append("                // TODO Auto-generated catch block\n");
 		buf.append("                e1.printStackTrace();\n");
@@ -1031,8 +1040,11 @@ public class LocalCorrectionQuickFixTest extends AbstractQuickFixTest {
 		StringBuilder buf = new StringBuilder();
 		buf.append("package test1;\n" //
 				+ "public class E {\n" //
-				+ "    public void test () {\n" //
+				+ "    public void throwException () throws Exception {\n" //
 				+ "        throw new Exception();\n" //
+				+ "    }" //
+				+ "    public void test () {\n" //
+				+ "        throwException();\n" //
 				+ "        try {\n" //
 				+ "        } catch (Exception e) {\n" //
 				+ "            // TODO: handle exception\n" //
@@ -1043,9 +1055,12 @@ public class LocalCorrectionQuickFixTest extends AbstractQuickFixTest {
 		buf = new StringBuilder();
 		buf.append("package test1;\n" //
 				+ "public class E {\n" //
+				+ "    public void throwException () throws Exception {\n" //
+				+ "        throw new Exception();\n" //
+				+ "    }" //
 				+ "    public void test () {\n" //
 				+ "        try {\n" //
-				+ "            throw new Exception();\n" //
+				+ "            throwException();\n" //
 				+ "        } catch (Exception e) {\n" //
 				+ "            // TODO Auto-generated catch block\n" //
 				+ "            e.printStackTrace();\n" //
@@ -1279,8 +1294,11 @@ public class LocalCorrectionQuickFixTest extends AbstractQuickFixTest {
 		buf = new StringBuilder();
 		buf.append("package test1;\n");
 		buf.append("public class E extends A {\n");
-		buf.append("    public void foo() {\n");
+		buf.append("    private void throwException() throws Exception {\n");
 		buf.append("        throw new Exception();\n");
+		buf.append("    }\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        throwException();\n");
 		buf.append("    }\n");
 		buf.append("}\n");
 		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
@@ -1288,8 +1306,11 @@ public class LocalCorrectionQuickFixTest extends AbstractQuickFixTest {
 		buf = new StringBuilder();
 		buf.append("package test1;\n");
 		buf.append("public class E extends A {\n");
-		buf.append("    public void foo() throws Exception {\n");
+		buf.append("    private void throwException() throws Exception {\n");
 		buf.append("        throw new Exception();\n");
+		buf.append("    }\n");
+		buf.append("    public void foo() throws Exception {\n");
+		buf.append("        throwException();\n");
 		buf.append("    }\n");
 		buf.append("}\n");
 
@@ -1298,9 +1319,12 @@ public class LocalCorrectionQuickFixTest extends AbstractQuickFixTest {
 		buf = new StringBuilder();
 		buf.append("package test1;\n");
 		buf.append("public class E extends A {\n");
+		buf.append("    private void throwException() throws Exception {\n");
+		buf.append("        throw new Exception();\n");
+		buf.append("    }\n");
 		buf.append("    public void foo() {\n");
 		buf.append("        try {\n");
-		buf.append("            throw new Exception();\n");
+		buf.append("            throwException();\n");
 		buf.append("        } catch (Exception e) {\n");
 		buf.append("            // TODO Auto-generated catch block\n");
 		buf.append("            e.printStackTrace();\n");
@@ -1322,8 +1346,11 @@ public class LocalCorrectionQuickFixTest extends AbstractQuickFixTest {
 		buf.append("import java.io.Closeable;\n");
 		buf.append("import java.io.FileNotFoundException;\n");
 		buf.append("public class A implements Closeable {\n");
-		buf.append("    public void close() {\n");
+		buf.append("    public void throwFileNotFoundException () throws FileNotFoundException {\n");
 		buf.append("        throw new FileNotFoundException();\n");
+		buf.append("    }\n");
+		buf.append("    public void close() {\n");
+		buf.append("        throwFileNotFoundException();\n");
 		buf.append("    }\n");
 		buf.append("}\n");
 		ICompilationUnit cu = pack1.createCompilationUnit("A.java", buf.toString(), false, null);
@@ -1333,8 +1360,11 @@ public class LocalCorrectionQuickFixTest extends AbstractQuickFixTest {
 		buf.append("import java.io.Closeable;\n");
 		buf.append("import java.io.FileNotFoundException;\n");
 		buf.append("public class A implements Closeable {\n");
-		buf.append("    public void close() throws FileNotFoundException {\n");
+		buf.append("    public void throwFileNotFoundException () throws FileNotFoundException {\n");
 		buf.append("        throw new FileNotFoundException();\n");
+		buf.append("    }\n");
+		buf.append("    public void close() throws FileNotFoundException {\n");
+		buf.append("        throwFileNotFoundException();\n");
 		buf.append("    }\n");
 		buf.append("}\n");
 
@@ -1345,9 +1375,12 @@ public class LocalCorrectionQuickFixTest extends AbstractQuickFixTest {
 		buf.append("import java.io.Closeable;\n");
 		buf.append("import java.io.FileNotFoundException;\n");
 		buf.append("public class A implements Closeable {\n");
+		buf.append("    public void throwFileNotFoundException () throws FileNotFoundException {\n");
+		buf.append("        throw new FileNotFoundException();\n");
+		buf.append("    }\n");
 		buf.append("    public void close() {\n");
 		buf.append("        try {\n");
-		buf.append("            throw new FileNotFoundException();\n");
+		buf.append("            throwFileNotFoundException();\n");
 		buf.append("        } catch (FileNotFoundException e) {\n");
 		buf.append("            // TODO Auto-generated catch block\n");
 		buf.append("            e.printStackTrace();\n");
@@ -1368,8 +1401,11 @@ public class LocalCorrectionQuickFixTest extends AbstractQuickFixTest {
 		buf.append("package test1;\n");
 		buf.append("import java.io.Closeable;\n");
 		buf.append("public class A implements Closeable {\n");
-		buf.append("    public void close() {\n");
+		buf.append("    public void throwThrowable() throws Throwable {\n");
 		buf.append("        throw new Throwable();\n");
+		buf.append("    }\n");
+		buf.append("    public void close() {\n");
+		buf.append("        throwThrowable();\n");
 		buf.append("    }\n");
 		buf.append("}\n");
 		ICompilationUnit cu = pack1.createCompilationUnit("A.java", buf.toString(), false, null);
@@ -1378,9 +1414,12 @@ public class LocalCorrectionQuickFixTest extends AbstractQuickFixTest {
 		buf.append("package test1;\n");
 		buf.append("import java.io.Closeable;\n");
 		buf.append("public class A implements Closeable {\n");
+		buf.append("    public void throwThrowable() throws Throwable {\n");
+		buf.append("        throw new Throwable();\n");
+		buf.append("    }\n");
 		buf.append("    public void close() {\n");
 		buf.append("        try {\n");
-		buf.append("            throw new Throwable();\n");
+		buf.append("            throwThrowable();\n");
 		buf.append("        } catch (Throwable e) {\n");
 		buf.append("            // TODO Auto-generated catch block\n");
 		buf.append("            e.printStackTrace();\n");


### PR DESCRIPTION
### New quick fixes

Note that most of these diagnostics already existed, although there are some cases where the diagnostics might be new as well. What's new is the quick fixes for those diagnostics. Some of these new quick fixes do require a compiler setting to be set to warning/error in order for the problem reporting to diagnose them as they're ignored by default. Most are diagnosed by default though.

  - UnqualifiedFieldAccess -> addUnqualifiedFieldAccessProposal
    - org.eclipse.jdt.core.compiler.problem.unqualifiedFieldAccess=error 
  
https://github.com/user-attachments/assets/b2f1ed58-06c4-4c23-ba81-4d350ad9546a

  - UnnecessaryInstanceof -> addUnnecessaryInstanceofProposal
    - org.eclipse.jdt.core.compiler.problem.unnecessaryTypeCheck=error 

https://github.com/user-attachments/assets/58ba4566-4e74-4fd5-b730-8bca23be4e04

  - IllegalQualifiedEnumConstantLabel -> addIllegalQualifiedEnumConstantLabelProposal

https://github.com/user-attachments/assets/aebfe8f8-80aa-4330-9e75-466c02447fae

  - UnnecessaryElse -> addUnnecessaryElseProposals
    - org.eclipse.jdt.core.compiler.problem.unnecessaryElse=error 

https://github.com/user-attachments/assets/f9e8ffb2-ce1e-42cc-a8df-651896a6c2fe

  - SuperclassMustBeAClass -> addInterfaceExtendsClassProposals

https://github.com/user-attachments/assets/c972185d-32fb-4b4e-9b15-63c324e44d53

  - AssignmentHasNoEffect -> addAssignmentHasNoEffectProposals

https://github.com/user-attachments/assets/334d07d3-6319-4749-99ae-49dc9209b492

  - FallthroughCase, IllegalFallthroughToPattern -> addFallThroughProposals
    - org.eclipse.jdt.core.compiler.problem.fallthroughCase=error 

https://github.com/user-attachments/assets/5c57efb3-7e7a-45d7-b20c-3267bd1a0964

  - UnsafeTypeConversion, RawTypeReference, UnsafeRawMethodInvocation -> addDeprecatedFieldsToMethodsProposals

https://github.com/user-attachments/assets/d7152525-0d48-48a9-85b4-58896eb6f65f

  - IllegalTotalPatternWithDefault -> addRemoveDefaultCaseProposal

https://github.com/user-attachments/assets/384082ab-af24-4355-bb20-ee95ea81e5e4

  - SuperfluousSemicolon -> addSuperfluousSemicolonProposal

https://github.com/user-attachments/assets/a8d8a92b-8e9a-410b-9eba-fb783ff02471

 - NonStaticFieldFromStaticInvocation, NonStaticFieldFromStaticInvocation -> addObjectReferenceProposal, addVariableReferenceProposal, addNewObjectProposal

https://github.com/user-attachments/assets/56ca83f7-785a-4aa9-bca0-b5249a2eec66

- AbstractServiceImplementation, ProviderMethodOrConstructorRequiredForServiceImpl, ServiceImplDefaultConstructorNotPublic -> addServiceProviderConstructorProposals
 
https://github.com/user-attachments/assets/5dce2633-0751-4ff1-861a-41b194dbf47f

- Fix the JDT-LS QuickFixProcessor to better match upstream (by preventing fall-throughs, with 'break' where appropriate)
- Preserve non-upstreamed behaviour of surrounding all selected statements when "Surrounding with try/catch"
- Based on https://eclip.se/545163 the "Surround with try-catch" quick-fix is not valid for a 'throw' statement so we should adjust those testcases to use methods with throw declarations instead
- Ensure the current compilation unit primary type is never used when it is null

**TODO** (prior to merging)
- [x] Basically all changes I noticed are things upstream introduced since we copied over code, and never got reintegrated, so switching to upstream's version should be a step in the right direction. There is only 1 exception I found. https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/1189 . ~~I need to verify whether upstream continues to fail to do this, and potentially upstream our one-line fix.~~ I've preserved the behaviour on our end (hacked a custom `ProblemLoation` that return the context's covered node when a selection exists)
  - **Update:**  Upstream JDT doesn't have this issue because the UI gets the full selection through [`SurroundWithTryCatchAction`](https://github.com/eclipse-jdt/eclipse.jdt.ui/blob/d5ec49f8e8dc761dcc073d6346a439297abdcbaf/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/SurroundWithTryCatchAction.java#L81). Our implementation goes through `LocalCorrectionsBaseSubProcessor.getUncaughtExceptionProposals(..)` whether it's a quick-fix or just a plain refactoring so we need to make sure the selection is correct with the extra code.
- [x] AbstractServiceImplementation, ProviderMethodOrConstructorRequiredForServiceImpl, ServiceImplDefaultConstructorNotPublic -> addServiceProviderConstructorProposals ~~appears to have some issues and isn't working correctly. Need to check if it's an upstream issue, in which case I think we can just add it and get it fixed there~~