### PR TITLE
Add some more quick fixes from LocalCorrectionsBaseSubProcessor.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
@@ -332,11 +332,10 @@ public class QuickFixProcessor {
 			// ModifierCorrectionSubProcessor.addNonFinalLocalProposal(context,
 			// problem, proposals);
 			// break;
-			// case IProblem.UninitializedLocalVariable:
-			// case IProblem.UninitializedLocalVariableHintMissingDefault:
-			// LocalCorrectionsSubProcessor.addUninitializedLocalVariableProposal(context,
-			// problem, proposals);
-			// break;
+			case IProblem.UninitializedLocalVariable:
+			case IProblem.UninitializedLocalVariableHintMissingDefault:
+				LocalCorrectionsSubProcessor.addUninitializedLocalVariableProposal(context, problem, proposals);
+				break;
 			case IProblem.UnhandledExceptionInDefaultConstructor:
 			case IProblem.UndefinedConstructorInDefaultConstructor:
 			case IProblem.NotVisibleConstructorInDefaultConstructor:
@@ -644,10 +643,9 @@ public class QuickFixProcessor {
 			// NullAnnotationsCorrectionProcessor.addRemoveRedundantAnnotationProposal(context,
 			// problem, proposals);
 			// break;
-			// case IProblem.UnusedTypeParameter:
-			// LocalCorrectionsSubProcessor.addUnusedTypeParameterProposal(context,
-			// problem, proposals);
-			// break;
+			case IProblem.UnusedTypeParameter:
+				LocalCorrectionsSubProcessor.addUnusedTypeParameterProposal(context, problem, proposals);
+				break;
 			// case IProblem.NullableFieldReference:
 			// NullAnnotationsCorrectionProcessor.addExtractCheckedLocalProposal(context,
 			// problem, proposals);
@@ -664,11 +662,10 @@ public class QuickFixProcessor {
 			case IProblem.IllegalQualifiedEnumConstantLabel:
 				LocalCorrectionsSubProcessor.addIllegalQualifiedEnumConstantLabelProposal(context, problem, proposals);
 				break;
-			// case IProblem.DuplicateInheritedDefaultMethods:
-			// case IProblem.InheritedDefaultMethodConflictsWithOtherInherited:
-			// LocalCorrectionsSubProcessor.addOverrideDefaultMethodProposal(context,
-			// problem, proposals);
-			// break;
+			case IProblem.DuplicateInheritedDefaultMethods:
+			case IProblem.InheritedDefaultMethodConflictsWithOtherInherited:
+				LocalCorrectionsSubProcessor.addOverrideDefaultMethodProposal(context, problem, proposals);
+				break;
 			// case IProblem.PotentialNullLocalVariableReference:
 			// IJavaProject prj2= context.getCompilationUnit().getJavaProject();
 			// if (prj2 != null &&

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/LocalCorrectionsSubProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/LocalCorrectionsSubProcessor.java
@@ -77,6 +77,7 @@ import org.eclipse.jdt.internal.corext.fix.UnimplementedCodeFixCore;
 import org.eclipse.jdt.internal.corext.fix.UnusedCodeFixCore;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.jdt.internal.ui.fix.CodeStyleCleanUpCore;
+import org.eclipse.jdt.internal.ui.text.correction.IProposalRelevance;
 import org.eclipse.jdt.internal.ui.text.correction.LocalCorrectionsBaseSubProcessor;
 import org.eclipse.jdt.internal.ui.text.correction.ProblemLocation;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.ChangeMethodSignatureProposalCore;
@@ -475,6 +476,24 @@ public class LocalCorrectionsSubProcessor extends LocalCorrectionsBaseSubProcess
 
 	public static void addVariableReferenceProposal(IInvocationContext context, IProblemLocation problem, Collection<ProposalKindWrapper> proposals) throws CoreException {
 		new LocalCorrectionsSubProcessor().getVariableReferenceProposal(context, problem, proposals);
+	}
+
+	public static void addUninitializedLocalVariableProposal(IInvocationContext context, IProblemLocation problem, Collection<ProposalKindWrapper> proposals) {
+		new LocalCorrectionsSubProcessor().getUninitializedLocalVariableProposal(context, problem, proposals);
+	}
+
+	public static void addOverrideDefaultMethodProposal(IInvocationContext context, IProblemLocation problem, Collection<ProposalKindWrapper> proposals) {
+		new LocalCorrectionsSubProcessor().getOverrideDefaultMethodProposal(context, problem, proposals);
+	}
+
+	public static void addUnusedTypeParameterProposal(IInvocationContext context, IProblemLocation problem, Collection<ProposalKindWrapper> proposals) {
+		UnusedCodeFixCore fix = UnusedCodeFixCore.createUnusedTypeParameterFix(context.getASTRoot(), problem);
+		if (fix != null) {
+			FixCorrectionProposalCore proposal = new FixCorrectionProposalCore(fix, fix.getCleanUp(), IProposalRelevance.UNUSED_MEMBER, context);
+			proposals.add(CodeActionHandler.wrap(proposal, CodeActionKind.QuickFix));
+		}
+
+		JavadocTagsSubProcessor.getUnusedAndUndocumentedParameterOrExceptionProposals(context, problem, proposals);
 	}
 
 	public static void getMissingEnumConstantCaseProposals(IInvocationContext context, IProblemLocation problem, Collection<ProposalKindWrapper> proposals) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDiagnosticsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDiagnosticsHandler.java
@@ -256,7 +256,11 @@ public abstract class BaseDiagnosticsHandler implements IProblemRequestor {
 			diag.setSeverity(convertSeverity(problem));
 			diag.setRange(convertRange(openable, problem));
 			Map<String, Object> data = new HashMap<>();
-			if (problem.getID() == IProblem.UndefinedName || problem.getID() == IProblem.UndefinedType || problem.getID() == IProblem.UninitializedBlankFinalField) {
+			if (problem.getID() == IProblem.UndefinedName
+					|| problem.getID() == IProblem.UndefinedType
+					|| problem.getID() == IProblem.UninitializedBlankFinalField
+					|| problem.getID() == IProblem.DuplicateInheritedDefaultMethods
+					|| problem.getID() == IProblem.InheritedDefaultMethodConflictsWithOtherInherited) {
 				data.put(DIAG_ARGUMENTS, problem.getArguments());
 			}
 			if (isDiagnosticTagSupported) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
@@ -358,7 +358,10 @@ public class CodeActionHandler {
 						arguments.add(e.getAsString());
 					}
 				} else if (args instanceof String[] args1) {
+					// Needed for test cases (no LSP4J transmission)
 					arguments = Arrays.asList(args1);
+				} else if (args instanceof List args1) {
+					arguments = args1;
 				}
 				Object ecjProblemId = data.get(BaseDiagnosticsHandler.DIAG_ECJ_PROBLEM_ID);
 				if (ecjProblemId instanceof String id) {


### PR DESCRIPTION
### New quick fixes

- UninitializedLocalVariable, UninitializedLocalVariableHintMissingDefault -> addUninitializedLocalVariableProposal

https://github.com/user-attachments/assets/939b28da-f453-459a-ae1e-e20e409d2b5a

- UnusedTypeParameter -> addUnusedTypeParameterProposal
  - org.eclipse.jdt.core.compiler.problem.unusedTypeParameter

https://github.com/user-attachments/assets/e1079744-1e28-4158-b73e-d808bc52ec5f

- DuplicateInheritedDefaultMethods, InheritedDefaultMethodConflictsWithOtherInherited -> addOverrideDefaultMethodProposal

https://github.com/user-attachments/assets/9b4f6d77-d86b-489e-be37-6f818827b8ca


- [x] I need to verify the line that converts the code action data as it seems a bit odd that we need to `List` instead of being handled by `String[]`