### PR TITLE
Adjust Equinox launcher detection for mason-registry packaging.

### DIFF
--- a/org.eclipse.jdt.ls.product/scripts/jdtls.py
+++ b/org.eclipse.jdt.ls.product/scripts/jdtls.py
@@ -49,6 +49,10 @@ def get_java_executable(known_args):
 
 def find_equinox_launcher(jdtls_base_directory):
 	plugins_dir = jdtls_base_directory / "plugins"
+	if (plugins_dir / 'org.eclipse.equinox.launcher.jar').is_file():
+		# mason-registry packaging
+		return str(plugins_dir / 'org.eclipse.equinox.launcher.jar')
+
 	launchers = plugins_dir.glob('org.eclipse.equinox.launcher_*.jar')
 	for launcher in launchers:
 		return str(plugins_dir / launcher)


### PR DESCRIPTION
Was setting up jdtls on my machine (running Fedora 41) and it was failing to find the equinox launcher jar.
I looked in the plugins directory that the script was searching and the jar was named `org.eclipse.equinox.launcher.jar`.

I updated this script to use that jar and it started working for me.