### PR TITLE
React to upstream changes preserving comments in lambda conversions.

### DIFF
--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/AnonymousClassCreationToLambdaTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/AnonymousClassCreationToLambdaTest.java
@@ -344,7 +344,9 @@ public class AnonymousClassCreationToLambdaTest extends AbstractSelectionTest {
 		buf.append("    void foo(String... strs);\n");
 		buf.append("}\n");
 		buf.append("public class C1 {\n");
-		buf.append("    FI fi = strs -> System.out.println();\n");
+		buf.append("    FI fi = strs -> {\n");
+		buf.append("             System.out.println();\n");
+		buf.append("    /*]*/};\n");
 		buf.append("}\n");
 		Expected e = new Expected("Convert to lambda expression", buf.toString());
 


### PR DESCRIPTION
It looks like https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1999 fixed things so that parts of the anonymous class that remain (ie. the last curly brace) do not lose their comments. It's a bit odd in our particular test case, but comment preservation is probably for the best.