### PR TITLE
Allow jdtls.py to be dynamically imported

### DIFF
--- a/org.eclipse.jdt.ls.product/scripts/jdtls
+++ b/org.eclipse.jdt.ls.product/scripts/jdtls
@@ -15,7 +15,10 @@ import importlib.util
 import sys
 import os
 
-spec = importlib.util.spec_from_file_location("jdtls", os.path.realpath(__file__) + ".py")
+script_dir = os.path.dirname(os.path.realpath(__file__))
+file_path = os.path.join(script_dir, "jdtls.py")
+
+spec = importlib.util.spec_from_file_location("jdtls", file_path)
 jdtls = importlib.util.module_from_spec(spec)
 sys.modules["jdtls"] = jdtls
 spec.loader.exec_module(jdtls)


### PR DESCRIPTION
Previous `jdtls` script didn't import `jdtls.py` properly, this is a problem I happened to have.
![image](https://github.com/user-attachments/assets/d58245a7-6ddc-4102-a94b-90be6b80800e)
The proposed change solves this problem entirely by importing `jdtls.py` module dynamically