### PR TITLE
Bump minimum required version for JDT-LS python script.

### DIFF
--- a/org.eclipse.jdt.ls.product/scripts/jdtls.py
+++ b/org.eclipse.jdt.ls.product/scripts/jdtls.py
@@ -40,8 +40,8 @@ def get_java_executable(known_args):
 	for match in matches:
 		java_major_version = int(match.group("major"))
 
-		if java_major_version < 17:
-			raise Exception("jdtls requires at least Java 17")
+		if java_major_version < 21:
+			raise Exception("jdtls requires at least Java 21")
 
 		return java_executable
 


### PR DESCRIPTION
- Fixes https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/3392 .
- Minimum required version went from 17 to 21