### PR TITLE
Only rename source file to match the single public type declaration.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
@@ -184,8 +184,12 @@ public class JavaClientConnection {
 	public boolean applyWorkspaceEdit(WorkspaceEdit edit){
 		ApplyWorkspaceEditParams $ = new ApplyWorkspaceEditParams();
 		$.setEdit(edit);
-		ApplyWorkspaceEditResponse response = client.applyEdit($).join();
-		return response.isApplied();
+		CompletableFuture<ApplyWorkspaceEditResponse> future = client.applyEdit($);
+		if (future != null) {
+			ApplyWorkspaceEditResponse response = future.join();
+			return response.isApplied();
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
- Fixes https://github.com/redhat-developer/vscode-java/issues/3963
- If 2 or more public type delcarations exist at the top level within a source file, renaming becomes ambiguous, so it should be avoided

(Improves upon https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3091)