### PR TITLE
Fix inherited document symbols to collect interfaces as well.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandler.java
@@ -284,8 +284,8 @@ public class DocumentSymbolHandler {
 						if (monitor.isCanceled()) {
 							throw new OperationCanceledException();
 						}
-						IType[] superClasses = supertypeHierarchy.getAllSuperclasses(tp);
-						for (IType superType : superClasses) {
+						IType[] superTypes = supertypeHierarchy.getAllSupertypes(tp);
+						for (IType superType : superTypes) {
 							if (!"java.lang.Object".equals(superType.getFullyQualifiedName())) {
 								children.addAll(Arrays.asList(filter(superType.getChildren())));
 							}


### PR DESCRIPTION
- Improving on https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3378 .