### PR TITLE
Fix RelativePattern by ensuring base URI contains the scheme.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ResourceUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ResourceUtils.java
@@ -314,7 +314,8 @@ public final class ResourceUtils {
 		}
 
 		if (path.isAbsolute() && !recursive) {
-			return Either.forRight(new RelativePattern(Either.forRight(path.removeLastSegments(1).toPortableString()), path.lastSegment()));
+			String baseUri = path.removeLastSegments(1).toFile().toURI().toString();
+			return Either.forRight(new RelativePattern(Either.forRight(baseUri), path.lastSegment()));
 		}
 
 		String globPattern = path.toPortableString();

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ResourceUtilsTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ResourceUtilsTest.java
@@ -34,7 +34,7 @@ public class ResourceUtilsTest {
 		assertEquals(Either.forLeft("/foo/bar/**"), toGlobPattern(Path.forPosix("/foo/bar/")));
 		assertEquals(Either.forLeft("**/foo/bar/**"), toGlobPattern(Path.forWindows("c:/foo/bar/")));
 		assertEquals(Either.forLeft("**/foo/bar/**"), toGlobPattern(Path.forWindows("c:\\foo\\bar")));
-		assertEquals(Either.forRight(new RelativePattern(Either.forRight("/foo/bar"), "foo.jar")), toGlobPattern(Path.forPosix("/foo/bar/foo.jar")));
+		assertEquals(Either.forRight(new RelativePattern(Either.forRight("file:/foo/bar"), "foo.jar")), toGlobPattern(Path.forPosix("/foo/bar/foo.jar")));
 	}
 
 	@Test


### PR DESCRIPTION
- Continuation of https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/1765