### PR TITLE
Flatten incoming preference map so as to perform merging correctly.

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Djdk.xml.maxGeneralEntitySizeLimit=1000000 -Djdk.xml.totalEntitySizeLimit=1000000
+-Djdk.xml.maxGeneralEntitySizeLimit=0 -Djdk.xml.totalEntitySizeLimit=0

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/MapFlattener.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/MapFlattener.java
@@ -14,10 +14,12 @@ package org.eclipse.jdt.ls.core.internal.handlers;
 
 import java.lang.reflect.Type;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 
@@ -169,6 +171,19 @@ public final class MapFlattener {
 
 	public static void setValue(Map<String, Object> configuration, String key, Object value) {
 		configuration.put(key, value);
+	}
+
+	public static void putAll(Map<String, Object> currentConfiguration, Map<String, Object> newConfiguration) {
+		Map<String, Object> flattenedNewConfig = newConfiguration.entrySet().stream().flatMap(MapFlattener::flatten).collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll);
+		currentConfiguration.putAll(flattenedNewConfig);
+	}
+
+	private static Stream<Map.Entry<String, Object>> flatten(Map.Entry<String, Object> entry) {
+		if (entry.getValue() instanceof Map<?, ?>) {
+			Map<String, Object> nested = (Map<String, Object>) entry.getValue();
+			return nested.entrySet().stream().map(e -> Map.entry(entry.getKey() + "." + e.getKey(), e.getValue())).flatMap(MapFlattener::flatten);
+		}
+		return Stream.of(entry);
 	}
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
@@ -57,6 +57,7 @@ import org.eclipse.jdt.ls.core.internal.ResourceUtils;
 import org.eclipse.jdt.ls.core.internal.StatusFactory;
 import org.eclipse.jdt.ls.core.internal.handlers.BaseDiagnosticsHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.FormatterHandler;
+import org.eclipse.jdt.ls.core.internal.handlers.MapFlattener;
 import org.eclipse.jdt.ls.core.internal.preferences.Preferences.SearchScope;
 import org.eclipse.jface.text.templates.Template;
 import org.eclipse.jface.text.templates.TemplateContextType;
@@ -225,7 +226,7 @@ public class PreferenceManager {
 	 */
 	public void update(Map<String, Object> preferences) {
 		Map<String, Object> currMap = this.preferences.asMap();
-		currMap.putAll(preferences);
+		MapFlattener.putAll(currMap, preferences);
 		Preferences newPreferences = Preferences.createFrom(currMap);
 		// Preserve preferences stored here that are never sent after initialization
 		newPreferences.setRootPaths(this.preferences.getRootPaths());

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/MapFlattenerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/MapFlattenerTest.java
@@ -154,4 +154,22 @@ public class MapFlattenerTest {
 		assertSame(bottom, getValue(config, "java.bottom"));
 	}
 
+	@Test
+	public void testMergeMaps() throws Exception {
+		Map<String, Object> result = new HashMap<>();
+		result.put("java.configuration.runtimes", new Map[] { Map.of("name", "JavaSE-1", "path", "/path/to/java-1") });
+		assertEquals(1, result.size());
+
+		assertEquals("JavaSE-1", ((Map[]) getValue(result, "java.configuration.runtimes"))[0].get("name"));
+		assertEquals("/path/to/java-1", ((Map[]) getValue(result, "java.configuration.runtimes"))[0].get("path"));
+
+		Map<String, Object> updatedSettings = new HashMap<>();
+		updatedSettings.put("java", Map.of("configuration", Map.of("runtimes",
+				new Map[] { Map.of("name", "JavaSE-99", "path", "/path/to/java-99") })));
+
+		MapFlattener.putAll(result, updatedSettings);
+		assertEquals("JavaSE-99", ((Map[]) getValue(result, "java.configuration.runtimes"))[0].get("name"));
+		assertEquals("/path/to/java-99", ((Map[]) getValue(result, "java.configuration.runtimes"))[0].get("path"));
+	}
+
 }


### PR DESCRIPTION
- Continuing from https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3412
- Add test case
- Also revise JAXP limits based on pre JDK 24 values.