### PR TITLE
JDTLS launcher conflicts with projects using older Java versions when JAVA_HOME points to Java 21

### DIFF
--- a/org.eclipse.jdt.ls.product/scripts/jdtls.py
+++ b/org.eclipse.jdt.ls.product/scripts/jdtls.py
@@ -25,9 +25,9 @@ def get_java_executable(known_args):
 	else:
 		java_executable = 'java'
 
-		if 'JAVA_HOME' in os.environ:
+		if 'JAVA_JDK_21' in os.environ:
 			ext = '.exe' if platform.system() == 'Windows' else ''
-			java_exec_to_test = Path(os.environ['JAVA_HOME']) / 'bin' / f'java{ext}'
+			java_exec_to_test = Path(os.environ['JAVA_JDK_21']) / 'bin' / f'java{ext}'
 			if java_exec_to_test.is_file():
 				java_executable = str(java_exec_to_test.resolve())
 


### PR DESCRIPTION
**Problem:**

When JAVA_HOME is set to Java 21 (required for JDTLS), but the user's project uses an older Java version (e.g., Java 17), in the jdtls logs we see errors like:

    Unsupported class file major version 65

This happens because the project’s build tools (Maven/Gradle) inherit JAVA_HOME, causing version mismatches.

**Root Cause:**

The jdtls.py launcher script currently relies on JAVA_HOME to locate the Java executable, forcing users to globally set JAVA_HOME=JDK21. This disrupts other projects running on older Java versions.

**Solution:**

Modify jdtls.py to prioritize a new environment variable JAVA_JDK_21 instead of JAVA_HOME. This:

- Allows JDTLS to run on Java 21 without overriding the system JAVA_HOME.
- Maintains backward compatibility (falls back to java in PATH if JAVA_JDK_21 is unset).

**Impact:**
Users can now:

- Set JAVA_JDK_21 to a JDK 21 path only for JDTLS.
- Keep JAVA_HOME pointing to their default JDK (e.g., Java 11/17) for other projects.