### PR TITLE
Add workspace folder variable resolution for settings url

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -1454,13 +1454,38 @@ public class Preferences {
 	}
 
 	public Preferences setFormatterUrl(String formatterUrl) {
-		this.formatterUrl = ResourceUtils.expandPath(formatterUrl);
+		this.formatterUrl = this.resolveWorkspaceFolder(ResourceUtils.expandPath(formatterUrl));
 		return this;
 	}
 
 	public Preferences setSettingsUrl(String settingsUrl) {
-		this.settingsUrl = ResourceUtils.expandPath(settingsUrl);
+		this.settingsUrl = this.resolveWorkspaceFolder(ResourceUtils.expandPath(settingsUrl));
 		return this;
+	}
+
+	private String resolveWorkspaceFolder(String filePath) {
+		final String workspaceFolderVariable = "${workspaceFolder}";
+		
+		if (!filePath.contains(workspaceFolderVariable)) {
+			return filePath;
+		}
+		Collection<IPath> rootPaths = getRootPaths();
+		
+		if (rootPaths == null || rootPaths.isEmpty()) {
+			return filePath;
+		}
+		for (IPath workspacePath : rootPaths) {
+			String resolvedPath = filePath.replace(workspaceFolderVariable, workspacePath.toOSString());
+			File resolvedFile = new File(resolvedPath);
+			
+			if (resolvedFile.exists()) {
+				return resolvedPath;
+			}
+		}
+		
+		// If no match found in any workspace folder, fall back to first workspace
+		IPath firstWorkspace = rootPaths.iterator().next();
+		return filePath.replace(workspaceFolderVariable, firstWorkspace.toOSString());
 	}
 
 	public Preferences setResourceFilters(List<String> resourceFilters) {


### PR DESCRIPTION
This PR adds support for resolving `${workspaceFolder}` in the following settings:
- java.format.settings.url
- java.settings.url

If `${workspaceFolder}` is present in the provided path, it will be replaced with the absolute path of the workspace folder (retrieved from `getRootPaths()`). The resolution logic checks all available workspace folders and uses the first matching path that exists.

Fixes: https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/2529 