### PR TITLE
refactor: use utility method to share usage of JDT token scanner

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
@@ -1916,6 +1916,27 @@ public final class JDTUtils {
 	}
 
 	/**
+	 * Tries to create an {@link IScanner} for the project.
+	 *
+	 * @param project the Java project for which the scanner will be created
+	 * @param tokenizeComments whether comments should be tokenized
+	 * @param tokenizeWhiteSpace whether white spaces should be tokenized
+	 * @param recordLineSeparator whether line separators should be recorded
+	 * @return the scanner, or {@code null} if not available
+	 */
+	public static IScanner createScanner(IJavaProject project, boolean tokenizeComments, boolean tokenizeWhiteSpace, boolean recordLineSeparator) {
+		if (project == null) {
+			return null;
+		}
+
+		final String sourceLevel = project.getOption(JavaCore.COMPILER_SOURCE, true);
+		final String complianceLevel = project.getOption(JavaCore.COMPILER_COMPLIANCE, true);
+		final boolean enablePreview = JavaCore.ENABLED.equals(project.getOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, true));
+
+		return ToolFactory.createScanner(tokenizeComments, tokenizeWhiteSpace, recordLineSeparator, sourceLevel, complianceLevel, enablePreview);
+	}
+
+	/**
 	 * Tries to create an {@link IScanner} for the source of the given compilation unit.
 	 *
 	 * @param compilationUnit the compilation unit

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
@@ -1937,40 +1937,6 @@ public final class JDTUtils {
 	}
 
 	/**
-	 * Tries to create an {@link IScanner} for the source of the given compilation unit.
-	 *
-	 * @param compilationUnit the compilation unit
-	 * @return the scanner, or {@code null} if not available
-	 */
-	public static IScanner createScanner(CompilationUnit compilationUnit) {
-		final ITypeRoot typeRoot = compilationUnit.getTypeRoot();
-		if (typeRoot == null) {
-			return null;
-		}
-		final IJavaProject javaProject = typeRoot.getJavaProject();
-		if (javaProject == null) {
-			return null;
-		}
-		final String source;
-		try {
-			source = typeRoot.getSource();
-		} catch (JavaModelException e) {
-			return null;
-		}
-		if (source == null) {
-			return null;
-		}
-
-		final String sourceLevel = javaProject.getOption(JavaCore.COMPILER_SOURCE, true);
-		final String complianceLevel = javaProject.getOption(JavaCore.COMPILER_COMPLIANCE, true);
-		final boolean enablePreview = JavaCore.ENABLED.equals(javaProject.getOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, true));
-
-		final IScanner scanner = ToolFactory.createScanner(false, false, false, sourceLevel, complianceLevel, enablePreview);
-		scanner.setSource(source.toCharArray());
-		return scanner;
-	}
-
-	/**
 	 * Get the AST from CoreASTProvider. After getting the AST, it will check if the buffer size is equal to
 	 * the AST's length. If it's not - indicating that the AST is out-of-date. The AST will be disposed and
 	 * request CoreASTProvider to get a new one.

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
@@ -54,6 +54,7 @@ import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.jdt.core.CompletionProposal;
 import org.eclipse.jdt.core.Flags;
+
 import org.eclipse.jdt.core.IAnnotatable;
 import org.eclipse.jdt.core.IAnnotation;
 import org.eclipse.jdt.core.IBuffer;
@@ -78,8 +79,10 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.Signature;
 import org.eclipse.jdt.core.SourceRange;
+import org.eclipse.jdt.core.ToolFactory;
 import org.eclipse.jdt.core.WorkingCopyOwner;
 import org.eclipse.jdt.core.compiler.CharOperation;
+import org.eclipse.jdt.core.compiler.IScanner;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.ASTVisitor;
@@ -103,7 +106,9 @@ import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.SuperConstructorInvocation;
 import org.eclipse.jdt.core.dom.Type;
+
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.eclipse.jdt.core.manipulation.CoreASTProvider;
 import org.eclipse.jdt.core.manipulation.SharedASTProviderCore;
 import org.eclipse.jdt.core.search.IJavaSearchScope;
 import org.eclipse.jdt.core.search.SearchEngine;
@@ -1908,6 +1913,72 @@ public final class JDTUtils {
 		} catch (JavaModelException e) {
 			return false;
 		}
+	}
+
+	/**
+	 * Tries to create an {@link IScanner} for the source of the given compilation unit.
+	 *
+	 * @param compilationUnit the compilation unit
+	 * @return the scanner, or {@code null} if not available
+	 */
+	public static IScanner createScanner(CompilationUnit compilationUnit) {
+		final ITypeRoot typeRoot = compilationUnit.getTypeRoot();
+		if (typeRoot == null) {
+			return null;
+		}
+		final IJavaProject javaProject = typeRoot.getJavaProject();
+		if (javaProject == null) {
+			return null;
+		}
+		final String source;
+		try {
+			source = typeRoot.getSource();
+		} catch (JavaModelException e) {
+			return null;
+		}
+		if (source == null) {
+			return null;
+		}
+
+		final String sourceLevel = javaProject.getOption(JavaCore.COMPILER_SOURCE, true);
+		final String complianceLevel = javaProject.getOption(JavaCore.COMPILER_COMPLIANCE, true);
+		final boolean enablePreview = JavaCore.ENABLED.equals(javaProject.getOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, true));
+
+		final IScanner scanner = ToolFactory.createScanner(false, false, false, sourceLevel, complianceLevel, enablePreview);
+		scanner.setSource(source.toCharArray());
+		return scanner;
+	}
+
+	/**
+	 * Get the AST from CoreASTProvider. After getting the AST, it will check if the buffer size is equal to
+	 * the AST's length. If it's not - indicating that the AST is out-of-date. The AST will be disposed and
+	 * request CoreASTProvider to get a new one.
+	 *
+	 * <p>
+	 * Such inconsistency will happen when a thread is calling getAST(), at the meantime, the
+	 * document has been changed. Though the disposeAST() will be called when document change event
+	 * comes, there is a chance when disposeAST() finishes before getAST(). In that case, an out-of-date
+	 * AST will be cached and be used by other threads.
+	 * </p>
+	 *
+	 */
+	public static CompilationUnit getAst(ITypeRoot typeRoot, IProgressMonitor monitor) {
+		CompilationUnit root = CoreASTProvider.getInstance().getAST(typeRoot, CoreASTProvider.WAIT_YES, monitor);
+		if (root == null) {
+			return null;
+		}
+		IJavaElement element = root.getJavaElement();
+		if (element instanceof ICompilationUnit cu) {
+			try {
+				if (cu.getBuffer().getLength() != root.getLength()) {
+					CoreASTProvider.getInstance().disposeAST();
+					root = CoreASTProvider.getInstance().getAST(typeRoot, CoreASTProvider.WAIT_YES, monitor);
+				}
+			} catch (JavaModelException e) {
+				JavaLanguageServerPlugin.log(e);
+			}
+		}
+		return root;
 	}
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandler.java
@@ -47,6 +47,7 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IParent;
 import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.jdt.core.IType;
@@ -204,7 +205,7 @@ public class DocumentSymbolHandler {
 				ISourceRange sourceRange = unit.getSourceRange();
 				if (sourceRange != null) {
 					final int shift = sourceRange.getOffset();
-					IScanner scanner = getScanner(JDTUtils.getAst(unit, monitor));
+					IScanner scanner = getScanner(unit.getJavaProject());
 					scanner.setSource(unit.getSource().toCharArray());
 					scanner.resetTo(shift, shift + sourceRange.getLength());
 				}
@@ -240,7 +241,7 @@ public class DocumentSymbolHandler {
 			String name = getName(unit);
 			symbol.setName(name);
 			if (type == PACKAGE_FRAGMENT) {
-				IScanner scanner = getScanner(JDTUtils.getAst(root, monitor));
+				IScanner scanner = getScanner(root.getJavaProject());
 				int token = 0;
 				int packageStart = -1;
 				int packageEnd = -1;
@@ -312,9 +313,9 @@ public class DocumentSymbolHandler {
 		return symbol;
 	}
 
-	private static IScanner getScanner(CompilationUnit unit) {
+	private static IScanner getScanner(IJavaProject project) {
 		if (fScanner == null) {
-			fScanner = JDTUtils.createScanner(unit);
+			fScanner = JDTUtils.createScanner(project, true, false, false);
 		}
 		return fScanner;
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandler.java
@@ -204,7 +204,7 @@ public class DocumentSymbolHandler {
 				ISourceRange sourceRange = unit.getSourceRange();
 				if (sourceRange != null) {
 					final int shift = sourceRange.getOffset();
-					IScanner scanner = getScanner();
+					IScanner scanner = getScanner(JDTUtils.getAst(unit, monitor));
 					scanner.setSource(unit.getSource().toCharArray());
 					scanner.resetTo(shift, shift + sourceRange.getLength());
 				}
@@ -240,7 +240,7 @@ public class DocumentSymbolHandler {
 			String name = getName(unit);
 			symbol.setName(name);
 			if (type == PACKAGE_FRAGMENT) {
-				IScanner scanner = getScanner();
+				IScanner scanner = getScanner(JDTUtils.getAst(root, monitor));
 				int token = 0;
 				int packageStart = -1;
 				int packageEnd = -1;
@@ -312,9 +312,9 @@ public class DocumentSymbolHandler {
 		return symbol;
 	}
 
-	private static IScanner getScanner() {
+	private static IScanner getScanner(CompilationUnit unit) {
 		if (fScanner == null) {
-			fScanner = ToolFactory.createScanner(true, false, false, true);
+			fScanner = JDTUtils.createScanner(unit);
 		}
 		return fScanner;
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/FoldingRangeHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/FoldingRangeHandler.java
@@ -36,6 +36,8 @@ import org.eclipse.jdt.core.ToolFactory;
 import org.eclipse.jdt.core.compiler.IScanner;
 import org.eclipse.jdt.core.compiler.ITerminalSymbols;
 import org.eclipse.jdt.core.compiler.InvalidInputException;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
@@ -50,9 +52,9 @@ public class FoldingRangeHandler {
 
 	private static IScanner fScanner;
 
-	private static IScanner getScanner() {
+	private static IScanner getScanner(CompilationUnit unit) {
 		if (fScanner == null) {
-			fScanner = ToolFactory.createScanner(true, false, false, true);
+			fScanner = JDTUtils.createScanner(unit);
 		}
 		return fScanner;
 	}
@@ -87,7 +89,7 @@ public class FoldingRangeHandler {
 			}
 
 			final int shift = range.getOffset();
-			IScanner scanner = getScanner();
+			IScanner scanner = getScanner(JDTUtils.getAst(unit, monitor));
 			scanner.setSource(contents.toCharArray());
 			scanner.resetTo(shift, shift + range.getLength());
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/FoldingRangeHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/FoldingRangeHandler.java
@@ -55,7 +55,7 @@ public class FoldingRangeHandler {
 
 	private static IScanner getScanner(IJavaProject project) {
 		if (fScanner == null) {
-			fScanner = JDTUtils.createScanner(project, true, false, false);
+			fScanner = JDTUtils.createScanner(project, true, false, true);
 		}
 		return fScanner;
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/FoldingRangeHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/FoldingRangeHandler.java
@@ -26,6 +26,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IImportContainer;
 import org.eclipse.jdt.core.IInitializer;
 import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.ISourceRange;
@@ -52,9 +53,9 @@ public class FoldingRangeHandler {
 
 	private static IScanner fScanner;
 
-	private static IScanner getScanner(CompilationUnit unit) {
+	private static IScanner getScanner(IJavaProject project) {
 		if (fScanner == null) {
-			fScanner = JDTUtils.createScanner(unit);
+			fScanner = JDTUtils.createScanner(project, true, false, false);
 		}
 		return fScanner;
 	}
@@ -89,7 +90,7 @@ public class FoldingRangeHandler {
 			}
 
 			final int shift = range.getOffset();
-			IScanner scanner = getScanner(JDTUtils.getAst(unit, monitor));
+			IScanner scanner = getScanner(unit.getJavaProject());
 			scanner.setSource(contents.toCharArray());
 			scanner.resetTo(shift, shift + range.getLength());
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokensVisitor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokensVisitor.java
@@ -16,11 +16,6 @@ package org.eclipse.jdt.ls.core.internal.semantictokens;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.jdt.core.IJavaProject;
-import org.eclipse.jdt.core.ITypeRoot;
-import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jdt.core.ToolFactory;
 import org.eclipse.jdt.core.compiler.IScanner;
 import org.eclipse.jdt.core.compiler.ITerminalSymbols;
 import org.eclipse.jdt.core.compiler.InvalidInputException;
@@ -56,18 +51,18 @@ import org.eclipse.jdt.core.dom.Type;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.TypeLiteral;
 import org.eclipse.jdt.internal.core.dom.util.DOMASTUtil;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.lsp4j.SemanticTokens;
-import org.jsoup.select.NodeVisitor;
 
 public class SemanticTokensVisitor extends ASTVisitor {
 	private CompilationUnit cu;
 	private final IScanner scanner;
 	private List<SemanticToken> tokens;
 
-	public SemanticTokensVisitor(CompilationUnit cu) {
+	public SemanticTokensVisitor(CompilationUnit unit) {
 		super(true);
-		this.cu = cu;
-		this.scanner = createScanner(cu);
+		this.cu = unit;
+		this.scanner = JDTUtils.createScanner(unit);
 		this.tokens = new ArrayList<>();
 	}
 
@@ -492,40 +487,6 @@ public class SemanticTokensVisitor extends ASTVisitor {
 		}
 		acceptNodeList(node.bodyDeclarations());
 		return false;
-	}
-
-	/**
-	 * Tries to create an {@link IScanner} for the source of the given compilation unit.
-	 *
-	 * @param cu the compilation unit
-	 * @return the scanner, or {@code null} if not available
-	 */
-	private IScanner createScanner(CompilationUnit cu) {
-		final ITypeRoot typeRoot = cu.getTypeRoot();
-		if (typeRoot == null) {
-			return null;
-		}
-		final IJavaProject javaProject = typeRoot.getJavaProject();
-		if (javaProject == null) {
-			return null;
-		}
-		final String source;
-		try {
-			source = typeRoot.getSource();
-		} catch (JavaModelException e) {
-			return null;
-		}
-		if (source == null) {
-			return null;
-		}
-
-		final String sourceLevel = javaProject.getOption(JavaCore.COMPILER_SOURCE, true);
-		final String complianceLevel = javaProject.getOption(JavaCore.COMPILER_COMPLIANCE, true);
-		final boolean enablePreview = JavaCore.ENABLED.equals(javaProject.getOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, true));
-
-		final IScanner scanner = ToolFactory.createScanner(false, false, false, sourceLevel, complianceLevel, enablePreview);
-		scanner.setSource(source.toCharArray());
-		return scanner;
 	}
 
 	private int getNextValidToken(IScanner scanner) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokensVisitor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokensVisitor.java
@@ -53,6 +53,7 @@ import org.eclipse.jdt.core.dom.TypeLiteral;
 import org.eclipse.jdt.internal.core.dom.util.DOMASTUtil;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.lsp4j.SemanticTokens;
+import org.jsoup.select.NodeVisitor;
 
 public class SemanticTokensVisitor extends ASTVisitor {
 	private CompilationUnit cu;
@@ -62,8 +63,13 @@ public class SemanticTokensVisitor extends ASTVisitor {
 	public SemanticTokensVisitor(CompilationUnit unit) {
 		super(true);
 		this.cu = unit;
-		this.scanner = JDTUtils.createScanner(unit);
 		this.tokens = new ArrayList<>();
+
+		this.scanner = JDTUtils.createScanner(unit.getTypeRoot().getJavaProject(), false, false, false);
+		try {
+			this.scanner.setSource(unit.getTypeRoot().getSource().toCharArray());
+		} catch (Exception __) {}
+
 	}
 
 	private class SemanticToken {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokensVisitor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokensVisitor.java
@@ -57,19 +57,28 @@ import org.jsoup.select.NodeVisitor;
 
 public class SemanticTokensVisitor extends ASTVisitor {
 	private CompilationUnit cu;
-	private final IScanner scanner;
+	private IScanner scanner;
 	private List<SemanticToken> tokens;
 
 	public SemanticTokensVisitor(CompilationUnit unit) {
 		super(true);
 		this.cu = unit;
 		this.tokens = new ArrayList<>();
+		this.scanner = null;
 
-		this.scanner = JDTUtils.createScanner(unit.getTypeRoot().getJavaProject(), false, false, false);
-		try {
-			this.scanner.setSource(unit.getTypeRoot().getSource().toCharArray());
-		} catch (Exception __) {}
-
+		if (unit.getTypeRoot() != null && unit.getTypeRoot().getJavaProject() != null) {
+			this.scanner = JDTUtils.createScanner(unit.getTypeRoot().getJavaProject(), false, false, false);
+			try {
+				String source = unit.getTypeRoot().getSource();
+				if (source != null) {
+					this.scanner.setSource(source.toCharArray());
+				} else {
+					this.scanner = null;
+				}
+			} catch (Exception __) {
+				this.scanner = null;
+			}
+		}
 	}
 
 	private class SemanticToken {


### PR DESCRIPTION
This PR addresses this issue, https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/2940

Includes minor refactoring of createScanner method and utilization of the CompilationUnit when for creating the same.