### PR TITLE
Ensure we use the same versions of logback-{classic,core}.

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -12,7 +12,6 @@
             <unit id="org.eclipse.m2e.core" version="0.0.0"/>
             <unit id="org.eclipse.m2e.maven.runtime" version="0.0.0"/>
             <unit id="org.eclipse.m2e.workspace.cli" version="0.0.0"/>
-            <unit id="ch.qos.logback.classic" version="0.0.0"/>
             <repository location="https://download.eclipse.org/technology/m2e/releases/2.8.0"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -39,6 +38,8 @@
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.xtext.xbase.lib" version="0.0.0"/>
+            <unit id="ch.qos.logback.classic" version="0.0.0"/>
+            <unit id="ch.qos.logback.core" version="0.0.0"/>
             <repository location="https://download.eclipse.org/releases/2025-06/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
- Retrieve the logback bundles from Eclipse release repository
- Fixes https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/3469