### PR TITLE
Revert "Set o.e.j.c.compiler.problem.nullUncheckedConversion to ignored by default"

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -2608,7 +2608,6 @@ public class Preferences {
 			options.put(JavaCore.COMPILER_PB_NULL_SPECIFICATION_VIOLATION, defaultOptions.get(JavaCore.COMPILER_PB_NULL_SPECIFICATION_VIOLATION));
 			options.put(JavaCore.COMPILER_PB_NULL_ANNOTATION_INFERENCE_CONFLICT, defaultOptions.get(JavaCore.COMPILER_PB_NULL_ANNOTATION_INFERENCE_CONFLICT));
 			options.put(JavaCore.COMPILER_PB_SYNTACTIC_NULL_ANALYSIS_FOR_FIELDS, defaultOptions.get(JavaCore.COMPILER_PB_SYNTACTIC_NULL_ANALYSIS_FOR_FIELDS));
-			options.put(JavaCore.COMPILER_PB_NULL_UNCHECKED_CONVERSION, defaultOptions.get(JavaCore.COMPILER_PB_NULL_UNCHECKED_CONVERSION));
 		} else {
 			options.put(JavaCore.COMPILER_ANNOTATION_NULL_ANALYSIS, "enabled");
 			options.put(JavaCore.COMPILER_NONNULL_ANNOTATION_NAME, nonnullType != null ? nonnullType : "");
@@ -2620,7 +2619,6 @@ public class Preferences {
 			options.put(JavaCore.COMPILER_PB_NULL_ANNOTATION_INFERENCE_CONFLICT, "warning");
 			options.put(JavaCore.COMPILER_PB_MISSING_NONNULL_BY_DEFAULT_ANNOTATION, "ignore");
 			options.put(JavaCore.COMPILER_PB_SYNTACTIC_NULL_ANALYSIS_FOR_FIELDS, JavaCore.ENABLED);
-			options.put(JavaCore.COMPILER_PB_NULL_UNCHECKED_CONVERSION, JavaCore.IGNORE);
 		}
 		return options;
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/NullAnalysisTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/NullAnalysisTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.util.Collections;
-import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 
@@ -112,15 +111,6 @@ public class NullAnalysisTest extends AbstractGradleBasedTest {
 			assertTrue(marker2.getResource() instanceof IFile);
 			assertEquals("TestJavax.java", ((IFile) marker2.getResource()).getFullPath().lastSegment());
 			IMarker marker3 = getWarningMarker(project, "Null type safety: The expression of type 'List<String>' needs unchecked conversion to conform to '@Nonnull List<String>'");
-			assertNull(marker3);
-			IJavaProject javaProject = JavaCore.create(project);
-			Map<String, String> options = javaProject.getOptions(true);
-			assertEquals(JavaCore.IGNORE, options.get(JavaCore.COMPILER_PB_NULL_UNCHECKED_CONVERSION));
-			Hashtable<String, String> defaultOptions = JavaCore.getDefaultOptions();
-			options.put(JavaCore.COMPILER_PB_NULL_UNCHECKED_CONVERSION, defaultOptions.get(JavaCore.COMPILER_PB_NULL_UNCHECKED_CONVERSION));
-			javaProject.setOptions(options);
-			waitForBackgroundJobs();
-			marker3 = getWarningMarker(project, "Null type safety: The expression of type 'List<String>' needs unchecked conversion to conform to '@Nonnull List<String>'");
 			assertNotNull(marker3);
 			assertTrue(marker3.getResource() instanceof IFile);
 			assertEquals("TestJavax.java", ((IFile) marker3.getResource()).getFullPath().lastSegment());

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManagerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManagerTest.java
@@ -406,5 +406,4 @@ public class PreferenceManagerTest {
 			assertEquals(false, preferenceManager.getPreferences().isTelemetryEnabled());
 		}
 	}
-
 }


### PR DESCRIPTION
This pull request replaces https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3225 which was based on master rather than main.

This reverts commit 6d8eb7a3677d014fdcf3c4761706832a24f9e68c because that change forces an opinionated and unnecessary fix on users.

The original issue was https://github.com/redhat-developer/vscode-java/issues/3501

In that issue, @snjeza [suggested](https://github.com/redhat-developer/vscode-java/issues/3501#issuecomment-1952529229) setting `org.eclipse.jdt.core.compiler.problem.nullUncheckedConversion=ignore` which is a reasonable workaround that any user can optionally apply. But it isn't correct to force this setting on all jdtls users.

In my project team, we want to keep this setting enabled, but jdtls keeps overwriting our settings, so we're forced to run a fork.

Could we please revert this change?