### PR TITLE
Add cleanups for various redundant modifiers/expressions/statements.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpRegistry.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpRegistry.java
@@ -57,7 +57,13 @@ public class CleanUpRegistry {
 			new LambdaExpressionAndMethodRefCleanUp(),
 			new OrganizeImportsCleanup(),
 			new RenameUnusedLocalVariableCleanup(),
-			new PatternInstanceofToSwitchCleanup());
+			new PatternInstanceofToSwitchCleanup(),
+			new RedundantModifiersCleanUp(),
+			new RedundantSuperCallCleanUp(),
+			new RedundantIfConditionCleanUp(),
+			new RedundantFallingThroughBlockEndCleanUp(),
+			new RedundantComparisonStatementCleanUp()
+		);
 
 		// Store in a Map so that they can be accessed by ID quickly
 		cleanUps = new HashMap<>();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/RedundantComparisonStatementCleanUp.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/RedundantComparisonStatementCleanUp.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+* Copyright (c) 2025 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.cleanup;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
+import org.eclipse.jdt.ui.cleanup.CleanUpContext;
+import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
+
+public class RedundantComparisonStatementCleanUp implements ISimpleCleanUp {
+
+	@Override
+	public Collection<String> getIdentifiers() {
+		return List.of("redundantComparisonStatement", CleanUpConstants.REMOVE_REDUNDANT_COMPARISON_STATEMENT);
+	}
+
+	@Override
+	public ICleanUpFix createFix(CleanUpContext context) throws CoreException {
+		Map<String, String> options = new Hashtable<>();
+		options.put(CleanUpConstants.REMOVE_REDUNDANT_COMPARISON_STATEMENT, CleanUpOptions.TRUE);
+		org.eclipse.jdt.internal.ui.fix.RedundantComparisonStatementCleanUp cleanup = new org.eclipse.jdt.internal.ui.fix.RedundantComparisonStatementCleanUp(options);
+		return cleanup.createFix(context);
+	}
+
+	@Override
+	public List<String> getRequiredCompilerMarkers() {
+		return Collections.emptyList();
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/RedundantFallingThroughBlockEndCleanUp.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/RedundantFallingThroughBlockEndCleanUp.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+* Copyright (c) 2025 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.cleanup;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
+import org.eclipse.jdt.ui.cleanup.CleanUpContext;
+import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
+
+public class RedundantFallingThroughBlockEndCleanUp implements ISimpleCleanUp {
+
+	@Override
+	public Collection<String> getIdentifiers() {
+		return List.of("redundantFallingThroughBlockEnd", CleanUpConstants.REDUNDANT_FALLING_THROUGH_BLOCK_END);
+	}
+
+	@Override
+	public ICleanUpFix createFix(CleanUpContext context) throws CoreException {
+		Map<String, String> options = new Hashtable<>();
+		options.put(CleanUpConstants.REDUNDANT_FALLING_THROUGH_BLOCK_END, CleanUpOptions.TRUE);
+		org.eclipse.jdt.internal.ui.fix.RedundantFallingThroughBlockEndCleanUp cleanup = new org.eclipse.jdt.internal.ui.fix.RedundantFallingThroughBlockEndCleanUp(options);
+		return cleanup.createFix(context);
+	}
+
+	@Override
+	public List<String> getRequiredCompilerMarkers() {
+		return Collections.emptyList();
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/RedundantIfConditionCleanUp.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/RedundantIfConditionCleanUp.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+* Copyright (c) 2025 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.cleanup;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
+import org.eclipse.jdt.ui.cleanup.CleanUpContext;
+import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
+
+public class RedundantIfConditionCleanUp implements ISimpleCleanUp {
+
+	@Override
+	public Collection<String> getIdentifiers() {
+		return List.of("redundantIfCondition", CleanUpConstants.REDUNDANT_IF_CONDITION);
+	}
+
+	@Override
+	public ICleanUpFix createFix(CleanUpContext context) throws CoreException {
+		Map<String, String> options = new Hashtable<>();
+		options.put(CleanUpConstants.REDUNDANT_IF_CONDITION, CleanUpOptions.TRUE);
+		org.eclipse.jdt.internal.ui.fix.RedundantIfConditionCleanUp cleanup = new org.eclipse.jdt.internal.ui.fix.RedundantIfConditionCleanUp(options);
+		return cleanup.createFix(context);
+	}
+
+	@Override
+	public List<String> getRequiredCompilerMarkers() {
+		return Collections.emptyList();
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/RedundantModifiersCleanUp.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/RedundantModifiersCleanUp.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+* Copyright (c) 2025 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.cleanup;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
+import org.eclipse.jdt.ui.cleanup.CleanUpContext;
+import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
+
+public class RedundantModifiersCleanUp implements ISimpleCleanUp {
+
+	@Override
+	public Collection<String> getIdentifiers() {
+		return List.of("redundantModifiers", CleanUpConstants.REMOVE_REDUNDANT_MODIFIERS);
+	}
+
+	@Override
+	public ICleanUpFix createFix(CleanUpContext context) throws CoreException {
+		Map<String, String> options = new Hashtable<>();
+		options.put(CleanUpConstants.REMOVE_REDUNDANT_MODIFIERS, CleanUpOptions.TRUE);
+		org.eclipse.jdt.internal.ui.fix.RedundantModifiersCleanUp cleanup = new org.eclipse.jdt.internal.ui.fix.RedundantModifiersCleanUp(options);
+		return cleanup.createFix(context);
+	}
+
+	@Override
+	public List<String> getRequiredCompilerMarkers() {
+		return Collections.emptyList();
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/RedundantSuperCallCleanUp.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/RedundantSuperCallCleanUp.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+* Copyright (c) 2025 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.cleanup;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
+import org.eclipse.jdt.ui.cleanup.CleanUpContext;
+import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
+
+public class RedundantSuperCallCleanUp implements ISimpleCleanUp {
+
+	@Override
+	public Collection<String> getIdentifiers() {
+		return List.of("redundantSuperCall", CleanUpConstants.REDUNDANT_SUPER_CALL);
+	}
+
+	@Override
+	public ICleanUpFix createFix(CleanUpContext context) throws CoreException {
+		Map<String, String> options = new Hashtable<>();
+		options.put(CleanUpConstants.REDUNDANT_SUPER_CALL, CleanUpOptions.TRUE);
+		org.eclipse.jdt.internal.ui.fix.RedundantSuperCallCleanUp cleanup = new org.eclipse.jdt.internal.ui.fix.RedundantSuperCallCleanUp(options);
+		return cleanup.createFix(context);
+	}
+
+	@Override
+	public List<String> getRequiredCompilerMarkers() {
+		return Collections.emptyList();
+	}
+
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpsTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpsTest.java
@@ -729,4 +729,31 @@ public class CleanUpsTest extends AbstractMavenBasedTest {
 		assertEquals(expected, actual);
 	}
 
+	@Test
+	public void testRedundantModifiersCleanup() throws Exception {
+		String contents = """
+				package test1;
+				public abstract interface IFoo {
+					public static final int MAGIC_NUMBER = 646;
+					public abstract int foo ();
+					public int bar (int bazz);
+				}
+				""";
+
+		ICompilationUnit unit = pack1.createCompilationUnit("A.java", contents, false, monitor);
+		String uri = unit.getUnderlyingResource().getLocationURI().toString();
+
+		String expected = """
+				package test1;
+				public interface IFoo {
+					int MAGIC_NUMBER = 646;
+					int foo ();
+					int bar (int bazz);
+				}
+				""";
+		List<TextEdit> textEdits = registry.getEditsForAllActiveCleanUps(new TextDocumentIdentifier(uri), Arrays.asList("redundantModifiers"), monitor);
+		String actual = TextEditUtil.apply(unit, textEdits);
+		assertEquals(expected, actual);
+	}
+
 }


### PR DESCRIPTION
- redundantComparisonStatement, redundantFallingThroughBlockEnd, redundantIfCondition, redundantModifiers, redundantSuperCall
- Addresses https://github.com/redhat-developer/vscode-java/issues/4066
- Requires https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2262