### PR TITLE
Try to find and setup sourcePath for android.jar

### DIFF
--- a/org.eclipse.jdt.ls.core/gradle/android/init.gradle
+++ b/org.eclipse.jdt.ls.core/gradle/android/init.gradle
@@ -391,7 +391,15 @@ class JavaLanguageServerAndroidPlugin implements Plugin<Project> {
 
         @Override
         void execute(Classpath classpath) {
-            classpath.entries.add(new Library(fileReferenceFactory.fromFile(androidSDKFile)))
+            Library library = new Library(fileReferenceFactory.fromFile(androidSDKFile))
+
+            File platformsDir = androidSDKFile.getParentFile() // android-sdk/platforms/android-XX
+            String platformBasename = platformsDir.getName() // android-XX
+            File sourcesDir = new File(platformsDir.getParentFile().getParentFile(), "sources" + File.separator + platformBasename)
+            if (sourcesDir.exists() && sourcesDir.isDirectory()) {
+                library.setSourcePath(fileReferenceFactory.fromFile(sourcesDir))
+            }
+            classpath.entries.add(new library)
         }
     }
 


### PR DESCRIPTION
Try to find and setup sourcePath for android.jar, this allow user to jump to actually sdk source code downloaded by sdkmanager, 
instead of using decompiler generate one