### PR TITLE
Set permissions for bundles to 644 (writeable for owner).

### DIFF
--- a/org.eclipse.jdt.ls.product/publish-assembly.xml
+++ b/org.eclipse.jdt.ls.product/publish-assembly.xml
@@ -22,7 +22,7 @@
         <include>features/**</include>
         <include>plugins/**</include>
       </includes>
-      <fileMode>444</fileMode>
+      <fileMode>644</fileMode>
     </fileSet>
     <fileSet>
       <directory>${basedir}/target/repository</directory>


### PR DESCRIPTION
- Assist downstream clients in managing the installation and align with other installations
- Fixes https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/3482