### PR TITLE
Fix AndroidSupport with recent AGP versions

### DIFF
--- a/org.eclipse.jdt.ls.core/gradle/android/init.gradle
+++ b/org.eclipse.jdt.ls.core/gradle/android/init.gradle
@@ -45,11 +45,11 @@ class JavaLanguageServerAndroidPlugin implements Plugin<Project> {
         if (!project.hasProperty(ECLIPSE_PROPERTY)) {
             return
         }
-        File androidSDKFile = getAndroidSDKFile(project)
-        if (androidSDKFile == null) {
-            return
-        }
         project.afterEvaluate {
+            File androidSDKFile = getAndroidSDKFile(project)
+            if (androidSDKFile == null) {
+                return
+            }
             List<Object> variants = getAndroidDebuggableVariants(project)
             EclipseModel eclipseModel = (EclipseModel) project.property(ECLIPSE_PROPERTY)
             // eclipseModel.synchronizationTasks() is available since Gradle 5.4

--- a/org.eclipse.jdt.ls.tests/projects/gradle/android/app/build.gradle
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/android/app/build.gradle
@@ -35,6 +35,7 @@ android {
     buildFeatures {
         viewBinding true
     }
+    namespace = 'com.example.myapplication'
 }
 
 dependencies {

--- a/org.eclipse.jdt.ls.tests/projects/gradle/android/build.gradle
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/android/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.4.0' apply false
-    id 'com.android.library' version '7.4.0' apply false
+    id 'com.android.application' version '8.3.2' apply false
+    id 'com.android.library' version '8.3.2' apply false
 }
 
 task clean(type: Delete) {


### PR DESCRIPTION
- Move getAndroidSDKFile into project.afterEvaluate
- Update testAndroidProjectSupport to AGP 8.3.2
- Fixes eclipse-jdtls/eclipse.jdt.ls#3181
- Fixes eclipse-jdtls/eclipse.jdt.ls#3284
- Fixes redhat-developer/vscode-java#3682
