### PR TITLE
Fix path expansion for 'sources' of 'referencedLibraries' setting.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -844,14 +844,17 @@ public class Preferences {
 			};
 			this.exclude.addAll(exclude);
 			this.sources = new HashMap<>() {
-
 				@Override
 				public String put(String key, String value) {
 					return super.put(ResourceUtils.expandPath(key), ResourceUtils.expandPath(value));
 				}
-
 			};
-			this.sources.putAll(sources);
+
+			// Avoid 'putAll' as it may not call 'put', thus skipping expansion
+			// https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/3495
+			for (Map.Entry<String, String> e : sources.entrySet()) {
+				this.sources.put(e.getKey(), e.getValue());
+			}
 		}
 
 		public Set<String> getInclude() {


### PR DESCRIPTION
- Fixes #3495 
- 'putAll' implementation for a Map is not guaranteed to call 'put' on each element, so 'sources' entries of 'java.project.referencedLibraries' may not get expanded
- Add testcase