### PR TITLE
Provide server info in response to initialize call.

### DIFF
--- a/org.eclipse.jdt.ls.core/pom.xml
+++ b/org.eclipse.jdt.ls.core/pom.xml
@@ -126,6 +126,34 @@
 					</dependency>
 				</dependencies>
 			</plugin>
+			<plugin>
+				<groupId>io.github.git-commit-id</groupId>
+				<artifactId>git-commit-id-maven-plugin</artifactId>
+				<version>9.0.1</version>
+				<executions>
+					<execution>
+						<id>get-the-git-infos</id>
+						<goals>
+							<goal>revision</goal>
+						</goals>
+						<phase>initialize</phase>
+					</execution>
+				</executions>
+				<configuration>
+					<generateGitPropertiesFile>true</generateGitPropertiesFile>
+					<generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+					<includeOnlyProperties>
+						<includeOnlyProperty>^git.commit.id$</includeOnlyProperty>
+						<includeOnlyProperty>^git.commit.id.abbrev$</includeOnlyProperty>
+						<includeOnlyProperty>^git.commit.message.short$</includeOnlyProperty>
+						<includeOnlyProperty>^git.branch$</includeOnlyProperty>
+						<includeOnlyProperty>^git.build.version$</includeOnlyProperty>
+					</includeOnlyProperties>
+					<gitDescribe>
+						<skip>true</skip>
+					</gitDescribe>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 	<repositories>

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseInitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseInitHandler.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.ResourceBundle;
 
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
@@ -32,6 +33,7 @@ import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
 import org.eclipse.jdt.ls.core.internal.IConstants;
+import org.eclipse.jdt.ls.core.internal.JDTEnvironmentUtils;
 import org.eclipse.jdt.ls.core.internal.JSONUtility;
 import org.eclipse.jdt.ls.core.internal.JVMConfigurator;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
@@ -43,6 +45,7 @@ import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.ServerInfo;
 import org.osgi.service.prefs.BackingStoreException;
 
 /**
@@ -65,6 +68,7 @@ public abstract class BaseInitHandler {
 	public InitializeResult initialize(InitializeParams param) {
 		logInfo("Initializing Java Language Server " + JavaLanguageServerPlugin.getVersion());
 		InitializeResult result = new InitializeResult();
+		setServerInfo(result);
 		handleInitializationOptions(param);
 		registerCapabilities(result);
 
@@ -73,6 +77,16 @@ public abstract class BaseInitHandler {
 		triggerInitialization(preferenceManager.getPreferences().getRootPaths());
 		return result;
 	}
+
+	 public void setServerInfo(InitializeResult initializeResult) {
+		var rb = ResourceBundle.getBundle("git");
+
+		var serverInfo = new ServerInfo();
+		var name = "JDT Language Server (%s)".formatted(JDTEnvironmentUtils.isSyntaxServer() ? "Syntax" : "Standard");
+		serverInfo.setName(name);
+		serverInfo.setVersion(rb.getString("git.build.version"));
+		initializeResult.setServerInfo(serverInfo);
+	 }
 
 	@SuppressWarnings("unchecked")
 	public Map<?, ?> handleInitializationOptions(InitializeParams param) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandlerTest.java
@@ -153,6 +153,15 @@ public class InitHandlerTest extends AbstractProjectsManagerBasedTest {
 	}
 
 	@Test
+	public void testServerInfo() throws Exception {
+		InitializeResult result = initialize(false);
+
+		assertNotNull(result.getServerInfo());
+		assertNotNull(result.getServerInfo().getVersion());
+		assertNotNull(result.getServerInfo().getName());
+	}
+
+	@Test
 	public void testExecuteCommandProviderDynamicRegistration() throws Exception {
 		ClientPreferences mockCapabilies = mock(ClientPreferences.class);
 		when(mockCapabilies.isExecuteCommandDynamicRegistrationSupported()).thenReturn(Boolean.TRUE);


### PR DESCRIPTION
The InitHandler will fill the serverInfo with the dynamic Maven version property that is generated by the git-commit-id-maven-plugin.

Fixes #3484

When executing  `:LspInfo` in Neovim I can verify that the provided change works end to end.

```
vim.lsp: Active Clients ~
- jdtls (id: 1)
  - Version: 1.50.0-SNAPSHOT
  - Root directory: ~/Projekte/Open-Source/sonarlint-language-server
  - Command: { "jdtls", "--java-executable", "/usr/lib/jvm/java-21-openjdk/bin/java", "-configuration", "/home/marc/.cache/jdtls/configuration", "-data", "~l/.cache/jdtls/sonarlint-language-server-a2f90f" }
  - Settings: {
      java = {
        configuration = {
          runtimes = { {
              name = "JavaSE-24",
              path = "/usr/lib/jvm/java-24-openjdk"
            }, {
              name = "JavaSE-21",
              path = "/usr/lib/jvm/java-21-openjdk"
            }, {
              name = "JavaSE-17",
              path = "/usr/lib/jvm/java-17-openjdk"
            } }
        }
      }
    }
  - Attached buffers: 1
```