### PR TITLE
Add 'from IntelliJ IDEA' to the decompiler header

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/decompiler/FernFlowerDecompiler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/decompiler/FernFlowerDecompiler.java
@@ -43,7 +43,7 @@ import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
 import org.jetbrains.java.decompiler.main.extern.IResultSaver;
 
 public class FernFlowerDecompiler extends DecompilerImpl {
-	public static final String DECOMPILER_HEADER = "// Source code is decompiled from a .class file using FernFlower decompiler.\n";
+	public static final String DECOMPILER_HEADER = "// Source code is decompiled from a .class file using FernFlower decompiler (from Intellij IDEA).\n";
 
 	public static boolean isDecompiledContents(String contents) {
 		return contents != null && contents.startsWith(DECOMPILER_HEADER);


### PR DESCRIPTION
Hi, I’m part of the IntelliJ team that maintains the Fernflower decompiler. We’re glad to see that Eclipse LSP makes use of Fernflower. Since maintaining the decompiler requires a significant ongoing effort, we’d greatly appreciate it if Eclipse LSP could support this work by mentioning IntelliJ IDEA in the decompilation banner. Thanks!