### PR TITLE
Use the Eclipse 4.37 platform release repository.

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -26,7 +26,7 @@
 			<unit id="org.eclipse.pde.junit.runtime" version="0.0.0" />
 			<unit id="org.eclipse.jdt.junit4.runtime" version="0.0.0" />
 			<unit id="org.eclipse.jdt.core.manipulation" version="0.0.0" />
-            <repository location="https://download.eclipse.org/eclipse/updates/4.37-I-builds/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.37/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.jdt.core.compiler.batch" version="0.0.0"/>


### PR DESCRIPTION
- https://download.eclipse.org/eclipse/updates/4.37-I-builds will probably disappear soon, and 4.38-I-builds has not reached M1 so for the sake of stability, let's stick to the 4.37 release for now.