### PR TITLE
Add "getTroubleshootingInfo" command

### DIFF
--- a/org.eclipse.jdt.ls.core/plugin.xml
+++ b/org.eclipse.jdt.ls.core/plugin.xml
@@ -142,6 +142,9 @@
             <command
                   id="java.vm.getAllInstalls">
             </command>
+			<command
+				  id="java.getDiagnosticInfo">
+	 		</command>
              <command
                   id="java.project.resolveText">
             </command>

--- a/org.eclipse.jdt.ls.core/plugin.xml
+++ b/org.eclipse.jdt.ls.core/plugin.xml
@@ -143,7 +143,7 @@
                   id="java.vm.getAllInstalls">
             </command>
 			<command
-				  id="java.getDiagnosticInfo">
+				  id="java.getTroubleshootingInfo">
 	 		</command>
              <command
                   id="java.project.resolveText">

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
@@ -23,7 +23,6 @@ import org.eclipse.buildship.core.internal.util.gradle.GradleVersion;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.ls.core.internal.commands.BuildPathCommand;
-import org.eclipse.jdt.ls.core.internal.commands.DiagnosticInfoCommand;
 import org.eclipse.jdt.ls.core.internal.commands.DiagnosticsCommand;
 import org.eclipse.jdt.ls.core.internal.commands.OrganizeImportsCommand;
 import org.eclipse.jdt.ls.core.internal.commands.ProjectClasspathEntries;
@@ -31,6 +30,7 @@ import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand;
 import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand.ClasspathOptions;
 import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand.GetAllProjectOptions;
 import org.eclipse.jdt.ls.core.internal.commands.SourceAttachmentCommand;
+import org.eclipse.jdt.ls.core.internal.commands.TroubleshootingInfoCommand;
 import org.eclipse.jdt.ls.core.internal.commands.TypeHierarchyCommand;
 import org.eclipse.jdt.ls.core.internal.commands.VmCommand;
 import org.eclipse.jdt.ls.core.internal.framework.protobuf.ProtobufSupport;
@@ -211,8 +211,8 @@ public class JDTDelegateCommandHandler implements IDelegateCommandHandler {
 					return new SmartDetectionHandler(smartDetectionParams).getLocation(monitor);
 				case VmCommand.GET_ALL_INSTALL_COMMAND_ID:
 					return VmCommand.getAllVmInstalls();
-				case DiagnosticInfoCommand.GET_DIAGNOSTIC_INFO_COMMAND_ID:
-					return DiagnosticInfoCommand.getDiagnosticInfo();
+				case TroubleshootingInfoCommand.GET_TROUBLESHOOTING_INFO_COMMAND:
+					return TroubleshootingInfoCommand.getTroubleshootingInfo();
 				case "java.project.resolveText":
 					return PasteEventHandler.handleFilePasteEvent((String) arguments.get(0), (String) arguments.get(1), monitor);
 				default:

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
@@ -15,7 +15,6 @@ package org.eclipse.jdt.ls.core.internal;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -23,12 +22,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.eclipse.buildship.core.internal.util.gradle.GradleVersion;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.ls.core.internal.commands.BuildPathCommand;
+import org.eclipse.jdt.ls.core.internal.commands.DiagnosticInfoCommand;
 import org.eclipse.jdt.ls.core.internal.commands.DiagnosticsCommand;
 import org.eclipse.jdt.ls.core.internal.commands.OrganizeImportsCommand;
 import org.eclipse.jdt.ls.core.internal.commands.ProjectClasspathEntries;
-import org.eclipse.jdt.ls.core.internal.commands.ProjectClasspathEntry;
 import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand;
 import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand.ClasspathOptions;
 import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand.GetAllProjectOptions;
@@ -213,6 +211,8 @@ public class JDTDelegateCommandHandler implements IDelegateCommandHandler {
 					return new SmartDetectionHandler(smartDetectionParams).getLocation(monitor);
 				case VmCommand.GET_ALL_INSTALL_COMMAND_ID:
 					return VmCommand.getAllVmInstalls();
+				case DiagnosticInfoCommand.GET_DIAGNOSTIC_INFO_COMMAND_ID:
+					return DiagnosticInfoCommand.getDiagnosticInfo();
 				case "java.project.resolveText":
 					return PasteEventHandler.handleFilePasteEvent((String) arguments.get(0), (String) arguments.get(1), monitor);
 				default:

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/DiagnosticInfoCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/DiagnosticInfoCommand.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Castle Ridge Software and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Castle Ridge Software - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.commands;
+
+import java.io.File;
+
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
+import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
+import org.eclipse.m2e.core.embedder.IMavenConfiguration;
+
+/**
+ * This command collects some diagnostic info to displaying to the use in case of issues during project import.¨
+ * The purpose of this info is to display the effective values being used: many times, the configuration passed to
+ * the language server is only used as a start, with additional detection and configuration going on inside the
+ * tools like maven, etc.
+ */
+public class DiagnosticInfoCommand {
+
+	private DiagnosticInfoCommand() {
+	}
+
+	public static final String GET_DIAGNOSTIC_INFO_COMMAND_ID = "java.getDiagnosticInfo";
+
+	/**
+	 * Return Diagnostic Info
+	 */
+	public static final DiagnosticInfo getDiagnosticInfo() {
+		return new DiagnosticInfo();
+	}
+
+	public static final class DiagnosticInfo {
+		public String mavenUserSettings;
+		public String mavenGlobalSettings;
+		public String gradleJavaHome;
+		public String gradleUserHome;
+		public String[] activeImporters;
+
+		public DiagnosticInfo() {
+			IMavenConfiguration config = IMavenConfiguration.getWorkspaceConfiguration();
+			File userSettings = config.getSettingsLocations().userSettings();
+			if (userSettings != null) {
+				this.mavenUserSettings = userSettings.toString();
+			}
+			File globalSettings = config.getSettingsLocations().globalSettings();
+			if (globalSettings != null) {
+				this.mavenGlobalSettings = config.getSettingsLocations().globalSettings().toString();
+			}
+			this.activeImporters = ProjectsManager.importers().stream().map(importer -> importer.getClass().getName()).toArray(size -> new String[size]);
+
+			Preferences prefs = JavaLanguageServerPlugin.getPreferencesManager().getPreferences();
+			this.gradleJavaHome= prefs.getGradleJavaHome();
+			this.gradleUserHome= prefs.getGradleUserHome();
+		}
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/TroubleshootingInfoCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/TroubleshootingInfoCommand.java
@@ -25,28 +25,28 @@ import org.eclipse.m2e.core.embedder.IMavenConfiguration;
  * the language server is only used as a start, with additional detection and configuration going on inside the
  * tools like maven, etc.
  */
-public class DiagnosticInfoCommand {
+public class TroubleshootingInfoCommand {
 
-	private DiagnosticInfoCommand() {
+	private TroubleshootingInfoCommand() {
 	}
 
-	public static final String GET_DIAGNOSTIC_INFO_COMMAND_ID = "java.getDiagnosticInfo";
+	public static final String GET_TROUBLESHOOTING_INFO_COMMAND = "java.getTroubleshootingInfo";
 
 	/**
 	 * Return Diagnostic Info
 	 */
-	public static final DiagnosticInfo getDiagnosticInfo() {
-		return new DiagnosticInfo();
+	public static final TroubleshootingInfo getTroubleshootingInfo() {
+		return new TroubleshootingInfo();
 	}
 
-	public static final class DiagnosticInfo {
+	public static final class TroubleshootingInfo {
 		public String mavenUserSettings;
 		public String mavenGlobalSettings;
 		public String gradleJavaHome;
 		public String gradleUserHome;
 		public String[] activeImporters;
 
-		public DiagnosticInfo() {
+		public TroubleshootingInfo() {
 			IMavenConfiguration config = IMavenConfiguration.getWorkspaceConfiguration();
 			File userSettings = config.getSettingsLocations().userSettings();
 			if (userSettings != null) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/TroubleshootingInfoCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/TroubleshootingInfoCommand.java
@@ -20,7 +20,7 @@ import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
 import org.eclipse.m2e.core.embedder.IMavenConfiguration;
 
 /**
- * This command collects some diagnostic info to displaying to the use in case of issues during project import.¨
+ * This command collects some diagnostic info to display to the user in case of issues during project import.
  * The purpose of this info is to display the effective values being used: many times, the configuration passed to
  * the language server is only used as a start, with additional detection and configuration going on inside the
  * tools like maven, etc.


### PR DESCRIPTION
This PR adds a command to get diagnostic info from the language server. 

This is a "companion"-PR to https://github.com/redhat-developer/vscode-java/pull/4153