### PR TITLE
Improve Null Analysis

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectsManager.java
@@ -690,7 +690,6 @@ public class StandardProjectsManager extends ProjectsManager {
 		protobufSupport.onDidProjectsImported(monitor);
 		IFrameworkSupport androidSupport = new AndroidSupport();
 		androidSupport.onDidProjectsImported(monitor);
-		this.preferenceManager.getPreferences().updateAnnotationNullAnalysisOptions();
 	}
 
 	public static void cleanInvalidJavaProjects(IProgressMonitor monitor) {
@@ -722,6 +721,7 @@ public class StandardProjectsManager extends ProjectsManager {
 			}
 			this.shouldUpdateProjects = false;
 		}
+		this.preferenceManager.getPreferences().updateAnnotationNullAnalysisOptions();
 	}
 
 	@Override


### PR DESCRIPTION
Fixes #3531 

When applying this PR, the Preferences.updateAnnotationNullAnalysisOptions(boolean) method is about 50% faster when you enable Null Analysis in the [spring-boot](https://github.com/spring-projects/spring-boot) project.
The PR also defers calling Preferences.updateAnnotationNullAnalysisOptions() after the project is built.
cc @rgrunber 