### PR TITLE
Fix JDK versions for build and update 'javac' required toolchain.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,10 +39,10 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-    - name: Set up JDK 23
+    - name: Set up JDK 21
       uses: actions/setup-java@v3
       with:
-            java-version: '23'
+            java-version: '21'
             distribution: 'temurin'
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -20,6 +20,6 @@ jobs:
     with:
       projectId: eclipse.jdt.ls
       submodules: recursive
-      javaVersion: '25-ea'
+      javaVersion: '25'
     secrets:
       gitlabAPIToken: ${{ secrets.ECLIPSE_GITLAB_API_TOKEN }}

--- a/org.eclipse.jdt.ls.tests/pom.xml
+++ b/org.eclipse.jdt.ls.tests/pom.xml
@@ -77,7 +77,7 @@
 								<configuration>
 									<toolchains>
 										<jdk>
-											<id>JavaSE-23</id>
+											<id>JavaSE-25</id>
 										</jdk>
 									</toolchains>
 								</configuration>


### PR DESCRIPTION
- It should still be possible to build with a JDK 21
- Running the test suite with 'javac' enabled requires JDK 25 now

Based on some observations from https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/3537