### PR TITLE
Add telemetry when importing projects

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerPlugin.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerPlugin.java
@@ -136,6 +136,7 @@ public class JavaLanguageServerPlugin extends Plugin {
 	private ExecutorService executorService;
 	private CompletionContributionService completionContributionService;
 	private LogHandler logHandler;
+	private final TelemetryManager telemetryManager;
 
 	public static LanguageServerApplication getLanguageServer() {
 		return pluginInstance == null ? null : pluginInstance.languageServer;
@@ -143,6 +144,10 @@ public class JavaLanguageServerPlugin extends Plugin {
 
 	public static BundleContext getBundleContext() {
 		return JavaLanguageServerPlugin.context;
+	}
+
+	public JavaLanguageServerPlugin() {
+		this.telemetryManager = new TelemetryManager();
 	}
 
 	/*
@@ -162,10 +167,10 @@ public class JavaLanguageServerPlugin extends Plugin {
 		if (JDTEnvironmentUtils.isSyntaxServer()) {
 			disableServices();
 			preferenceManager = new PreferenceManager();
-			projectsManager = new SyntaxProjectsManager(preferenceManager);
+			projectsManager = new SyntaxProjectsManager(preferenceManager, telemetryManager);
 		} else {
 			preferenceManager = new StandardPreferenceManager();
-			projectsManager = new StandardProjectsManager(preferenceManager);
+			projectsManager = new StandardProjectsManager(preferenceManager, telemetryManager);
 		}
 		digestStore = new DigestStore(getStateLocation().toFile());
 		try {
@@ -367,7 +372,6 @@ public class JavaLanguageServerPlugin extends Plugin {
 	}
 
 	private void startConnection() throws IOException {
-		TelemetryManager telemetryManager = new TelemetryManager();
 		boolean firstTimeInitialization = ProjectUtils.getAllProjects().length == 0;
 		telemetryManager.onLanguageServerStart(System.currentTimeMillis(), firstTimeInitialization);
 		Launcher<JavaLanguageClient> launcher;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/LogReader.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/LogReader.java
@@ -28,10 +28,13 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.StringTokenizer;
+
+import org.eclipse.core.runtime.IStatus;
 
 /**
  * Copied from org.eclipse.ui.internal.views.log.LogReader
@@ -447,5 +450,24 @@ public class LogReader {
 		public int getSeverity() {
 			return severity;
 		}
+
+		public static LogEntry from(IStatus status) {
+			LogEntry entry = new LogEntry();
+			entry.fDate = new Date();
+			entry.message = status.getMessage();
+			entry.severity = status.getSeverity();
+			entry.code = status.getCode();
+			entry.pluginId = status.getPlugin();
+			if (status.getException() != null) {
+				StringWriter sw = new StringWriter();
+				status.getException().printStackTrace(new PrintWriter(sw));
+				String exceptionAsString = sw.toString();
+				entry.stack= status.getException().getMessage()+ '\n' + exceptionAsString;
+			}
+
+			entry.children = Arrays.stream(status.getChildren()).map(s -> from(status)).toList();
+			return entry;
+		}
 	}
+
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
@@ -80,6 +80,7 @@ import org.eclipse.jdt.ls.core.internal.IProjectImporter;
 import org.eclipse.jdt.ls.core.internal.JDTEnvironmentUtils;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaClientConnection.JavaLanguageClient;
+import org.eclipse.jdt.ls.core.internal.LogReader.LogEntry;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.JobHelpers;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
@@ -91,6 +92,8 @@ import org.eclipse.jdt.ls.core.internal.handlers.ProjectEncodingMode;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 
+import com.google.gson.JsonObject;
+
 public abstract class ProjectsManager implements ISaveParticipant, IProjectsManager {
 
 	public static final String DEFAULT_PROJECT_NAME = "jdt.ls-java-project";
@@ -100,15 +103,18 @@ public abstract class ProjectsManager implements ISaveParticipant, IProjectsMana
 	public static final String BUILD_FILE_MARKER_TYPE = "org.eclipse.jdt.ls.buildFileMarker";
 	private static final int JDTLS_FILTER_TYPE = IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.INHERITABLE | IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS;
 
-	private PreferenceManager preferenceManager;
+	protected final PreferenceManager preferenceManager;
+	protected final TelemetryManager telemetryManager;
+
 	protected JavaLanguageClient client;
 
 	public enum CHANGE_TYPE {
 		CREATED, CHANGED, DELETED
 	};
 
-	public ProjectsManager(PreferenceManager preferenceManager) {
+	public ProjectsManager(PreferenceManager preferenceManager, TelemetryManager telemetryManager) {
 		this.preferenceManager = preferenceManager;
+		this.telemetryManager = telemetryManager;
 	}
 
 	@Override
@@ -159,12 +165,21 @@ public abstract class ProjectsManager implements ISaveParticipant, IProjectsMana
 			File rootFolder = rootPath.toFile();
 			try {
 				for (IProjectImporter importer : importers()) {
-					importer.initialize(rootFolder);
-					if (importer.applies(subMonitor.split(1))) {
-						importer.importToWorkspace(subMonitor.split(70));
-						if (importer.isResolved(rootFolder)) {
-							break;
+					JsonObject properties = new JsonObject();
+					properties.addProperty("importer", importer.getClass().getName());
+					try {
+						importer.initialize(rootFolder);
+						if (importer.applies(subMonitor.split(1))) {
+							importer.importToWorkspace(subMonitor.split(70));
+							if (importer.isResolved(rootFolder)) {
+								break;
+							}
 						}
+					} catch (CoreException e) {
+						TelemetryEvent.addLogEntryProperties(properties, LogEntry.from(e.getStatus()));
+						throw e;
+					} finally {
+						this.telemetryManager.sendEvent(new TelemetryEvent(TelemetryEvent.IMPORT_PROJECT, properties));
 					}
 				}
 			} catch (CoreException e) {
@@ -187,10 +202,19 @@ public abstract class ProjectsManager implements ISaveParticipant, IProjectsMana
 					.filter(rootPath::isPrefixOf).collect(Collectors.toSet());
 			try {
 				for (IProjectImporter importer : importers()) {
-					importer.initialize(rootFolder);
-					if (importer.applies(buildFiles, subMonitor.split(1))) {
-						importer.importToWorkspace(subMonitor.split(70));
-						buildFiles = removeImportedConfigurations(buildFiles, importer);
+					JsonObject properties = new JsonObject();
+					properties.addProperty("importer", importer.getClass().getName());
+					try {
+						importer.initialize(rootFolder);
+						if (importer.applies(buildFiles, subMonitor.split(1))) {
+							importer.importToWorkspace(subMonitor.split(70));
+							buildFiles = removeImportedConfigurations(buildFiles, importer);
+						}
+					} catch (CoreException e) {
+						TelemetryEvent.addLogEntryProperties(properties, LogEntry.from(e.getStatus()));
+						throw e;
+					} finally {
+						this.telemetryManager.sendEvent(new TelemetryEvent(TelemetryEvent.IMPORT_PROJECT, properties));
 					}
 				}
 			} catch (CoreException e) {
@@ -207,11 +231,11 @@ public abstract class ProjectsManager implements ISaveParticipant, IProjectsMana
 	private Set<IPath> removeImportedConfigurations(Set<IPath> configurations, IProjectImporter importer) {
 		return configurations.stream()
 			.filter(config -> {
-				try {
-					return !importer.isResolved(config.toFile());
-				} catch (OperationCanceledException | CoreException e) {
-					return true;
-				}
+			try {
+				return !importer.isResolved(config.toFile());
+			} catch (OperationCanceledException | CoreException e) {
+				return true;
+			}
 			})
 			.collect(Collectors.toSet());
 	}
@@ -683,8 +707,8 @@ public abstract class ProjectsManager implements ISaveParticipant, IProjectsMana
 			}
 			List<IResourceFilterDescription> filters = Stream.of(project.getFilters())
 					.filter(f -> {
-						FileInfoMatcherDescription matcher = f.getFileInfoMatcherDescription();
-						return CORE_RESOURCES_MATCHER_ID.equals(matcher.getId()) && matcher.getArguments() instanceof String args && args.contains(CREATED_BY_JAVA_LANGUAGE_SERVER);
+				FileInfoMatcherDescription matcher = f.getFileInfoMatcherDescription();
+				return CORE_RESOURCES_MATCHER_ID.equals(matcher.getId()) && matcher.getArguments() instanceof String args && args.contains(CREATED_BY_JAVA_LANGUAGE_SERVER);
 					})
 					.collect(Collectors.toList());
 			boolean filterExists = false;
@@ -841,8 +865,8 @@ public abstract class ProjectsManager implements ISaveParticipant, IProjectsMana
 			);
 			List<URI> projectUris = filesToImport.stream()
 					.map(path -> {
-						IFile file = JDTUtils.findFile(path.toFile().toURI().toString());
-						return file == null ? null : file.getProject();
+				IFile file = JDTUtils.findFile(path.toFile().toURI().toString());
+				return file == null ? null : file.getProject();
 					})
 					.filter(Objects::nonNull)
 					.map(project -> ProjectUtils.getProjectRealFolder(project).toFile().toURI())

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectsManager.java
@@ -109,7 +109,6 @@ public class StandardProjectsManager extends ProjectsManager {
 	private final static String FORMATTER_OPTION_PREFIX = JavaCore.PLUGIN_ID + ".formatter"; //$NON-NLS-1$
 	protected static final String BUILD_SUPPORT_EXTENSION_POINT_ID = "buildSupport";
 	private static final Set<Either<String, RelativePattern>> watchers = new LinkedHashSet<>();
-	private PreferenceManager preferenceManager;
 	private boolean buildFinished;
 	private boolean shouldUpdateProjects;
 
@@ -146,9 +145,8 @@ public class StandardProjectsManager extends ProjectsManager {
 
 	private IPreferencesChangeListener preferenceChangeListener = null;
 
-	public StandardProjectsManager(PreferenceManager preferenceManager) {
-		super(preferenceManager);
-		this.preferenceManager = preferenceManager;
+	public StandardProjectsManager(PreferenceManager preferenceManager, TelemetryManager telemetryManager) {
+		super(preferenceManager, telemetryManager);
 	}
 
 	@Override

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/TelemetryEvent.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/TelemetryEvent.java
@@ -12,7 +12,15 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal.managers;
 
+import org.eclipse.jdt.ls.core.internal.LogReader.LogEntry;
+
+import com.google.gson.JsonObject;
+
 public class TelemetryEvent {
+
+	public static final String JAVA_PROJECT_BUILD = "java.workspace.initialized";
+	public static final String IMPORT_PROJECT = "java.workspace.importProject";
+
 	private String name;
 	private Object properties;
 
@@ -27,5 +35,25 @@ public class TelemetryEvent {
 
 	public Object getProperties() {
 		return properties;
+	}
+
+	public static void addLogEntryProperties(JsonObject properties, LogEntry entry) {
+		properties.addProperty("message", redact(entry.getMessage()));
+		if (entry.getStack() != null) {
+			properties.addProperty("exception", entry.getMessage() + '\n' + entry.getStack());
+		}
+	}
+
+	private static String redact(String message) {
+		// not sure why we're doing this, introduced in https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/2715
+		if (message == null) {
+			return null;
+		}
+
+		if (message.startsWith("Error occured while building workspace.")) {
+			return "Error occured while building workspace.";
+		}
+
+		return message;
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/TelemetryManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/TelemetryManager.java
@@ -42,9 +42,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 
 public class TelemetryManager {
-
-	private static final String JAVA_PROJECT_BUILD = "java.workspace.initialized";
-
 	private JavaLanguageClient client;
 	private PreferenceManager prefs;
 	private ProjectsManager projectsManager;
@@ -52,10 +49,6 @@ public class TelemetryManager {
 	private long serviceReadyTime;
 	private long projectsInitializedTime;
 	private boolean firstTimeInitialization;
-	public TelemetryManager(JavaLanguageClient client, PreferenceManager prefs) {
-		this.client = client;
-		this.prefs = prefs;
-	}
 
 	public TelemetryManager() {
 	}
@@ -189,7 +182,7 @@ public class TelemetryManager {
 		properties.addProperty("dependency.count", Integer.toString(indexCount));
 		properties.addProperty("dependency.size", Long.toString(librarySize));
 
-		telemetryEvent(JAVA_PROJECT_BUILD, properties);
+		telemetryEvent(TelemetryEvent.JAVA_PROJECT_BUILD, properties);
 	}
 
 	/**
@@ -250,10 +243,14 @@ public class TelemetryManager {
 	}
 
 	private void telemetryEvent(String name, JsonObject properties) {
-		boolean telemetryEnabled = prefs.getPreferences().isTelemetryEnabled();
-		if (telemetryEnabled) {
-			client.telemetryEvent(new TelemetryEvent(name, properties));
+		this.sendEvent(new TelemetryEvent(name, properties));
+	}
+
+	public void sendEvent(TelemetryEvent event) {
+		if (prefs == null  || !prefs.getPreferences().isTelemetryEnabled()) {
+			return;
 		}
+		client.telemetryEvent(event);
 	}
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/syntaxserver/SyntaxProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/syntaxserver/SyntaxProjectsManager.java
@@ -50,6 +50,7 @@ import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.ResourceUtils;
 import org.eclipse.jdt.ls.core.internal.managers.IBuildSupport;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
+import org.eclipse.jdt.ls.core.internal.managers.TelemetryManager;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
 import org.eclipse.lsp4j.DidChangeWatchedFilesRegistrationOptions;
@@ -82,8 +83,8 @@ public class SyntaxProjectsManager extends ProjectsManager {
 		}
 	};
 
-	public SyntaxProjectsManager(PreferenceManager preferenceManager) {
-		super(preferenceManager);
+	public SyntaxProjectsManager(PreferenceManager preferenceManager, TelemetryManager telemetryManager) {
+		super(preferenceManager, telemetryManager);
 	}
 
 	@Override

--- a/org.eclipse.jdt.ls.tests.syntaxserver/src/org/eclipse/jdt/ls/core/internal/syntaxserver/AbstractSyntaxProjectsManagerBasedTest.java
+++ b/org.eclipse.jdt.ls.tests.syntaxserver/src/org/eclipse/jdt/ls/core/internal/syntaxserver/AbstractSyntaxProjectsManagerBasedTest.java
@@ -47,6 +47,7 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.WorkingCopyOwner;
 import org.eclipse.jdt.ls.core.internal.DocumentAdapter;
 import org.eclipse.jdt.ls.core.internal.JavaClientConnection.JavaLanguageClient;
+import org.eclipse.jdt.ls.core.internal.managers.TelemetryManager;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.JobHelpers;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
@@ -105,7 +106,7 @@ public abstract class AbstractSyntaxProjectsManagerBasedTest {
 
 		oldPreferenceManager = JavaLanguageServerPlugin.getPreferencesManager();
 		JavaLanguageServerPlugin.setPreferencesManager(preferenceManager);
-		projectsManager = new SyntaxProjectsManager(preferenceManager);
+		projectsManager = new SyntaxProjectsManager(preferenceManager, new TelemetryManager());
 		monitor = new NullProgressMonitor();
 		WorkingCopyOwner.setPrimaryBufferProvider(new WorkingCopyOwner() {
 			@Override

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractProjectsManagerBasedTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractProjectsManagerBasedTest.java
@@ -179,7 +179,7 @@ public abstract class AbstractProjectsManagerBasedTest {
 
 		oldPreferenceManager = JavaLanguageServerPlugin.getPreferencesManager();
 		JavaLanguageServerPlugin.setPreferencesManager(preferenceManager);
-		projectsManager = new StandardProjectsManager(preferenceManager);
+		projectsManager = new StandardProjectsManager(preferenceManager, new TelemetryManager());
 		ProgressReporterManager progressManager = new ProgressReporterManager(this.client, preferenceManager);
 		progressManager.setReportThrottle(0);//disable throttling to ensure we capture all events
 		Job.getJobManager().setProgressProvider(progressManager);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectManagerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectManagerTest.java
@@ -35,7 +35,7 @@ public class StandardProjectManagerTest {
 		 * @param preferenceManager
 		 */
 		public StandardProjectsManagerDummy(PreferenceManager preferenceManager) {
-			super(preferenceManager);
+			super(preferenceManager, new TelemetryManager());
 		}
 
 		@Override


### PR DESCRIPTION
This PR adds a telemetry even each time a projects are imported. The event reports the class name of the importer being used and logs the exception if the importer throws one. This will allow us to track a couple of things:

1. Number of failed imports vs. all import runs
2. Which importers fail more often than others
3. Relative usage of importers, which proxies use of build tools.