### PR TITLE
feat: suppress same-name numbered parameters inlay hints

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InlayHintsPreferenceChangeListener.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InlayHintsPreferenceChangeListener.java
@@ -25,7 +25,8 @@ public class InlayHintsPreferenceChangeListener implements IPreferencesChangeLis
     public void preferencesChange(Preferences oldPreferences, Preferences newPreferences) {
 		if (!Objects.equals(oldPreferences.getInlayHintsParameterMode(), newPreferences.getInlayHintsParameterMode())
 		|| oldPreferences.isInlayHintsVariableTypesEnabled() != newPreferences.isInlayHintsVariableTypesEnabled()
-		|| oldPreferences.isInlayHintsParameterTypesEnabled() != newPreferences.isInlayHintsParameterTypesEnabled()) {
+		|| oldPreferences.isInlayHintsParameterTypesEnabled() != newPreferences.isInlayHintsParameterTypesEnabled()
+		|| oldPreferences.isInlayHintsSuppressedWhenSameNameNumberedParameter() != newPreferences.isInlayHintsSuppressedWhenSameNameNumberedParameter()) {
             refresh();
         }
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -502,9 +502,12 @@ public class Preferences {
 	 */
 	public static final String JAVA_INLAYHINTS_PARAMETERNAMES_ENABLED = "java.inlayHints.parameterNames.enabled";
 
+	public static final String JAVA_INLAYHINTS_PARAMETERNAMES_SUPPRESS_WHEN_SAME_NAME_NUMBERED = "java.inlayHints.parameterNames.suppressWhenSameNameNumbered";
+
 	public static final String JAVA_INLAYHINTS_VARIABLETYPES_ENABLED = "java.inlayHints.variableTypes.enabled";
 
 	public static final String JAVA_INLAYHINTS_PARAMETERTYPES_ENABLED = "java.inlayHints.parameterTypes.enabled";
+
 	/**
 	 * Preference key for the inlay hints exclusion list
 	 */
@@ -716,6 +719,7 @@ public class Preferences {
 	private boolean chainCompletionEnabled;
 	private List<String> diagnosticFilter;
 	private SearchScope searchScope;
+	private boolean inlayHintsSuppressedWhenSameNameNumberedParameter;
 
 	static {
 		JAVA_IMPORT_EXCLUSIONS_DEFAULT = new LinkedList<>();
@@ -1331,6 +1335,8 @@ public class Preferences {
 		prefs.setIncludeSourceMethodDeclarations(includeSourceMethodDeclarations);
 		String inlayHintsParameterMode = getString(configuration, JAVA_INLAYHINTS_PARAMETERNAMES_ENABLED, null);
 		prefs.setInlayHintsParameterMode(InlayHintsParameterMode.fromString(inlayHintsParameterMode, InlayHintsParameterMode.LITERALS));
+		boolean inlayHintsSuppressedWhenSameNameNumberedParameter = getBoolean(configuration, JAVA_INLAYHINTS_PARAMETERNAMES_SUPPRESS_WHEN_SAME_NAME_NUMBERED, true);
+		prefs.setInlayHintsSuppressedWhenSameNameNumberedParameter(inlayHintsSuppressedWhenSameNameNumberedParameter);
 		List<String> inlayHintsExclusionList = getList(configuration, JAVA_INLAYHINTS_PARAMETERNAMES_EXCLUSIONS, Collections.emptyList());
 		prefs.setInlayHintsExclusionList(inlayHintsExclusionList);
 		boolean inlayHintsVariableTypesEnabled = getBoolean(configuration, JAVA_INLAYHINTS_VARIABLETYPES_ENABLED, false);
@@ -2357,6 +2363,14 @@ public class Preferences {
 
 	public void setInlayHintsParameterMode(InlayHintsParameterMode inlayHintsParameterMode) {
 		this.inlayHintsParameterMode = inlayHintsParameterMode;
+	}
+
+	public boolean isInlayHintsSuppressedWhenSameNameNumberedParameter() {
+		return inlayHintsSuppressedWhenSameNameNumberedParameter;
+	}
+
+	public void setInlayHintsSuppressedWhenSameNameNumberedParameter(boolean inlayHintsSuppressedWhenSameNameNumberedParameter) {
+		this.inlayHintsSuppressedWhenSameNameNumberedParameter = inlayHintsSuppressedWhenSameNameNumberedParameter;
 	}
 
 	public Preferences setProjectEncoding(ProjectEncodingMode projectEncoding) {


### PR DESCRIPTION
Adds new `java.inlayHints.parameterNames.suppressWhenSameNameNumbered` setting to show/hide inlay hints for method parameters that follow the same prefix followed by an incremented number (1st parameter must start at 1, increment by 1).

When set to `true`, the default, e1, e2, e3 parameter inlay hints are hidden:
<img width="202" height="30" alt="Screenshot 2025-10-10 at 13 04 51" src="https://github.com/user-attachments/assets/b43ca58a-e8fd-43e8-8475-2734e9762ba5" />

shown when set to `false`:
<img width="291" height="30" alt="Screenshot 2025-10-10 at 13 05 05" src="https://github.com/user-attachments/assets/b902cbb5-c850-4be4-aff5-a4aec4cd3516" />
