### PR TITLE
Allow whitespace before a Region Start or Region End marker comment

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/FoldingRangeHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/FoldingRangeHandler.java
@@ -48,8 +48,8 @@ import org.eclipse.lsp4j.FoldingRangeRequestParams;
 
 public class FoldingRangeHandler {
 
-	private static final Pattern REGION_START_PATTERN = Pattern.compile("^//\\s*#?region|^//\\s+<editor-fold.*>");
-	private static final Pattern REGION_END_PATTERN = Pattern.compile("^//\\s*#?endregion|^//\\s+</editor-fold>");
+	private static final Pattern REGION_START_PATTERN = Pattern.compile("^\\h//\\s*#?region|^//\\s+<editor-fold.*>");
+	private static final Pattern REGION_END_PATTERN = Pattern.compile("^\\h//\\s*#?endregion|^//\\s+</editor-fold>");
 
 	private static IScanner fScanner;
 
@@ -301,3 +301,4 @@ public class FoldingRangeHandler {
 		}
 	}
 }
+


### PR DESCRIPTION
Many formatters (such as prettier) add whitespace before comments to align them with the code they are contained in. This change accommodates files formatted with these tools.