### PR TITLE
fix: don't log an error for IContentProvider instances not matching the IDecompiler interface

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ContentProviderManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ContentProviderManager.java
@@ -105,7 +105,7 @@ public class ContentProviderManager {
 		for (ContentProviderDescriptor match : matches) {
 			IContentProvider contentProvider = match.getContentProvider();
 			if (!providerType.isInstance(contentProvider)) {
-				JavaLanguageServerPlugin.logError("Unable to load " + providerType.getSimpleName() + " class for " + match.id);
+				JavaLanguageServerPlugin.debugTrace(match.id + " doesn't match " + providerType.getSimpleName() + ". Skipping.");
 				continue;
 			}
 


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-java/issues/3178