### PR TITLE
feat: return CompletionItemKind.Field instead of Property for Annotation attributes completion

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -514,6 +514,7 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 				return CompletionItemKind.Constant;
 			}
 			return CompletionItemKind.Field;
+		case CompletionProposal.ANNOTATION_ATTRIBUTE_REF:
 		case CompletionProposal.FIELD_REF_WITH_CASTED_RECEIVER:
 			return CompletionItemKind.Field;
 		case CompletionProposal.KEYWORD:
@@ -531,8 +532,6 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 		case CompletionProposal.LAMBDA_EXPRESSION:
 			return CompletionItemKind.Method;
 			//text
-		case CompletionProposal.ANNOTATION_ATTRIBUTE_REF:
-			return CompletionItemKind.Property;
 		case CompletionProposal.JAVADOC_BLOCK_TAG:
 		case CompletionProposal.JAVADOC_FIELD_REF:
 		case CompletionProposal.JAVADOC_INLINE_TAG:

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -3293,10 +3293,10 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertNotNull(list);
 		assertEquals(1, list.getItems().size());
 		ci = list.getItems().get(0);
-		assertEquals(CompletionItemKind.Property, ci.getKind());
+		assertEquals(CompletionItemKind.Field, ci.getKind());
 		assertEquals("someMethod : String", ci.getLabel());
 		resolvedItem = server.resolveCompletionItem(ci).join();
-		assertEquals(CompletionItemKind.Property, resolvedItem.getKind());
+		assertEquals(CompletionItemKind.Field, resolvedItem.getKind());
 		documentation = resolvedItem.getDocumentation().getLeft();
 		assertEquals("Default: \"test\"", documentation);
 	}
@@ -4064,7 +4064,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertNotNull(list);
 		assertFalse(list.getItems().isEmpty());
 		for (CompletionItem item : list.getItems()) {
-			assertEquals(CompletionItemKind.Property, item.getKind());
+			assertEquals(CompletionItemKind.Field, item.getKind());
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-java/issues/3242#issuecomment-1683448506

Rendering in VS Code changes from the weird wrench
<img width="531" height="66" alt="Screenshot 2025-11-03 at 11 39 58" src="https://github.com/user-attachments/assets/e1d8a118-fef9-4a1c-be43-374a7a7c18f4" />

to the regular field icon
<img height="66" alt="Screenshot 2025-11-03 at 11 13 54" src="https://github.com/user-attachments/assets/d5793c3e-ebe3-45cc-9127-51bbfe108f63" />
