### PR TITLE
Wait for update jobs & build before reporting "build finished"

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JobHelpers.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JobHelpers.java
@@ -201,7 +201,7 @@ public final class JobHelpers {
 			try {
 				Thread.sleep(POLLING_DELAY);
 			} catch(InterruptedException e) {
-				// ignore and keep waiting
+				Thread.currentThread().interrupt();
 			}
 		}
 	}
@@ -246,6 +246,10 @@ public final class JobHelpers {
 		waitForJobs(RepositoryRegistryUpdateJobMatcher.INSTANCE, MAX_TIME_MILLIS);
 	}
 
+	public static void waitForUpdateJobs(int maxTimeMillis) {
+		waitForJobs(UpdateJobMatcher.INSTANCE, maxTimeMillis);
+	}
+
 	// copied from ./org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceTests.java
 	public static void waitUntilIndexesReady() {
 		// dummy query for waiting until the indexes are ready
@@ -266,6 +270,17 @@ public final class JobHelpers {
 	interface IJobMatcher {
 
 		boolean matches(Job job);
+
+	}
+
+	static class UpdateJobMatcher implements IJobMatcher {
+
+		public static final IJobMatcher INSTANCE = new UpdateJobMatcher();
+
+		@Override
+		public boolean matches(Job job) {
+			return job.belongsTo(IConstants.UPDATE_PROJECT_FAMILY);
+		}
 
 	}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -330,6 +330,10 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 					pm.checkIndexes();
 					debugTrace(">> indexes checked");
 					pm.projectsBuildFinished(monitor);
+
+					JobHelpers.waitForUpdateJobs(60 * 60 * 1000);
+					JobHelpers.waitForBuildJobs(60 * 60 * 1000); // 1 hour
+
 					telemetryManager.onBuildFinished(System.currentTimeMillis());
 					workspaceDiagnosticsHandler = new WorkspaceDiagnosticsHandler(JDTLanguageServer.this.client, pm, preferenceManager.getClientPreferences(), documentLifeCycleHandler);
 					workspaceDiagnosticsHandler.addResourceChangeListener();


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-java/issues/4230

I noticed that the telemetry event `java.workspace.initialized` was fired with autobuild still happening after the event. In my case (maven source) this lead to no project errors and not unresolved imports being reported in telemetry.

The PR waits for the "Update Project" jobs that are triggered after import and the ensuing autobuild to finish before reporting the telemetry.