### PR TITLE
fix: implement new assignToVariableAssistProposalToT() from LocalCorrectionsBaseSubProcess

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/LocalCorrectionsSubProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/LocalCorrectionsSubProcessor.java
@@ -80,6 +80,7 @@ import org.eclipse.jdt.internal.ui.fix.CodeStyleCleanUpCore;
 import org.eclipse.jdt.internal.ui.text.correction.IProposalRelevance;
 import org.eclipse.jdt.internal.ui.text.correction.LocalCorrectionsBaseSubProcessor;
 import org.eclipse.jdt.internal.ui.text.correction.ProblemLocation;
+import org.eclipse.jdt.internal.ui.text.correction.proposals.AssignToVariableAssistProposalCore;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.ChangeMethodSignatureProposalCore;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.ConstructorFromSuperclassProposalCore;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.CreateNewObjectProposalCore;
@@ -919,6 +920,11 @@ public class LocalCorrectionsSubProcessor extends LocalCorrectionsBaseSubProcess
 
 	@Override
 	protected ProposalKindWrapper newLocalVariableCorrectionProposalToT(NewLocalVariableCorrectionProposalCore core, int uid) {
+		return CodeActionHandler.wrap(core, CodeActionKind.QuickFix);
+	}
+
+	@Override
+	protected ProposalKindWrapper assignToVariableAssistProposalToT(AssignToVariableAssistProposalCore core) {
 		return CodeActionHandler.wrap(core, CodeActionKind.QuickFix);
 	}
 


### PR DESCRIPTION
https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2640  broke LocalCorrectionsSubProcessor by introducing a new abstract `assignToVariableAssistProposalToT()` method. This PR fixes it.