### PR TITLE
build: fetch jdt.core bundles from the canonical JDT repository

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -26,13 +26,13 @@
 			<unit id="org.eclipse.pde.junit.runtime" version="0.0.0" />
 			<unit id="org.eclipse.jdt.junit4.runtime" version="0.0.0" />
 			<unit id="org.eclipse.jdt.core.manipulation" version="0.0.0" />
+			<unit id="org.eclipse.jdt.core.compiler.batch" version="0.0.0"/>
+			<unit id="org.eclipse.jdt.core" version="0.0.0"/>
+			<unit id="org.eclipse.jdt.apt.core" version="0.0.0"/>
             <repository location="https://download.eclipse.org/eclipse/updates/4.38-I-builds/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="org.eclipse.jdt.core.compiler.batch" version="0.0.0"/>
-            <unit id="org.eclipse.jdt.core" version="0.0.0"/>
 			<unit id="org.eclipse.jdt.core.javac" version="0.0.0"/>
-            <unit id="org.eclipse.jdt.apt.core" version="0.0.0"/>
             <repository location="https://ci.eclipse.org/ls/job/jdt-core-incubator/job/dom-with-javac/lastSuccessfulBuild/artifact/repository/target/repository/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
... to ensure we always get the latest fixes from upstream, instead of picking up maybe stale jars from the incubator repo.

Signed-off-by: Fred Bricon <fbricon@gmail.com>
