### PR TITLE
feat: enable 'refreshCodeLenses'

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
@@ -217,6 +217,10 @@ public class JavaClientConnection {
 		return this.client.refreshInlayHints();
 	}
 
+	public CompletableFuture<Void> refreshCodeLenses() {
+		return this.client.refreshCodeLenses();
+	}
+
 	public void telemetryEvent(Object object) {
 		if (JavaLanguageServerPlugin.getPreferencesManager() != null
 			&& JavaLanguageServerPlugin.getPreferencesManager().getPreferences().isTelemetryEnabled()) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeLensPreferenceChangeListener.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeLensPreferenceChangeListener.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.preferences.IPreferencesChangeListener;
+import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
+
+public class CodeLensPreferenceChangeListener implements IPreferencesChangeListener {
+
+	@Override
+	public void preferencesChange(Preferences oldPreferences, Preferences newPreferences) {
+		if (oldPreferences.isReferencesCodeLensEnabled() != newPreferences.isReferencesCodeLensEnabled()
+				|| !Objects.equals(oldPreferences.getImplementationsCodeLens(), newPreferences.getImplementationsCodeLens())) {
+			refresh();
+		}
+	}
+
+	private void refresh() {
+		if (!JavaLanguageServerPlugin.getPreferencesManager()
+				.getClientPreferences().isCodeLensRefreshSupported()) {
+			return;
+		}
+		JavaLanguageServerPlugin.getInstance().getClientConnection().refreshCodeLenses();
+	}
+}
+

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -275,6 +275,7 @@ final public class InitHandler extends BaseInitHandler {
 					resetBuildState.run();
 					projectsManager.registerListeners();
 					preferenceManager.addPreferencesChangeListener(new InlayHintsPreferenceChangeListener());
+					preferenceManager.addPreferencesChangeListener(new CodeLensPreferenceChangeListener());
 				}
 				return Status.OK_STATUS;
 			}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -513,6 +513,13 @@ public class ClientPreferences {
 			&& capabilities.getWorkspace().getInlayHint().getRefreshSupport().booleanValue();
 	}
 
+	public boolean isCodeLensRefreshSupported() {
+		return v3supported
+			&& capabilities.getWorkspace().getCodeLens() != null
+			&& capabilities.getWorkspace().getCodeLens().getRefreshSupport() != null
+			&& capabilities.getWorkspace().getCodeLens().getRefreshSupport().booleanValue();
+	}
+
 	public Collection<String> excludedMarkerTypes() {
 		Object list = extendedClientCapabilities.getOrDefault("excludedMarkerTypes", null);
 		return list instanceof Collection<?> excludedMarkerTypes //


### PR DESCRIPTION
fixes #3047

You can test it in vscode-java by changing the `java.referencesCodeLens.enabled` and `java.implementationCodeLens` values, while a Java file is opened.