### PR TITLE
feat: add preference to disable returning Javadoc on hover

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/HoverInfoProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/HoverInfoProvider.java
@@ -94,6 +94,9 @@ public class HoverInfoProvider {
 
 	public List<Either<String, MarkedString>> computeHover(int line, int column, IProgressMonitor monitor) {
 		List<Either<String, MarkedString>> res = new LinkedList<>();
+		if (preferenceManager != null && !preferenceManager.getPreferences().isHoverJavadocEnabled()) {
+			return res;
+		}
 		try {
 			if (monitor.isCanceled()) {
 				return cancelled(res);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/HoverHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/HoverHandler.java
@@ -34,6 +34,9 @@ public class HoverHandler {
 	}
 
 	public Hover hover(TextDocumentPositionParams position, IProgressMonitor monitor) {
+		if (preferenceManager != null && !preferenceManager.getPreferences().isHoverJavadocEnabled()) {
+			return null;
+		}
 		ITypeRoot unit = null;
 		try {
 			boolean returnCompilationUnit = preferenceManager == null ? false : preferenceManager.isClientSupportsClassFileContent() && (preferenceManager.getPreferences().isIncludeDecompiledSources());

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -260,6 +260,11 @@ public class Preferences {
 	public static final String SIGNATURE_HELP_DESCRIPTION_ENABLED_KEY = "java.signatureHelp.description.enabled";
 
 	/**
+	 * Preference key to enable/disable Javadoc on hover.
+	 */
+	public static final String JAVA_HOVER_JAVADOC_ENABLED_KEY = "java.hover.javadoc.enabled";
+
+	/**
 	 * Preference key to enable/disable rename.
 	 */
 	public static final String RENAME_ENABLED_KEY = "java.rename.enabled";
@@ -634,6 +639,7 @@ public class Preferences {
 	private boolean javaSaveActionsOrganizeImportsEnabled;
 	private boolean signatureHelpEnabled;
 	private boolean signatureHelpDescriptionEnabled;
+	private boolean hoverJavadocEnabled;
 	private boolean renameEnabled;
 	private boolean executeCommandEnabled;
 	private boolean autobuildEnabled;
@@ -917,6 +923,7 @@ public class Preferences {
 		javaSaveActionsOrganizeImportsEnabled = false;
 		signatureHelpEnabled = false;
 		signatureHelpDescriptionEnabled = false;
+		hoverJavadocEnabled = true;
 		renameEnabled = true;
 		executeCommandEnabled = true;
 		autobuildEnabled = true;
@@ -1082,6 +1089,7 @@ public class Preferences {
 		prefs.javaSaveActionsOrganizeImportsEnabled = this.javaSaveActionsOrganizeImportsEnabled;
 		prefs.signatureHelpEnabled = this.signatureHelpEnabled;
 		prefs.signatureHelpDescriptionEnabled = this.signatureHelpDescriptionEnabled;
+		prefs.hoverJavadocEnabled = this.hoverJavadocEnabled;
 		prefs.renameEnabled = this.renameEnabled;
 		prefs.executeCommandEnabled = this.executeCommandEnabled;
 		prefs.autobuildEnabled = this.autobuildEnabled;
@@ -1343,6 +1351,11 @@ public class Preferences {
 		if (getValue(configuration, SIGNATURE_HELP_DESCRIPTION_ENABLED_KEY) != null) {
 			boolean signatureDescriptionEnabled = getBoolean(configuration, SIGNATURE_HELP_DESCRIPTION_ENABLED_KEY, existing.signatureHelpDescriptionEnabled);
 			prefs.setSignatureHelpDescriptionEnabled(signatureDescriptionEnabled);
+		}
+
+		if (getValue(configuration, JAVA_HOVER_JAVADOC_ENABLED_KEY) != null) {
+			boolean hoverJavadocEnabled = getBoolean(configuration, JAVA_HOVER_JAVADOC_ENABLED_KEY, existing.hoverJavadocEnabled);
+			prefs.setHoverJavadocEnabled(hoverJavadocEnabled);
 		}
 
 		if (getValue(configuration, RENAME_ENABLED_KEY) != null) {
@@ -2032,6 +2045,11 @@ public class Preferences {
 		this.signatureHelpDescriptionEnabled = signatureHelpDescriptionEnabled;
 	}
 
+	private Preferences setHoverJavadocEnabled(boolean enabled) {
+		this.hoverJavadocEnabled = enabled;
+		return this;
+	}
+
 	private Preferences setImplementationCodelens(String implementationCodeLensOption) {
 		this.implementationsCodeLens = implementationCodeLensOption;
 		return this;
@@ -2383,6 +2401,10 @@ public class Preferences {
 
 	public boolean isSignatureHelpDescriptionEnabled() {
 		return signatureHelpDescriptionEnabled;
+	}
+
+	public boolean isHoverJavadocEnabled() {
+		return hoverJavadocEnabled;
 	}
 
 	public boolean isRenameEnabled() {


### PR DESCRIPTION
Introduces new `java.hover.javadoc.enabled` preference to disable displaying javadoc on hover. We might provide other kind of hover in the future, hence the granular setting name.

addresses https://github.com/redhat-developer/vscode-java/issues/1420

<img width="1091" height="222" alt="Screenshot 2025-11-21 at 08 54 05" src="https://github.com/user-attachments/assets/030a658c-0b80-4f6c-a84d-911d5440a372" />

Signed-off-by: Fred Bricon <fbricon@gmail.com>
