### PR TITLE
Parse rootPath as path string instead of url

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseInitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseInitHandler.java
@@ -108,18 +108,19 @@ public abstract class BaseInitHandler {
 				}
 			}
 		} else {
-			String rootPath = param.getRootUri();
-			if (rootPath == null) {
-				rootPath = param.getRootPath();
+			IPath filePath = null;
+			String rootUri = param.getRootUri();
+			if (rootUri != null) {
+				filePath = ResourceUtils.canonicalFilePathFromURI(rootUri);
+			} else {
+				String rootPath = param.getRootPath();
 				if (rootPath != null) {
 					logInfo("In LSP 3.0, InitializeParams.rootPath is deprecated in favour of InitializeParams.rootUri!");
+					filePath = IPath.fromOSString(rootPath);
 				}
 			}
-			if (rootPath != null) {
-				IPath filePath = ResourceUtils.canonicalFilePathFromURI(rootPath);
-				if (filePath != null) {
-					rootPaths.add(filePath);
-				}
+			if (filePath != null) {
+				rootPaths.add(filePath);
 			}
 		}
 		if (rootPaths.isEmpty()) {


### PR DESCRIPTION
Parsing `rootPath` as uri crashes the server if it contains any characters not allowed in uris (such as space). This only happens if neither `rootUrl` or `workspaceFolders` are set. This is the case in helix for some reason if it falls back to cwd as a workspace path.

The spec doesnt say anything about url encoding characters in `rootPath` and vscode also sends it unencoded so this should be the correct behavior (even if it's been deprecated for 10 years).