### PR TITLE
Address NPE in new implementation of `getMarkdownContentReader`

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/JavadocContentAccess2.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/JavadocContentAccess2.java
@@ -77,12 +77,14 @@ public class JavadocContentAccess2 {
 
 	@Deprecated
 	public static Reader getPlainTextContentReader(IMember member) throws JavaModelException {
-		return new StringReader(getPlainTextContent(member));
+		String content = getPlainTextContent(member);
+		return content == null ? null : new StringReader(content);
 	}
 
 	@Deprecated
 	public static Reader getMarkdownContentReader(IJavaElement member) throws JavaModelException {
-		return new StringReader(getMarkdownContent(member));
+		String content = getMarkdownContent(member);
+		return content == null ? null : new StringReader(content);
 	}
 
 	public static String getPlainTextContent(IMember member) throws JavaModelException {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/javadoc/JavadocContentTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/javadoc/JavadocContentTest.java
@@ -14,6 +14,7 @@ package org.eclipse.jdt.ls.core.internal.javadoc;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import org.eclipse.jdt.core.IField;
 import org.eclipse.jdt.core.IJavaProject;
@@ -132,5 +133,15 @@ public class JavadocContentTest extends AbstractProjectsManagerBasedTest {
 		// @formatter:on
 		assertEquals(expectedJavadoc, javadoc.getValue());
 
+	}
+
+	@Test
+	public void testNullJavadoc() throws Exception {
+		IType type = project.findType("org.sample.TestJavadoc");
+		assertNotNull(type);
+		IType inner = type.getType("Inner");
+		assertNotNull(inner);
+		assertNull(JavadocContentAccess2.getMarkdownContentReader(inner));
+		assertNull(JavadocContentAccess2.getMarkdownContent(inner));
 	}
 }


### PR DESCRIPTION
(also `getPlainTextContentReader`) Adds a test for it too.