### PR TITLE
Use the Eclipse 4.38 platform release repository.

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -29,7 +29,7 @@
 			<unit id="org.eclipse.jdt.core.compiler.batch" version="0.0.0"/>
 			<unit id="org.eclipse.jdt.core" version="0.0.0"/>
 			<unit id="org.eclipse.jdt.apt.core" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.38-I-builds/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.38/R-4.38-202512010920/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.jdt.core.javac" version="0.0.0"/>


### PR DESCRIPTION
On December 10 (2025-12 / 4.38 GA), the 4.38-I-builds repo will be removed, and we want to avoid using 4.39-I-builds prior to the 4.39 M1 for stability reasons.