### PR TITLE
Incorrect Javadoc rendering when inline @ tokens appear in block tags

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/AbstractJavaDocConverter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/AbstractJavaDocConverter.java
@@ -189,19 +189,27 @@ abstract class AbstractJavaDocConverter {
 		@Override
 		protected void printRest(StringBuilder buffer, List<Pair> rest) {
 			if (!rest.isEmpty()) {
-				Iterator<Pair> e = rest.iterator();
-				while (e.hasNext()) {
-					Pair p = e.next();
-					buffer.append("<li>"); //$NON-NLS-1$
-					if (p.fTag() != null) {
+				if (rest.size() == 1) {
+					Iterator<Pair> e = rest.iterator();
+					if (e.hasNext()) {
+						Pair p = e.next();
 						buffer.append(p.fTag());
 					}
-					if (p.fContent() != null) {
-						buffer.append("<ul><li>"); //$NON-NLS-1$
-						buffer.append(p.fContent());
-						buffer.append("</li></ul>"); //$NON-NLS-1$
+				} else {
+					Iterator<Pair> e = rest.iterator();
+					while (e.hasNext()) {
+						Pair p = e.next();
+						buffer.append("<li>"); //$NON-NLS-1$
+						if (p.fTag() != null) {
+							buffer.append(p.fTag());
+						}
+						if (p.fContent() != null) {
+							buffer.append("<ul><li>"); //$NON-NLS-1$
+							buffer.append(p.fContent());
+							buffer.append("</li></ul>"); //$NON-NLS-1$
+						}
+						buffer.append("</li>"); //$NON-NLS-1$
 					}
-					buffer.append("</li>"); //$NON-NLS-1$
 				}
 			}
 		}
@@ -209,10 +217,15 @@ abstract class AbstractJavaDocConverter {
 		@Override
 		protected String printSimpleTag(List<Pair> rest) {
 			StringBuilder buffer = new StringBuilder();
-			buffer.append("<ul>"); //$NON-NLS-1$
-			printTagAttributes(buffer);
-			printRest(buffer, rest);
-			buffer.append("</ul>"); //$NON-NLS-1$
+			if (rest.size() == 1) {
+				printTagAttributes(buffer);
+				printRest(buffer, rest);
+			} else {
+				buffer.append("<ul>"); //$NON-NLS-1$
+				printTagAttributes(buffer);
+				printRest(buffer, rest);
+				buffer.append("</ul>"); //$NON-NLS-1$
+			}
 			return buffer.toString();
 		}
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HoverHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HoverHandlerTest.java
@@ -1050,4 +1050,30 @@ public class HoverHandlerTest extends AbstractProjectsManagerBasedTest {
 		actual = ResourceUtils.dos2Unix(actual);
 		assertEquals(expectedJavadoc, actual, "Unexpected hover ");
 	}
+
+	@Test
+	public void testIncorrectJavadocRendering_3649() throws Exception {
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+		String content = """
+				package test1;
+				/**
+				  * Some javadoc and then ...
+				  * @jls 9.6.4.1 @Target
+				  */
+				public class Hover {}
+				""";
+		ICompilationUnit cu = pack1.createCompilationUnit("Hover.java", content, false, null);
+		Hover hover = getHover(cu, 5, 14);
+		assertNotNull(hover);
+		assertEquals(2, hover.getContents().getLeft().size());
+
+		//@formatter:off
+		String expectedJavadoc = "Some javadoc and then ...\n"
+				+ "\n"
+				+ "* **@jls**\n"
+				+ "  * 9.6.4.1 @Target";
+		String actual = hover.getContents().getLeft().get(1).getLeft();
+		actual = ResourceUtils.dos2Unix(actual);
+		assertEquals(expectedJavadoc, actual, "Unexpected hover ");
+	}
 }


### PR DESCRIPTION
Fix incorrect Javadoc list rendering when inline @ tokens appear in block tags

Fix: https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/3631