### PR TITLE
Fix build failure by downgrading `jakarta.servlet-api` to stable version

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -82,7 +82,7 @@
 				<dependency>
 					<groupId>jakarta.servlet</groupId>
 					<artifactId>jakarta.servlet-api</artifactId>
-					<version>6.2.0-M1</version>
+					<version>6.1.0</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>


### PR DESCRIPTION
Jenkins Build fails to build due to `jakarta.servlet:jakarta.servlet-api:jar:6.2.0-M1` having a parent POM dependency on `org.eclipse.ee4j:project:pom:2.0.0-SNAPSHOT` which is no longer available in Maven Central

Failing build: https://ci.eclipse.org/ls/job/jdt-ls-pr/5785/