### PR TITLE
Incorrect Markdown hover rendering for inline member references

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/JavadocContentAccess2.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/JavadocContentAccess2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2017 IBM Corporation and others.
+ * Copyright (c) 2008, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -241,14 +241,6 @@ public class JavadocContentAccess2 {
 			Name qualifier = methodRef.getQualifier();
 			refTypeName = qualifier == null ? "" : qualifier.getFullyQualifiedName(); //$NON-NLS-1$
 			refMemberName = methodRef.getName().getIdentifier();
-			if (refMemberName != null) {
-				if (e.toString().endsWith(")")) {
-					refMemberName = methodRef.toString();
-					if (refMemberName.startsWith("#")) {
-						refMemberName = refMemberName.substring(1);
-					}
-				}
-			}
 			@SuppressWarnings("unchecked")
 			List<MethodRefParameter> params = methodRef.parameters();
 			int ps = params.size();

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HoverHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HoverHandlerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2017 Red Hat Inc. and others.
+ * Copyright (c) 2016-2026 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -1085,15 +1085,15 @@ public class HoverHandlerTest extends AbstractProjectsManagerBasedTest {
 		ICompilationUnit cu = pack1.createCompilationUnit("Markdown.java", buf.toString(), false, null);
 		Hover hover = getHover(cu, 2, 14);
 		assertNotNull(hover);
-		assertEquals(2, hover.getContents().getLeft().size());
+		assertEquals(3, hover.getContents().getLeft().size());
 
 		String uri = JDTUtils.toURI(cu) + "#3";
 		//@formatter:off
-		String expectedJavadoc = "[newMethodBeingLinkedToo](" + uri +") ";
+		String expectedJavadoc = "[newMethodBeingLinkedToo](" + uri +")";
 		//@formatter:on
 		String actual = hover.getContents().getLeft().get(1).getLeft();
 		actual = ResourceUtils.dos2Unix(actual);
-		assertEquals(expectedJavadoc.toString(), actual, "Unexpected hover ");
+		assertEquals(expectedJavadoc.toString(), actual.stripTrailing(), "Unexpected hover ");
 	}
 
 	@Test
@@ -1114,72 +1114,14 @@ public class HoverHandlerTest extends AbstractProjectsManagerBasedTest {
 		ICompilationUnit cu = pack1.createCompilationUnit("Markdown.java", buf.toString(), false, null);
 		Hover hover = getHover(cu, 2, 14);
 		assertNotNull(hover);
-		assertEquals(2, hover.getContents().getLeft().size());
+		assertEquals(3, hover.getContents().getLeft().size());
 
 		String uri = JDTUtils.toURI(cu) + "#3";
 		//@formatter:off
-		String expectedJavadoc = "[newMethodBeingLinkedToo](" + uri +") ";
+		String expectedJavadoc = "[newMethodBeingLinkedToo](" + uri +")";
 		//@formatter:on
 		String actual = hover.getContents().getLeft().get(1).getLeft();
 		actual = ResourceUtils.dos2Unix(actual);
-		assertEquals(expectedJavadoc.toString(), actual, "Unexpected hover ");
-	}
-
-	@Test
-	public void testHoverInlineLinkTagInMarkdown_03() throws Exception {
-		String name = "java25";
-		importProjects("eclipse/" + name);
-		IProject project = getProject(name);
-		IJavaProject javaProject = JavaCore.create(project);
-		IPackageFragmentRoot packageFragmentRoot = javaProject.getPackageFragmentRoot(project.getFolder("src/main/java"));
-		IPackageFragment pack1 = packageFragmentRoot.createPackageFragment("test", false, null);
-		StringBuilder buf = new StringBuilder();
-		//@formatter:off
-		buf.append("package test;\n"
-				+ "/// {@link #newMethodBeingLinkedToo()}\n"
-				+ "public class Markdown{}"
-		);
-		//@formatter:on
-		ICompilationUnit cu = pack1.createCompilationUnit("Markdown.java", buf.toString(), false, null);
-		Hover hover = getHover(cu, 2, 14);
-		assertNotNull(hover);
-		assertEquals(2, hover.getContents().getLeft().size());
-
-		String uri = JDTUtils.toURI(cu) + "#3";
-		//@formatter:off
-		String expectedJavadoc = "[newMethodBeingLinkedToo()](" + uri +") ";
-		//@formatter:on
-		String actual = hover.getContents().getLeft().get(1).getLeft();
-		actual = ResourceUtils.dos2Unix(actual);
-		assertEquals(expectedJavadoc.toString(), actual, "Unexpected hover ");
-	}
-
-	@Test
-	public void testHoverInlineLinkTagInMarkdown_04() throws Exception {
-		String name = "java25";
-		importProjects("eclipse/" + name);
-		IProject project = getProject(name);
-		IJavaProject javaProject = JavaCore.create(project);
-		IPackageFragmentRoot packageFragmentRoot = javaProject.getPackageFragmentRoot(project.getFolder("src/main/java"));
-		IPackageFragment pack1 = packageFragmentRoot.createPackageFragment("test", false, null);
-		StringBuilder buf = new StringBuilder();
-		//@formatter:off
-		buf.append("package test;\n"
-				+ "/// {@link #newMethodBeingLinkedToo(int x)}\n"
-				+ "public class Markdown{}"
-		);
-		//@formatter:on
-		ICompilationUnit cu = pack1.createCompilationUnit("Markdown.java", buf.toString(), false, null);
-		Hover hover = getHover(cu, 2, 14);
-		assertNotNull(hover);
-		assertEquals(2, hover.getContents().getLeft().size());
-
-		String uri = JDTUtils.toURI(cu) + "#3";
-		//@formatter:off
-		String expectedJavadoc = "[newMethodBeingLinkedToo(int x)](" + uri +") ";
-		//@formatter:on
-		String actual = hover.getContents().getLeft().get(1).getLeft();
-		actual = ResourceUtils.dos2Unix(actual);
-		assertEquals(expectedJavadoc.toString(), actual, "Unexpected hover ");
+		assertEquals(expectedJavadoc.toString(), actual.stripTrailing(), "Unexpected hover ");
 	}
 }


### PR DESCRIPTION
This change fixes the rendering of inline {@link} and {@linkplain} member references in Markdown-based hover content. References such as {@link #methodName} or {@linkplain #methodName} are now converted into correct, navigable Markdown links.

Fix: https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/3655