### PR TITLE
{@code} / {@literal} inline tag is not rendered correctly in Markdown hover

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/JavadocContentAccess2.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/JavadocContentAccess2.java
@@ -168,6 +168,8 @@ public class JavadocContentAccess2 {
 			if (e instanceof TagElement t) {
 				if ("@link".equals(t.getTagName()) || "@linkplain".equals(t.getTagName())) {
 					collectLinkedTag(element, t, buf);
+				} else if ("@code".equals(t.getTagName()) || "@literal".equals(t.getTagName())) {
+					collectCodeAndLiteralTag(element, t, buf);
 				} else {
 					collectTagElements(content, element, t, buf);
 				}
@@ -191,6 +193,25 @@ public class JavadocContentAccess2 {
 				} else {
 					buf.append(" ");
 				}
+			}
+		}
+	}
+
+	private static void collectCodeAndLiteralTag(IJavaElement element, TagElement t, StringBuilder buf) {
+		if (t.fragments().size() > 0) {
+			try {
+				if (t.fragments().size() == 1) {
+					String code = ((TextElement) t.fragments().get(0)).getText();
+					if ("@code".equals(t.getTagName())) {
+						buf.append("`" + code + "`");
+					} else if ("@literal".equals(t.getTagName())) {
+						// escape chars applied for <>*^&\`[]
+						code = code.replaceAll("([<>*^&\\\\`\\[\\]])", "\\\\$1");
+						buf.append(code);
+					}
+				}
+			} catch (Exception e) {
+				JavaManipulationPlugin.log(e);
 			}
 		}
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/JavadocContentAccess2.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/JavadocContentAccess2.java
@@ -166,9 +166,9 @@ public class JavadocContentAccess2 {
 		while (!queue.isEmpty()) {
 			ASTNode e = queue.pop();
 			if (e instanceof TagElement t) {
-				if ("@link".equals(t.getTagName()) || "@linkplain".equals(t.getTagName())) {
+				if (TagElement.TAG_LINK.equals(t.getTagName()) || TagElement.TAG_LINKPLAIN.equals(t.getTagName())) {
 					collectLinkedTag(element, t, buf);
-				} else if ("@code".equals(t.getTagName()) || "@literal".equals(t.getTagName())) {
+				} else if (TagElement.TAG_CODE.equals(t.getTagName()) || TagElement.TAG_LITERAL.equals(t.getTagName())) {
 					collectCodeAndLiteralTag(element, t, buf);
 				} else {
 					collectTagElements(content, element, t, buf);
@@ -200,14 +200,30 @@ public class JavadocContentAccess2 {
 	private static void collectCodeAndLiteralTag(IJavaElement element, TagElement t, StringBuilder buf) {
 		if (t.fragments().size() > 0) {
 			try {
-				if (t.fragments().size() == 1) {
-					String code = ((TextElement) t.fragments().get(0)).getText();
-					if ("@code".equals(t.getTagName())) {
-						buf.append("`" + code + "`");
-					} else if ("@literal".equals(t.getTagName())) {
-						// escape chars applied for <>*^&\`[]
-						code = code.replaceAll("([<>*^&\\\\`\\[\\]])", "\\\\$1");
-						buf.append(code);
+				if (t.fragments().size() > 0) {
+					if (TagElement.TAG_CODE.equals(t.getTagName())) {
+						if (t.fragments().size() == 1) {
+							buf.append("`" + ((TextElement) t.fragments().get(0)).getText().strip() + "`");
+						} else {
+							String code;
+							for (int i = 0; i < t.fragments().size(); i++) {
+								code = ((TextElement) t.fragments().get(i)).getText().strip();
+								if (i == 0) {
+									buf.append("`" + code);
+								} else if (i == (t.fragments().size() - 1)) {
+									buf.append(code + "`");
+								} else {
+									buf.append(code);
+								}
+							}
+						}
+					} else if (TagElement.TAG_LITERAL.equals(t.getTagName())) {
+						String code;
+						for (int i = 0; i < t.fragments().size(); i++) {
+							code = ((TextElement) t.fragments().get(i)).getText().strip();
+							code = code.replaceAll("([<>*^&\\\\`\\[\\]])", "\\\\$1");
+							buf.append(code);
+						}
 					}
 				}
 			} catch (Exception e) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HoverHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HoverHandlerTest.java
@@ -1071,7 +1071,7 @@ public class HoverHandlerTest extends AbstractProjectsManagerBasedTest {
 		assertEquals(2, hover.getContents().getLeft().size());
 		StringBuilder expectedJavadoc = new StringBuilder();
 		//@formatter:off
-		expectedJavadoc.append("` List<String>` ");
+		expectedJavadoc.append("`List<String>` ");
 		//@formatter:on
 		String actual = hover.getContents().getLeft().get(1).getLeft();
 		actual = ResourceUtils.dos2Unix(actual);
@@ -1098,7 +1098,67 @@ public class HoverHandlerTest extends AbstractProjectsManagerBasedTest {
 		assertEquals(2, hover.getContents().getLeft().size());
 		StringBuilder expectedJavadoc = new StringBuilder();
 		//@formatter:off
-		expectedJavadoc.append(" List\\<String\\> \\<\\>\\*\\^\\&\\`\\[\\] ");
+		expectedJavadoc.append("List\\<String\\> \\<\\>\\*\\^\\&\\`\\[\\] ");
+		//@formatter:on
+		String actual = hover.getContents().getLeft().get(1).getLeft();
+		actual = ResourceUtils.dos2Unix(actual);
+		assertEquals(expectedJavadoc.toString(), actual, "Unexpected hover ");
+	}
+
+	@Test
+	public void testHoverMarkdownWithCodeTag_03() throws Exception {
+		String name = "java25";
+		importProjects("eclipse/" + name);
+		IProject project = getProject(name);
+		IJavaProject javaProject = JavaCore.create(project);
+		IPackageFragmentRoot packageFragmentRoot = javaProject.getPackageFragmentRoot(project.getFolder("src/main/java"));
+		IPackageFragment pack1 = packageFragmentRoot.createPackageFragment("test", false, null);
+		StringBuilder buf = new StringBuilder();
+		//@formatter:off
+		buf.append("package test;\n"
+				+ "/// Here's some code {@code \n"
+				+ "///     List<String> list = List.of(\"Hello World!\");\n"
+				+ "/// } \n"
+				+ "/// that does something.\n"
+				+ "public class Markdown{}\n");
+		//@formatter:on
+		ICompilationUnit cu = pack1.createCompilationUnit("Test.java", buf.toString(), false, null);
+		Hover hover = getHover(cu, 5, 14);
+		assertNotNull(hover);
+		assertEquals(2, hover.getContents().getLeft().size());
+		//@formatter:off
+		StringBuilder expectedJavadoc = new StringBuilder();
+		expectedJavadoc.append("Here's some code  `List<String> list = List.of(\"Hello World!\");` that does something.");
+		//@formatter:on
+		String actual = hover.getContents().getLeft().get(1).getLeft();
+		actual = ResourceUtils.dos2Unix(actual);
+		assertEquals(expectedJavadoc.toString(), actual, "Unexpected hover ");
+	}
+
+	@Test
+	public void testHoverMarkdownWithCodeTag_04() throws Exception {
+		String name = "java25";
+		importProjects("eclipse/" + name);
+		IProject project = getProject(name);
+		IJavaProject javaProject = JavaCore.create(project);
+		IPackageFragmentRoot packageFragmentRoot = javaProject.getPackageFragmentRoot(project.getFolder("src/main/java"));
+		IPackageFragment pack1 = packageFragmentRoot.createPackageFragment("test", false, null);
+		StringBuilder buf = new StringBuilder();
+		//@formatter:off
+		buf.append("package test;\n"
+				+ "/// Here's some code {@literal \n"
+				+ "///     List<String> list = List.of(\"Hello World!\");\n"
+				+ "/// } \n"
+				+ "/// that does something.\n"
+				+ "public class Markdown{}\n");
+		//@formatter:on
+		ICompilationUnit cu = pack1.createCompilationUnit("Test.java", buf.toString(), false, null);
+		Hover hover = getHover(cu, 5, 14);
+		assertNotNull(hover);
+		assertEquals(2, hover.getContents().getLeft().size());
+		//@formatter:off
+		StringBuilder expectedJavadoc = new StringBuilder();
+		expectedJavadoc.append("Here's some code List\\<String\\> list = List.of(\"Hello World!\");} that does something.");
 		//@formatter:on
 		String actual = hover.getContents().getLeft().get(1).getLeft();
 		actual = ResourceUtils.dos2Unix(actual);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HoverHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HoverHandlerTest.java
@@ -1050,4 +1050,58 @@ public class HoverHandlerTest extends AbstractProjectsManagerBasedTest {
 		actual = ResourceUtils.dos2Unix(actual);
 		assertEquals(expectedJavadoc, actual, "Unexpected hover ");
 	}
+
+	@Test
+	public void testHoverMarkdownWithCodeTag_01() throws Exception {
+		String name = "java25";
+		importProjects("eclipse/" + name);
+		IProject project = getProject(name);
+		IJavaProject javaProject = JavaCore.create(project);
+		IPackageFragmentRoot packageFragmentRoot = javaProject.getPackageFragmentRoot(project.getFolder("src/main/java"));
+		IPackageFragment pack1 = packageFragmentRoot.createPackageFragment("test", false, null);
+		StringBuilder buf = new StringBuilder();
+		//@formatter:off
+		buf.append("package test;\n"
+				+ "/// {@code List<String>}\n"
+				+ "public class Markdown{}\n");
+		//@formatter:on
+		ICompilationUnit cu = pack1.createCompilationUnit("Test.java", buf.toString(), false, null);
+		Hover hover = getHover(cu, 2, 14);
+		assertNotNull(hover);
+		assertEquals(2, hover.getContents().getLeft().size());
+		StringBuilder expectedJavadoc = new StringBuilder();
+		//@formatter:off
+		expectedJavadoc.append("` List<String>` ");
+		//@formatter:on
+		String actual = hover.getContents().getLeft().get(1).getLeft();
+		actual = ResourceUtils.dos2Unix(actual);
+		assertEquals(expectedJavadoc.toString(), actual, "Unexpected hover ");
+	}
+
+	@Test
+	public void testHoverMarkdownWithCodeTag_02() throws Exception {
+		String name = "java25";
+		importProjects("eclipse/" + name);
+		IProject project = getProject(name);
+		IJavaProject javaProject = JavaCore.create(project);
+		IPackageFragmentRoot packageFragmentRoot = javaProject.getPackageFragmentRoot(project.getFolder("src/main/java"));
+		IPackageFragment pack1 = packageFragmentRoot.createPackageFragment("test", false, null);
+		StringBuilder buf = new StringBuilder();
+		//@formatter:off
+		buf.append("package test;\n"
+				+ "/// {@literal List<String> <>*^&`[]}\n"
+				+ "public class Markdown{}\n");
+		//@formatter:on
+		ICompilationUnit cu = pack1.createCompilationUnit("Test.java", buf.toString(), false, null);
+		Hover hover = getHover(cu, 2, 14);
+		assertNotNull(hover);
+		assertEquals(2, hover.getContents().getLeft().size());
+		StringBuilder expectedJavadoc = new StringBuilder();
+		//@formatter:off
+		expectedJavadoc.append(" List\\<String\\> \\<\\>\\*\\^\\&\\`\\[\\] ");
+		//@formatter:on
+		String actual = hover.getContents().getLeft().get(1).getLeft();
+		actual = ResourceUtils.dos2Unix(actual);
+		assertEquals(expectedJavadoc.toString(), actual, "Unexpected hover ");
+	}
 }


### PR DESCRIPTION
This PR fixes an issue where the {@code} inline tag is not rendered correctly in the Markdown hover. It also addresses incorrect handling of the {@literal} tag, which is included as part of the same issue.
In {@literal} tags, below characters are escaped and rendered accordingly. 
```
<>*^&\[]`
```


Fix: https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/3672