### PR TITLE
Potential fix for code scanning alert no. 10: Failure to use HTTPS or SFTP URL in Maven artifact upload/download

### DIFF
--- a/org.eclipse.jdt.ls.tests/projects/eclipse/testbundle/pom.xml
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/testbundle/pom.xml
@@ -25,7 +25,7 @@
         <repository>
             <id>oxygen</id>
             <layout>p2</layout>
-            <url>http://download.eclipse.org/releases/oxygen</url>
+            <url>https://download.eclipse.org/releases/oxygen</url>
         </repository>
     </repositories>
 </project>


### PR DESCRIPTION
Potential fix for [https://github.com/eclipse-jdtls/eclipse.jdt.ls/security/code-scanning/10](https://github.com/eclipse-jdtls/eclipse.jdt.ls/security/code-scanning/10)

In general, the fix is to ensure all Maven repository and distribution management URLs use secure protocols (`https://` or `sftp://`) instead of insecure ones like `http://` or `ftp://`. This prevents attackers from tampering with artifacts in transit.

For this specific POM, the best fix is to change the repository URL on line 28 from `http://download.eclipse.org/releases/oxygen` to `https://download.eclipse.org/releases/oxygen`. This keeps the same host and path (so behavior and semantics remain the same) while switching to HTTPS so dependencies are downloaded securely. No additional plugins, properties, or structural changes are needed in this file.

Concretely:
- Edit `org.eclipse.jdt.ls.tests/projects/eclipse/testbundle/pom.xml`.
- In the `<repositories>` section, update the `<url>` element under the `oxygen` repository to use `https://`.
- No extra imports, dependencies, or method definitions are required since this is pure XML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
