### PR TITLE
feat: add setting to disable adding imports on paste

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/PasteEventHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/PasteEventHandler.java
@@ -54,6 +54,7 @@ import org.eclipse.jdt.internal.corext.refactoring.util.TextChangeManager;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
+import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.jdt.ls.core.internal.handlers.OrganizeImportsHandler.ImportCandidate;
 import org.eclipse.jdt.ls.core.internal.handlers.OrganizeImportsHandler.ImportSelection;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
@@ -311,6 +312,10 @@ public class PasteEventHandler {
 	}
 
 	public static DocumentPasteEdit getMissingImportsWorkspaceEdit(PasteEventParams params, ICompilationUnit cu, IProgressMonitor monitor) throws CoreException {
+		PreferenceManager preferenceManager = JavaLanguageServerPlugin.getPreferencesManager();
+		if (preferenceManager != null && !preferenceManager.getPreferences().isJavaUpdateImportsOnPasteEnabled()) {
+			return null;
+		}
 		Range range = params.getLocation().getRange();
 		String originalDocumentUri = params.getCopiedDocumentUri();
 		String insertText = params.getText();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -251,6 +251,11 @@ public class Preferences {
 	public static final String JAVA_SAVE_ACTIONS_ORGANIZE_IMPORTS_KEY = "java.saveActions.organizeImports";
 
 	/**
+	 * Preference key to enable/disable organize imports on paste
+	 */
+	public static final String JAVA_UPDATE_IMPORTS_ON_PASTE_ENABLED_KEY = "java.updateImportsOnPaste.enabled";
+
+	/**
 	 * Preference key to enable/disable signature help.
 	 */
 	public static final String SIGNATURE_HELP_ENABLED_KEY = "java.signatureHelp.enabled";
@@ -637,6 +642,7 @@ public class Preferences {
 	private String javaQuickFixShowAt;
 	private boolean javaFormatOnTypeEnabled;
 	private boolean javaSaveActionsOrganizeImportsEnabled;
+	private boolean javaUpdateImportsOnPasteEnabled;
 	private boolean signatureHelpEnabled;
 	private boolean signatureHelpDescriptionEnabled;
 	private boolean hoverJavadocEnabled;
@@ -922,6 +928,7 @@ public class Preferences {
 		javaQuickFixShowAt = LINE;
 		javaFormatOnTypeEnabled = false;
 		javaSaveActionsOrganizeImportsEnabled = false;
+		javaUpdateImportsOnPasteEnabled = true;
 		signatureHelpEnabled = false;
 		signatureHelpDescriptionEnabled = false;
 		hoverJavadocEnabled = true;
@@ -1088,6 +1095,7 @@ public class Preferences {
 		prefs.javaQuickFixShowAt = this.javaQuickFixShowAt;
 		prefs.javaFormatOnTypeEnabled = this.javaFormatOnTypeEnabled;
 		prefs.javaSaveActionsOrganizeImportsEnabled = this.javaSaveActionsOrganizeImportsEnabled;
+		prefs.javaUpdateImportsOnPasteEnabled = this.javaUpdateImportsOnPasteEnabled;
 		prefs.signatureHelpEnabled = this.signatureHelpEnabled;
 		prefs.signatureHelpDescriptionEnabled = this.signatureHelpDescriptionEnabled;
 		prefs.hoverJavadocEnabled = this.hoverJavadocEnabled;
@@ -1343,6 +1351,11 @@ public class Preferences {
 		if (containsKey(configuration, JAVA_SAVE_ACTIONS_ORGANIZE_IMPORTS_KEY)) {
 			boolean javaSaveActionAutoOrganizeImportsEnabled = getBoolean(configuration, JAVA_SAVE_ACTIONS_ORGANIZE_IMPORTS_KEY, existing.javaSaveActionsOrganizeImportsEnabled);
 			prefs.setJavaSaveActionAutoOrganizeImportsEnabled(javaSaveActionAutoOrganizeImportsEnabled);
+		}
+
+		if (containsKey(configuration, JAVA_UPDATE_IMPORTS_ON_PASTE_ENABLED_KEY)) {
+			boolean javaUpdateImportsOnPasteEnabled = getBoolean(configuration, JAVA_UPDATE_IMPORTS_ON_PASTE_ENABLED_KEY, existing.javaUpdateImportsOnPasteEnabled);
+			prefs.setJavaUpdateImportsOnPasteEnabled(javaUpdateImportsOnPasteEnabled);
 		}
 
 		if (containsKey(configuration, SIGNATURE_HELP_ENABLED_KEY)) {
@@ -2146,6 +2159,11 @@ public class Preferences {
 		return this;
 	}
 
+	public Preferences setJavaUpdateImportsOnPasteEnabled(boolean javaUpdateImportsOnPasteEnabled) {
+		this.javaUpdateImportsOnPasteEnabled = javaUpdateImportsOnPasteEnabled;
+		return this;
+	}
+
 	public Preferences setHashCodeEqualsTemplateUseJava7Objects(boolean hashCodeEqualsTemplateUseJ7Objects) {
 		this.hashCodeEqualsTemplateUseJava7Objects = hashCodeEqualsTemplateUseJ7Objects;
 		return this;
@@ -2400,6 +2418,10 @@ public class Preferences {
 
 	public boolean isJavaSaveActionsOrganizeImportsEnabled() {
 		return javaSaveActionsOrganizeImportsEnabled;
+	}
+
+	public boolean isJavaUpdateImportsOnPasteEnabled() {
+		return javaUpdateImportsOnPasteEnabled;
 	}
 
 	public boolean isSignatureHelpEnabled() {


### PR DESCRIPTION
New "java.updateImportsOnPaste.enabled" boolean setting, to enable/disable updating imports when pasting Java code in a file.

See https://github.com/redhat-developer/vscode-java/issues/4325

