### PR TITLE
feat: add setting to show generated code in document symbols

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandler.java
@@ -161,7 +161,7 @@ public class DocumentSymbolHandler {
 			if (type != IJavaElement.TYPE && type != IJavaElement.FIELD && type != IJavaElement.METHOD) {
 				continue;
 			}
-			if (element instanceof SourceMethod method && JDTUtils.isGenerated(method)) {
+			if (element instanceof SourceMethod method && JDTUtils.isGenerated(method) && !preferenceManager.getPreferences().isShowGeneratedCodeSymbols()) {
 				continue;
 			}
 			Location location = JDTUtils.toLocation(element);
@@ -229,7 +229,7 @@ public class DocumentSymbolHandler {
 		if (type != TYPE && type != FIELD && type != METHOD && type != PACKAGE_DECLARATION && type != COMPILATION_UNIT && type != PACKAGE_FRAGMENT) {
 			return null;
 		}
-		if (unit instanceof SourceMethod method && JDTUtils.isGenerated(method)) {
+		if (unit instanceof SourceMethod method && JDTUtils.isGenerated(method) && !preferenceManager.getPreferences().isShowGeneratedCodeSymbols()) {
 			return null;
 		}
 		if (monitor.isCanceled()) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -114,6 +114,11 @@ public class Preferences {
 	public static final String JAVA_SYMBOLS_INCLUDE_SOURCE_METHOD_DECLARATIONS = "java.symbols.includeSourceMethodDeclarations";
 
 	/**
+	 * Include generated code (e.g. Lombok getters, setters, constructors) in document symbols.
+	 */
+	public static final String JAVA_SYMBOLS_INCLUDE_GENERATED_CODE = "java.symbols.includeGeneratedCode";
+
+	/**
 	 * Insert spaces when pressing Tab
 	 */
 	public static final String JAVA_CONFIGURATION_INSERTSPACES = "java.format.insertSpaces";
@@ -678,6 +683,7 @@ public class Preferences {
 	private boolean smartSemicolonDetection;
 	private boolean includeDecompiledSources;
 	private boolean includeSourceMethodDeclarations;
+	private boolean showGeneratedCodeSymbols;
 
 	private String mavenUserSettings;
 	private String mavenGlobalSettings;
@@ -977,6 +983,7 @@ public class Preferences {
 		smartSemicolonDetection = false;
 		includeDecompiledSources = true;
 		includeSourceMethodDeclarations = false;
+		showGeneratedCodeSymbols = false;
 		insertSpaces = true;
 		tabSize = DEFAULT_TAB_SIZE;
 		mavenNotCoveredPluginExecutionSeverity = IGNORE;
@@ -1145,6 +1152,7 @@ public class Preferences {
 		prefs.smartSemicolonDetection = this.smartSemicolonDetection;
 		prefs.includeDecompiledSources = this.includeDecompiledSources;
 		prefs.includeSourceMethodDeclarations = this.includeSourceMethodDeclarations;
+		prefs.showGeneratedCodeSymbols = this.showGeneratedCodeSymbols;
 		prefs.inlayHintsParameterMode = this.inlayHintsParameterMode;
 		prefs.inlayHintsSuppressedWhenSameNameNumberedParameter = this.inlayHintsSuppressedWhenSameNameNumberedParameter;
 		prefs.inlayHintsVariableTypesEnabled = this.inlayHintsVariableTypesEnabled;
@@ -1734,6 +1742,11 @@ public class Preferences {
 		if (containsKey(configuration, JAVA_SYMBOLS_INCLUDE_SOURCE_METHOD_DECLARATIONS)) {
 			boolean includeSourceMethodDeclarations = getBoolean(configuration, JAVA_SYMBOLS_INCLUDE_SOURCE_METHOD_DECLARATIONS, existing.includeSourceMethodDeclarations);
 			prefs.setIncludeSourceMethodDeclarations(includeSourceMethodDeclarations);
+		}
+
+		if (containsKey(configuration, JAVA_SYMBOLS_INCLUDE_GENERATED_CODE)) {
+			boolean showGeneratedCodeSymbols = getBoolean(configuration, JAVA_SYMBOLS_INCLUDE_GENERATED_CODE, existing.showGeneratedCodeSymbols);
+			prefs.setShowGeneratedCodeSymbols(showGeneratedCodeSymbols);
 		}
 
 		if (containsKey(configuration, JAVA_INLAYHINTS_PARAMETERNAMES_ENABLED)) {
@@ -2823,6 +2836,14 @@ public class Preferences {
 
 	public void setIncludeSourceMethodDeclarations(boolean includeSourceMethodDeclarations) {
 		this.includeSourceMethodDeclarations = includeSourceMethodDeclarations;
+	}
+
+	public boolean isShowGeneratedCodeSymbols() {
+		return this.showGeneratedCodeSymbols;
+	}
+
+	public void setShowGeneratedCodeSymbols(boolean showGeneratedCodeSymbols) {
+		this.showGeneratedCodeSymbols = showGeneratedCodeSymbols;
 	}
 
 	public Preferences setInsertSpaces(boolean insertSpaces) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandlerTest.java
@@ -235,6 +235,27 @@ public class DocumentSymbolHandlerTest extends AbstractProjectsManagerBasedTest 
 	}
 
 	@Test
+	public void testLombok_showGeneratedCodeSymbols() throws Exception {
+		boolean lombokDisabled = "true".equals(System.getProperty("jdt.ls.lombok.disabled"));
+		if (lombokDisabled) {
+			return;
+		}
+		preferences.setShowGeneratedCodeSymbols(true);
+		try {
+			importProjects("maven/mavenlombok");
+			project = ResourcesPlugin.getWorkspace().getRoot().getProject("mavenlombok");
+			String className = "org.sample.Test";
+			List<? extends SymbolInformation> symbols = getSymbols(className);
+			assertFalse(symbols.isEmpty(), "No symbols found for " + className);
+			assertHasSymbol("Test", "Test.java", SymbolKind.Class, symbols);
+			Optional<? extends SymbolInformation> method = symbols.stream().filter(s -> (s.getKind() == SymbolKind.Method)).findAny();
+			assertTrue(method.isPresent(), "Generated methods should appear when java.symbols.includeGeneratedCode is true");
+		} finally {
+			preferences.setShowGeneratedCodeSymbols(false);
+		}
+	}
+
+	@Test
 	public void testDecompiledSource() throws Exception {
 		importProjects("eclipse/reference");
 		IProject project = WorkspaceHelper.getProject("reference");


### PR DESCRIPTION
New `java.symbols.includeGeneratedCode` boolean setting to enable returning generated code in document symbols. 
See https://github.com/redhat-developer/vscode-java/issues/4084