### PR TITLE
fix: better encode Markdown links

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
@@ -912,7 +912,7 @@ public final class JDTUtils {
 				query.append("&element=").append(elementName);
 			}
 			uriString = new URI(JDT_SCHEME, "contents", pathBuilder.toString(), query.toString(), null).toASCIIString();
-
+			uriString = cleanupURL(uriString);
 		} catch (URISyntaxException e) {
 			JavaLanguageServerPlugin.logException("Error generating URI for class ", e);
 		}
@@ -1988,6 +1988,20 @@ public final class JDTUtils {
 			}
 		}
 		return root;
+	}
+
+	/** Percent-encodes ( and ) in jdt:// hrefs so [label](url) is not broken (see #3705). */
+	public static String cleanupURL(String url) {
+		if (url == null) {
+			return url;
+		}
+		if (url.indexOf('(') > -1 ) {
+			return url.replace("(", "%28");
+		}
+		if (url.indexOf(')') > -1) {
+			return url.replace(")", "%29");
+		}
+		return url;
 	}
 
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CallHierarchyHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CallHierarchyHandlerTest.java
@@ -190,7 +190,7 @@ public class CallHierarchyHandlerTest extends AbstractProjectsManagerBasedTest {
 		String jarUri = call0Calls.get(0).getTo().getUri();
 		assertTrue(jarUri.startsWith("jdt://"));
 		assertTrue(jarUri.contains("org.apache.commons.lang3.text/WordUtils.java?"));
-		assertTrue(jarUri.contains("org.apache.commons.lang3.text(WordUtils.class"));
+		assertTrue(jarUri.contains("org.apache.commons.lang3.text%28WordUtils.class"));
 	}
 
 	@Test

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HoverHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HoverHandlerTest.java
@@ -214,9 +214,10 @@ public class HoverHandlerTest extends AbstractProjectsManagerBasedTest {
 			assertNotNull(hover.getContents());
 			assertEquals(2, hover.getContents().getLeft().size());
 			assertEquals("com.aspose.words.Document.Document(String fileName) throws Exception", hover.getContents().getLeft().get(0).getRight().getValue());
-			//External library should link to the library file
-			assertTrue(hover.getContents().getLeft().get(1).getLeft().startsWith("Source: *[aspose-words-15.12.0-jdk16.jar](jdt://contents/aspose-words-15.12.0-jdk16.jar/com.aspose.words/Document.class?"),
-					"Unexpected Source from " + hover.getContents().getLeft().get(1).getLeft());
+			String source = hover.getContents().getLeft().get(1).getLeft();
+			String prefix = "Source: *[aspose-words-15.12.0-jdk16.jar](jdt://contents/aspose-words-15.12.0-jdk16.jar/com.aspose.words/Document.class?";
+			assertTrue(source.startsWith(prefix), "Unexpected Source from " + source);
+			assertFalse(source.substring(prefix.length()).contains("("), "Source URL is not sanitized: " + source);
 		} finally {
 			if (unit != null) {
 				unit.discardWorkingCopy();
@@ -536,7 +537,7 @@ public class HoverHandlerTest extends AbstractProjectsManagerBasedTest {
 		Either<String, MarkedString> javadoc = hover.getContents().getLeft().get(1);
 		String content = null;
 		assertTrue(javadoc != null && javadoc.getLeft() != null && (content = javadoc.getLeft()) != null, "javadoc has null content");
-		assertMatches("This link doesnt work \\[LinkToSomethingNotFound\\]\\(\\)", content);
+		assertMatches("This link doesnt work LinkToSomethingNotFound", content);
 	}
 
 	@Test
@@ -912,7 +913,7 @@ public class HoverHandlerTest extends AbstractProjectsManagerBasedTest {
 	@Test
 	public void testNoLinkWhenClassContentUnsupported() throws Exception {
 		initPreferenceManager(false);
-		testClassContentSupport("Uses \\[WordUtils\\]\\(\\)");
+		testClassContentSupport("Uses WordUtils");
 	}
 
 	@Test

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ResolveSourceMappingHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ResolveSourceMappingHandlerTest.java
@@ -52,7 +52,7 @@ public class ResolveSourceMappingHandlerTest extends AbstractProjectsManagerBase
 		String uri = ResolveSourceMappingHandler.resolveStackTraceLocation("at org.junit.Assert.assertEquals(Assert.java:117)", Arrays.asList("quickstart2"));
 		assertTrue(uri.startsWith("jdt://contents/junit-4.13.jar/org.junit/Assert.java"));
 		assertTrue(uri.contains(
-				"junit%5C/junit%5C/4.13%5C/junit-4.13.jar=/maven.pomderived=/true=/=/test=/true=/=/maven.groupId=/junit=/=/maven.artifactId=/junit=/=/maven.version=/4.13=/=/maven.scope=/test=/=/maven.pomderived=/true=/%3Corg.junit(Assert.class"));
+				"junit%5C/junit%5C/4.13%5C/junit-4.13.jar=/maven.pomderived=/true=/=/test=/true=/=/maven.groupId=/junit=/=/maven.artifactId=/junit=/=/maven.version=/4.13=/=/maven.scope=/test=/=/maven.pomderived=/true=/%3Corg.junit%28Assert.class"));
 	}
 
 	@Test
@@ -60,6 +60,6 @@ public class ResolveSourceMappingHandlerTest extends AbstractProjectsManagerBase
 		String uri = ResolveSourceMappingHandler.resolveStackTraceLocation("at org.junit.Assert.assertEquals(Assert.java:117)", null);
 		assertTrue(uri.startsWith("jdt://contents/junit-4.13.jar/org.junit/Assert.java"));
 		assertTrue(uri.contains(
-				"junit%5C/4.13%5C/junit-4.13.jar=/maven.pomderived=/true=/=/test=/true=/=/maven.groupId=/junit=/=/maven.artifactId=/junit=/=/maven.version=/4.13=/=/maven.scope=/test=/=/maven.pomderived=/true=/%3Corg.junit(Assert.class"));
+				"junit%5C/4.13%5C/junit-4.13.jar=/maven.pomderived=/true=/=/test=/true=/=/maven.groupId=/junit=/=/maven.artifactId=/junit=/=/maven.version=/4.13=/=/maven.scope=/test=/=/maven.pomderived=/true=/%3Corg.junit%28Assert.class"));
 	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/javadoc/JavaDoc2MarkdownConverterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/javadoc/JavaDoc2MarkdownConverterTest.java
@@ -13,6 +13,7 @@
 package org.eclipse.jdt.ls.core.internal.javadoc;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -169,6 +170,22 @@ public class JavaDoc2MarkdownConverterTest extends AbstractJavadocConverterTest 
 		String[] labelAndURIFromMarkdown = extractLabelAndURIFromLinkMarkdown(convertedMarkdown);
 		assertEquals("JDT", labelAndURIFromMarkdown[0]);
 		assertEquals("jdt://some_location", labelAndURIFromMarkdown[1]);
+	}
+
+	/**
+	 * Ensures the custom anchor renderer encodes parentheses in jdt:// hrefs so
+	 * Markdown link syntax [text](url) is not broken. See #3705.
+	 */
+	@Test
+	public void testJdtLinkWithParenthesesInUrlIsEncodedByAnchorRenderer() throws IOException {
+		String htmlWithUnencodedParens = "<a href=\"jdt://contents/foo.jar/pkg/Clazz.class?=x/%3Cpkg(Clazz.class#42\">waitForExit</a>";
+		JavaDoc2MarkdownConverter converter = new JavaDoc2MarkdownConverter(htmlWithUnencodedParens);
+		String convertedMarkdown = converter.getAsString();
+
+		String[] labelAndURIFromMarkdown = extractLabelAndURIFromLinkMarkdown(convertedMarkdown);
+		assertEquals("waitForExit", labelAndURIFromMarkdown[0]);
+		assertTrue(labelAndURIFromMarkdown[1].contains("%28Clazz.class#42"), "jdt URL should contain encoded opening parenthesis: " + labelAndURIFromMarkdown[1]);
+		assertFalse(labelAndURIFromMarkdown[1].contains("(Clazz.class"), "jdt URL should not contain raw ( before .class: " + labelAndURIFromMarkdown[1]);
 	}
 
 	@Test

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/javadoc/JavadocContentTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/javadoc/JavadocContentTest.java
@@ -70,8 +70,8 @@ public class JavadocContentTest extends AbstractProjectsManagerBasedTest {
 				  * Some dude
 				  * Another one
 				* **See Also:**
-				  * [some.pkg.SomeClass]()
-				  * [some.pkg.SomeClass.someMethod()]()""";
+				  * some.pkg.SomeClass
+				  * some.pkg.SomeClass.someMethod()""";
 		assertEquals(expectedJavadoc, javadoc.getValue());
 	}
 


### PR DESCRIPTION
Fixes #3705, encodes opening parenthesis like remark did. 
Basically reuses flexmark's original processA to include both URL fixing and javadoc links processing, avoids an extra loop over all anchors.