### PR TITLE
enhancement: remove the first blank from codelens

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/NewCUProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/NewCUProposal.java
@@ -431,7 +431,10 @@ public class NewCUProposal extends ChangeCorrectionProposalCore {
 		IPackageFragment pack = (IPackageFragment) cu.getParent();
 		String content = CodeGeneration.getCompilationUnitContent(cu, fileComment, typeComment, typeContent, lineDelimiter);
 		if (content != null) {
-
+			// Strip leading blank lines that may result from empty template variables (e.g. ${filecomment})
+			while (content.startsWith(lineDelimiter)) {
+				content = content.substring(lineDelimiter.length());
+			}
 			ASTParser parser = ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
 			parser.setProject(cu.getJavaProject());
 			parser.setSource(content.toCharArray());
@@ -443,8 +446,9 @@ public class NewCUProposal extends ChangeCorrectionProposalCore {
 		StringBuilder buf = new StringBuilder();
 		if (!pack.isDefaultPackage()) {
 			buf.append("package ").append(pack.getElementName()).append(';'); //$NON-NLS-1$
+			buf.append(lineDelimiter);
 		}
-		buf.append(lineDelimiter).append(lineDelimiter);
+		buf.append(lineDelimiter);
 		buf.append(typeContent);
 		return buf.toString();
 	}


### PR DESCRIPTION
Create class from quick fix > It always has a blank line in new class file as below
<img width="343" height="173" alt="image" src="https://github.com/user-attachments/assets/51c8204c-793d-4fe8-98e8-a216b6cfdea4" />
Repro step: Create a new folder > Create a new file:A.java > Paste the following code in A.java > Select "Create class 'File'" from quick fixes > Go to File.java

```java
public class A {
    public static void main(String[] args) {
        File f = new File("demo.txt");
    }
}
```