### PR TITLE
feat: add hinlay hints for format parameters

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InlayHintsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InlayHintsHandler.java
@@ -45,7 +45,7 @@ public class InlayHintsHandler {
 	 */
 	public List<InlayHint> inlayHint(InlayHintParams params, IProgressMonitor monitor) {
 		var prefs = preferenceManager.getPreferences();
-		if (InlayHintsParameterMode.NONE.equals(prefs.getInlayHintsParameterMode()) && !prefs.isInlayHintsVariableTypesEnabled()) {
+		if (InlayHintsParameterMode.NONE.equals(prefs.getInlayHintsParameterMode()) && !prefs.isInlayHintsVariableTypesEnabled() && !prefs.isInlayHintsFormatParametersEnabled()) {
 			return Collections.emptyList();
 		}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InlayHintsPreferenceChangeListener.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InlayHintsPreferenceChangeListener.java
@@ -26,7 +26,8 @@ public class InlayHintsPreferenceChangeListener implements IPreferencesChangeLis
 		if (!Objects.equals(oldPreferences.getInlayHintsParameterMode(), newPreferences.getInlayHintsParameterMode())
 		|| oldPreferences.isInlayHintsVariableTypesEnabled() != newPreferences.isInlayHintsVariableTypesEnabled()
 		|| oldPreferences.isInlayHintsParameterTypesEnabled() != newPreferences.isInlayHintsParameterTypesEnabled()
-		|| oldPreferences.isInlayHintsSuppressedWhenSameNameNumberedParameter() != newPreferences.isInlayHintsSuppressedWhenSameNameNumberedParameter()) {
+		|| oldPreferences.isInlayHintsSuppressedWhenSameNameNumberedParameter() != newPreferences.isInlayHintsSuppressedWhenSameNameNumberedParameter()
+		|| oldPreferences.isInlayHintsFormatParametersEnabled() != newPreferences.isInlayHintsFormatParametersEnabled()) {
             refresh();
         }
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -524,6 +524,8 @@ public class Preferences {
 
 	public static final String JAVA_INLAYHINTS_PARAMETERTYPES_ENABLED = "java.inlayHints.parameterTypes.enabled";
 
+	public static final String JAVA_INLAYHINTS_FORMATPARAMETERS_ENABLED = "java.inlayHints.formatParameters.enabled";
+
 	/**
 	 * Preference key for the inlay hints exclusion list
 	 */
@@ -722,6 +724,7 @@ public class Preferences {
 	private List<String> inlayHintsExclusionList;
 	private boolean inlayHintsVariableTypesEnabled;
 	private boolean inlayHintsParameterTypesEnabled;
+	private boolean inlayHintsFormatParametersEnabled;
 	private ProjectEncodingMode projectEncoding;
 	private boolean avoidVolatileChanges;
 	private boolean protobufSupportEnabled;
@@ -991,6 +994,7 @@ public class Preferences {
 		inlayHintsParameterMode = InlayHintsParameterMode.LITERALS;
 		inlayHintsVariableTypesEnabled = false;
 		inlayHintsParameterTypesEnabled = false;
+		inlayHintsFormatParametersEnabled = false;
 		projectEncoding = ProjectEncodingMode.IGNORE;
 		avoidVolatileChanges = true;
 		javacEnabled = false;
@@ -1157,6 +1161,7 @@ public class Preferences {
 		prefs.inlayHintsSuppressedWhenSameNameNumberedParameter = this.inlayHintsSuppressedWhenSameNameNumberedParameter;
 		prefs.inlayHintsVariableTypesEnabled = this.inlayHintsVariableTypesEnabled;
 		prefs.inlayHintsParameterTypesEnabled = this.inlayHintsParameterTypesEnabled;
+		prefs.inlayHintsFormatParametersEnabled = this.inlayHintsFormatParametersEnabled;
 		prefs.projectEncoding = this.projectEncoding;
 		prefs.avoidVolatileChanges = this.avoidVolatileChanges;
 		prefs.protobufSupportEnabled = this.protobufSupportEnabled;
@@ -1774,6 +1779,11 @@ public class Preferences {
 			prefs.setInlayHintsParameterTypesEnabled(inlayHintsParameterTypesEnabled);
 		}
 
+		if (containsKey(configuration, JAVA_INLAYHINTS_FORMATPARAMETERS_ENABLED)) {
+			boolean inlayHintsFormatParametersEnabled = getBoolean(configuration, JAVA_INLAYHINTS_FORMATPARAMETERS_ENABLED, existing.inlayHintsFormatParametersEnabled);
+			prefs.setInlayHintsFormatParametersEnabled(inlayHintsFormatParametersEnabled);
+		}
+
 		if (containsKey(configuration, JAVA_PROJECT_ENCODING)) {
 			String projectEncoding = getString(configuration, JAVA_PROJECT_ENCODING, null);
 			prefs.setProjectEncoding(ProjectEncodingMode.fromString(projectEncoding, existing.projectEncoding));
@@ -1906,6 +1916,14 @@ public class Preferences {
 
 	public void setInlayHintsParameterTypesEnabled(boolean inlayHintsParameterTypesEnabled) {
 		this.inlayHintsParameterTypesEnabled = inlayHintsParameterTypesEnabled;
+	}
+
+	public boolean isInlayHintsFormatParametersEnabled() {
+		return inlayHintsFormatParametersEnabled;
+	}
+
+	public void setInlayHintsFormatParametersEnabled(boolean inlayHintsFormatParametersEnabled) {
+		this.inlayHintsFormatParametersEnabled = inlayHintsFormatParametersEnabled;
 	}
 
 	private static boolean validateFilePattern(String filename) {


### PR DESCRIPTION
Adds a new `java.inlayHints.formatParameters.enabled` setting to enable hinlay hints for format parameters (defaults to false)

Applies to String.formatted() and select classes defining the printf() and format() methods.

<img width="466" height="155" alt="Screenshot 2026-02-26 at 16 17 24" src="https://github.com/user-attachments/assets/927a3208-43e9-4926-a8c2-81445f80caf8" />

See https://github.com/redhat-developer/vscode-java/issues/4350

