### PR TITLE
Add new null annotation quick-fixes from upstream JDT

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
@@ -653,6 +653,13 @@ public class QuickFixProcessor {
 			case IProblem.RedundantNullDefaultAnnotationField:
 				NullAnnotationsCorrectionProcessor.addRemoveRedundantAnnotationProposal(context, problem, proposals);
 				break;
+			case IProblem.DereferencingNullableExpression:
+			case IProblem.NullityMismatchingTypeAnnotation:
+				NullAnnotationsCorrectionProcessor.addReplaceNullableAnnotationProposal(context, problem, proposals);
+				break;
+			case IProblem.ContradictoryNullAnnotations:
+				NullAnnotationsCorrectionProcessor.addRemoveContradictoryAnnotationProposals(context, problem, proposals);
+				break;
 			case IProblem.UnusedTypeParameter:
 				LocalCorrectionsSubProcessor.addUnusedTypeParameterProposal(context, problem, proposals);
 				break;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDiagnosticsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDiagnosticsHandler.java
@@ -262,6 +262,7 @@ public abstract class BaseDiagnosticsHandler implements IProblemRequestor {
 					|| problem.getID() == IProblem.DuplicateInheritedDefaultMethods
 					|| problem.getID() == IProblem.FeatureNotSupported
 					|| problem.getID() == IProblem.MultiConstantCaseLabelsNotSupported || problem.getID() == IProblem.InvalidUsageOfTypeAnnotations
+					|| problem.getID() == IProblem.ContradictoryNullAnnotations
 					|| problem.getID() == IProblem.InheritedDefaultMethodConflictsWithOtherInherited) {
 				data.put(DIAG_ARGUMENTS, problem.getArguments());
 			}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/NullAnnotationsCorrectionProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/NullAnnotationsCorrectionProcessor.java
@@ -69,6 +69,14 @@ public class NullAnnotationsCorrectionProcessor extends NullAnnotationsCorrectio
 		new NullAnnotationsCorrectionProcessor().getLocalVariableAnnotationProposal(context, problem, proposals);
 	}
 
+	public static void addRemoveContradictoryAnnotationProposals(IInvocationContext context, IProblemLocation problem, Collection<ProposalKindWrapper> proposals) {
+		new NullAnnotationsCorrectionProcessor().getRemoveContradictoryAnnotationProposals(context, problem, proposals);
+	}
+
+	public static void addReplaceNullableAnnotationProposal(IInvocationContext context, IProblemLocation problem, Collection<ProposalKindWrapper> proposals) {
+		new NullAnnotationsCorrectionProcessor().getReplaceNullableAnnotationProposal(context, problem, proposals);
+	}
+
 	private NullAnnotationsCorrectionProcessor() {
 	}
 	/* (non-Javadoc)

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/NullAnnotationsQuickFix1d8Test.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/NullAnnotationsQuickFix1d8Test.java
@@ -1320,7 +1320,6 @@ public class NullAnnotationsQuickFix1d8Test extends AbstractQuickFixTest {
 					}
 					""", false, null);
 
-			CompilationUnit unit = getASTRoot(cu);
 			assertCodeActionExists(cu, new String[] { "Add @SuppressWarnings 'null' to 'isValid()'", "Add @SuppressWarnings 'null' to 'validationStatus'", "Change parameter 'refPrefix' to '@NonNull'" });
 		}
 
@@ -1353,6 +1352,153 @@ public class NullAnnotationsQuickFix1d8Test extends AbstractQuickFixTest {
 
 			assertCodeActionExists(cu, new String[] { "Add @SuppressWarnings 'null' to 'isValid()'", "Add @SuppressWarnings 'null' to 'validationStatus'", "Change parameter 'refPrefix' to '@NonNull'",
 					"Change parameter of 'validateNewRefName(..)' to '@Nullable'" });
+		}
+
+		@Test
+		public void testGH2913() throws Exception {
+			IPackageFragment my = fSourceFolder.createPackageFragment("my", false, null);
+			ICompilationUnit cu = my.createCompilationUnit("Test.java", """
+					package my;
+					import org.eclipse.jdt.annotation.*;
+					public class Test {
+					  public void invokeMe(@Nullable String aaa) {
+					    System.out.println(aaa.length());
+					  }
+					}
+					""", false, null);
+
+			String str1 = """
+					package my;
+					import org.eclipse.jdt.annotation.*;
+					public class Test {
+					  public void invokeMe(@NonNull String aaa) {
+					    System.out.println(aaa.length());
+					  }
+					}
+					""";
+			Expected e1 = new Expected("Change 'aaa' to '@NonNull'", str1);
+			assertCodeActionExists(cu, e1);
+		}
+
+		@Test
+		public void testGH2919() throws Exception {
+			IPackageFragment my = fSourceFolder.createPackageFragment("my", false, null);
+			ICompilationUnit cu = my.createCompilationUnit("Test.java", """
+					package my;
+					import org.eclipse.jdt.annotation.NonNull;
+					import org.eclipse.jdt.annotation.Nullable;
+					public class Test {
+					  public @Nullable @NonNull String invokeMe(String aaa) {
+					    return "abc";
+					  }
+					}
+					""", false, null);
+
+			String str1 = """
+					package my;
+					import org.eclipse.jdt.annotation.Nullable;
+					public class Test {
+					  public @Nullable String invokeMe(String aaa) {
+					    return "abc";
+					  }
+					}
+					""";
+			Expected e1 = new Expected("Remove '@NonNull'", str1);
+
+			String str2 = """
+					package my;
+					import org.eclipse.jdt.annotation.NonNull;
+					public class Test {
+					  public @NonNull String invokeMe(String aaa) {
+					    return "abc";
+					  }
+					}
+					""";
+			Expected e2 = new Expected("Remove '@Nullable'", str2);
+			assertCodeActions(cu, e1, e2);
+		}
+
+		@Test
+		public void testGH2822_1() throws Exception {
+			IPackageFragment my = fSourceFolder.createPackageFragment("my", false, null);
+			ICompilationUnit cu = my.createCompilationUnit("Test.java", """
+					package my;
+					import org.eclipse.jdt.annotation.*;
+					public class Test {
+					  public void doStuff() {
+					    invokeMe(getString());
+					  }
+					  public void invokeMe(@NonNull String value) {
+					    System.out.println(value.length());
+					  }
+					  public @Nullable String getString() {
+					    return "my string";
+					  }
+					}
+					""", false, null);
+
+
+			String str1 = """
+					package my;
+					import org.eclipse.jdt.annotation.*;
+					public class Test {
+					  public void doStuff() {
+					    invokeMe(getString());
+					  }
+					  public void invokeMe(@NonNull String value) {
+					    System.out.println(value.length());
+					  }
+					  public @NonNull String getString() {
+					    return "my string";
+					  }
+					}
+					""";
+			Expected e1 = new Expected("Change 'getString()' to '@NonNull'", str1);
+			assertCodeActionExists(cu, e1);
+		}
+
+		@Test
+		public void testGH2822_2() throws Exception {
+			IPackageFragment my = fSourceFolder.createPackageFragment("my", false, null);
+			ICompilationUnit cu = my.createCompilationUnit("Test.java", """
+					package my;
+					import org.eclipse.jdt.annotation.*;
+					public class Test {
+					  public void doStuff() {
+					    invokeMe(getString());
+					  }
+					  public void invokeMe(@NonNull String value) {
+					    System.out.println(value.length());
+					  }
+					  public @Nullable String getString() {
+					    return getOtherString();
+					  }
+					  public @NonNull String getOtherString() {
+					  	return "other string";
+					  }
+					}
+					""", false, null);
+
+			String str1 = """
+					package my;
+					import org.eclipse.jdt.annotation.*;
+					public class Test {
+					  public void doStuff() {
+					    invokeMe(getString());
+					  }
+					  public void invokeMe(@NonNull String value) {
+					    System.out.println(value.length());
+					  }
+					  public @NonNull String getString() {
+					    return getOtherString();
+					  }
+					  public @NonNull String getOtherString() {
+					  	return "other string";
+					  }
+					}
+					""";
+			Expected e1 = new Expected("Change 'getString()' to '@NonNull'", str1);
+			assertCodeActionExists(cu, e1);
 		}
 
 }


### PR DESCRIPTION
- add quick-fixes for IProblem.DeferencingNullableExpression, IProblem.NullityMismatchingTypeAnnotation, IProblem.ContradictoryNullAnnotations
- add new code to NullAnnotationsCorrectionsProcessor
- add new tests to NullAnnotationsQuickFix1d8Test