### PR TITLE
Add new quick-fixes

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -75,6 +75,7 @@ import org.eclipse.jdt.ls.core.internal.handlers.CodeActionHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.OrganizeImportsHandler;
 import org.eclipse.jdt.ls.core.internal.text.correction.ModifierCorrectionSubProcessor;
 import org.eclipse.jdt.ls.core.internal.text.correction.NullAnnotationsCorrectionProcessor;
+import org.eclipse.jdt.ls.core.internal.text.correction.TypeArgumentMismatchSubProcessor;
 import org.eclipse.jdt.ls.core.internal.text.correction.VarargsWarningsSubProcessor;
 import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
 import org.eclipse.jdt.ui.text.java.IInvocationContext;
@@ -453,34 +454,23 @@ public class QuickFixProcessor {
 			case IProblem.DeadCode:
 				LocalCorrectionsSubProcessor.getUnreachableCodeProposals(context, problem, proposals);
 				break;
-			// case IProblem.DiamondNotBelow17:
-			// TypeArgumentMismatchSubProcessor.getInferDiamondArgumentsProposal(context,
-			// problem, proposals);
-			// //$FALL-THROUGH$
-			// case IProblem.LambdaExpressionNotBelow18:
-			// LocalCorrectionsSubProcessor.getConvertLambdaToAnonymousClassCreationsProposals(context,
-			// problem, proposals);
-			// //$FALL-THROUGH$
-			// case IProblem.NonGenericType:
-			// TypeArgumentMismatchSubProcessor.removeMismatchedArguments(context,
-			// problem, proposals);
-			// break;
-			// case IProblem.MissingOverrideAnnotation:
-			// case
-			// IProblem.MissingOverrideAnnotationForInterfaceMethodImplementation:
-			// ModifierCorrectionSubProcessor.addOverrideAnnotationProposal(context,
-			// problem, proposals);
-			// break;
+			case IProblem.NonGenericType:
+				TypeArgumentMismatchSubProcessor.removeMismatchedArguments(context, problem, proposals);
+				break;
+			case IProblem.MissingOverrideAnnotation:
+			case IProblem.MissingOverrideAnnotationForInterfaceMethodImplementation:
+				ModifierCorrectionSubProcessor.addOverrideAnnotationProposal(context, problem, proposals);
+				break;
 			case IProblem.MethodMustOverride:
 			case IProblem.MethodMustOverrideOrImplement:
 				ModifierCorrectionSubProcessor.removeOverrideAnnotationProposal(context, problem, proposals);
 				break;
-			// case IProblem.FieldMissingDeprecatedAnnotation:
-			// case IProblem.MethodMissingDeprecatedAnnotation:
-			// case IProblem.TypeMissingDeprecatedAnnotation:
-			// ModifierCorrectionSubProcessor.addDeprecatedAnnotationProposal(context,
-			// problem, proposals);
-			// break;
+			case IProblem.FieldMissingDeprecatedAnnotation:
+			case IProblem.MethodMissingDeprecatedAnnotation:
+			case IProblem.TypeMissingDeprecatedAnnotation:
+			case IProblem.MemberOfDeprecatedTypeNotDeprecated:
+				ModifierCorrectionSubProcessor.addDeprecatedAnnotationProposal(context, problem, proposals);
+				break;
 			case IProblem.OverridingDeprecatedMethod:
 			case IProblem.OverridingDeprecatedSinceVersionMethod:
 			case IProblem.OverridingTerminallyDeprecatedMethod:

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/ModifierCorrectionSubProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/ModifierCorrectionSubProcessor.java
@@ -38,6 +38,14 @@ import org.eclipse.lsp4j.CodeActionKind;
 
 public class ModifierCorrectionSubProcessor extends ModifierCorrectionSubProcessorCore<ProposalKindWrapper> {
 
+	public static void addOverrideAnnotationProposal(IInvocationContext context, IProblemLocation problem, Collection<ProposalKindWrapper> proposals) {
+		new ModifierCorrectionSubProcessor().getOverrideAnnotationProposal(context, problem, proposals);
+	}
+
+	public static void addDeprecatedAnnotationProposal(IInvocationContext context, IProblemLocation problem, Collection<ProposalKindWrapper> proposals) {
+		new ModifierCorrectionSubProcessor().getDeprecatedAnnotationProposal(context, problem, proposals);
+	}
+
 	public static void addNonAccessibleReferenceProposal(IInvocationContext context, IProblemLocation problem, Collection<ProposalKindWrapper> proposals, int kind, int relevance) throws CoreException {
 		new ModifierCorrectionSubProcessor().getNonAccessibleReferenceProposal(context, problem, proposals, kind, relevance);
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/TypeArgumentMismatchSubProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/TypeArgumentMismatchSubProcessor.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Red Hat Inc. - modified for jdt.ls
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.text.correction;
+
+import java.util.Collection;
+
+import org.eclipse.jdt.internal.ui.text.correction.TypeArgumentMismatchBaseSubProcessor;
+import org.eclipse.jdt.ls.core.internal.corrections.ProposalKindWrapper;
+import org.eclipse.jdt.ls.core.internal.handlers.CodeActionHandler;
+import org.eclipse.jdt.ui.text.java.IInvocationContext;
+import org.eclipse.jdt.ui.text.java.IProblemLocation;
+import org.eclipse.jdt.ui.text.java.correction.ASTRewriteCorrectionProposalCore;
+import org.eclipse.lsp4j.CodeActionKind;
+
+public class TypeArgumentMismatchSubProcessor extends TypeArgumentMismatchBaseSubProcessor<ProposalKindWrapper> {
+
+	public static void removeMismatchedArguments(IInvocationContext context, IProblemLocation problem, Collection<ProposalKindWrapper> proposals) {
+		new TypeArgumentMismatchSubProcessor().addRemoveMismatchedArgumentProposals(context, problem, proposals);
+	}
+
+	private TypeArgumentMismatchSubProcessor() {
+	}
+
+	@Override
+	public ProposalKindWrapper astRewriteCorrectionProposalToT(ASTRewriteCorrectionProposalCore core) {
+		return CodeActionHandler.wrap(core, CodeActionKind.QuickFix);
+	}
+
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/ModifierCorrectionsQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/ModifierCorrectionsQuickFixTest.java
@@ -1773,4 +1773,328 @@ public class ModifierCorrectionsQuickFixTest extends AbstractQuickFixTest {
 		assertCodeActionExists(cu, e1);
 	}
 
+	@Test
+	public void testMethodOverrideDeprecated1() throws Exception {
+		Map<String, String> options9 = new HashMap<>();
+		JavaModelUtil.setComplianceOptions(options9, JavaCore.VERSION_9);
+		options9.put(JavaCore.COMPILER_PB_DEPRECATION_WHEN_OVERRIDING_DEPRECATED_METHOD, JavaCore.ENABLED);
+		options9.put(JavaCore.COMPILER_PB_DEPRECATION, JavaCore.WARNING);
+		fJProject.setOptions(options9);
+
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("pack", false, null);
+		String str = """
+				package pack;
+				public class E {
+				    @Deprecated(since="3")
+				    public void foo() {
+				    }
+				}   \s
+
+				class F extends E {
+				    /**
+				     */
+				    public void foo() {
+				    }
+				}
+
+				""";
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", str, false, null);
+
+		String[] expected = new String[2];
+		expected[0] = """
+				package pack;
+				public class E {
+				    @Deprecated(since="3")
+				    public void foo() {
+				    }
+				}   \s
+
+				class F extends E {
+				    /**
+				     * @deprecated
+				     */
+				    @Deprecated
+					public void foo() {
+				    }
+				}
+
+				""";
+
+		expected[1] = """
+				package pack;
+				public class E {
+				    @Deprecated(since="3")
+				    public void foo() {
+				    }
+				}   \s
+
+				class F extends E {
+				    /**
+				     */
+				    @SuppressWarnings("deprecation")
+					public void foo() {
+				    }
+				}
+
+				""";
+
+		Expected e0 = new Expected("Mark method as deprecated", expected[0]);
+		Expected e1 = new Expected("Add @SuppressWarnings 'deprecation' to 'foo()'", expected[1]);
+		assertCodeActions(cu, e0, e1);
+	}
+
+	// Bug 530600 - [9][quick fix] should handle new variants of IProblem.OverridingDeprecatedMethod
+	// - forRemoval
+	@Test
+	public void testMethodOverrideDeprecated2() throws Exception {
+		Map<String, String> options9 = new HashMap<>();
+		JavaModelUtil.setComplianceOptions(options9, JavaCore.VERSION_9);
+		options9.put(JavaCore.COMPILER_PB_DEPRECATION_WHEN_OVERRIDING_DEPRECATED_METHOD, JavaCore.ENABLED);
+		options9.put(JavaCore.COMPILER_PB_DEPRECATION, JavaCore.WARNING);
+		fJProject.setOptions(options9);
+
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("pack", false, null);
+		String str = """
+				package pack;
+				public class E {
+				    @Deprecated(forRemoval=true)
+				    public void foo() {
+				    }
+				}   \s
+
+				class F extends E {
+				    /**
+				     */
+				    public void foo() {
+				    }
+				}
+
+				""";
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", str, false, null);
+
+		String[] expected = new String[2];
+		expected[0] = """
+				package pack;
+				public class E {
+				    @Deprecated(forRemoval=true)
+				    public void foo() {
+				    }
+				}   \s
+
+				class F extends E {
+				    /**
+				     * @deprecated
+				     */
+				    @Deprecated
+					public void foo() {
+				    }
+				}
+
+				""";
+
+		expected[1] = """
+				package pack;
+				public class E {
+				    @Deprecated(forRemoval=true)
+				    public void foo() {
+				    }
+				}   \s
+
+				class F extends E {
+				    /**
+				     */
+				    @SuppressWarnings("removal")
+					public void foo() {
+				    }
+				}
+
+				""";
+
+		Expected e0 = new Expected("Mark method as deprecated", expected[0]);
+		Expected e1 = new Expected("Add @SuppressWarnings 'removal' to 'foo()'", expected[1]);
+		assertCodeActions(cu, e0, e1);
+	}
+
+	// Bug 530600 - [9][quick fix] should handle new variants of IProblem.OverridingDeprecatedMethod
+	// - since and forRemoval
+	@Test
+	public void testMethodOverrideDeprecated3() throws Exception {
+		Map<String, String> options9 = new HashMap<>();
+		JavaModelUtil.setComplianceOptions(options9, JavaCore.VERSION_9);
+		options9.put(JavaCore.COMPILER_PB_DEPRECATION_WHEN_OVERRIDING_DEPRECATED_METHOD, JavaCore.ENABLED);
+		options9.put(JavaCore.COMPILER_PB_DEPRECATION, JavaCore.WARNING);
+		fJProject.setOptions(options9);
+
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("pack", false, null);
+		String str = """
+				package pack;
+				public class E {
+				    @Deprecated(since="4.2",forRemoval=true)
+				    public void foo() {
+				    }
+				}   \s
+
+				class F extends E {
+				    /**
+				     */
+				    public void foo() {
+				    }
+				}
+
+				""";
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", str, false, null);
+
+		String[] expected = new String[2];
+		expected[0] = """
+				package pack;
+				public class E {
+				    @Deprecated(since="4.2",forRemoval=true)
+				    public void foo() {
+				    }
+				}   \s
+
+				class F extends E {
+				    /**
+				     * @deprecated
+				     */
+				    @Deprecated
+					public void foo() {
+				    }
+				}
+
+				""";
+
+		expected[1] = """
+				package pack;
+				public class E {
+				    @Deprecated(since="4.2",forRemoval=true)
+				    public void foo() {
+				    }
+				}   \s
+
+				class F extends E {
+				    /**
+				     */
+				    @SuppressWarnings("removal")
+					public void foo() {
+				    }
+				}
+
+				""";
+
+		Expected e0 = new Expected("Mark method as deprecated", expected[0]);
+		Expected e1 = new Expected("Add @SuppressWarnings 'removal' to 'foo()'", expected[1]);
+		assertCodeActions(cu, e0, e1);
+	}
+
+	@Test
+	public void testMissingMethodDeprecationAnnotation() throws Exception {
+		Map<String, String> options9 = new HashMap<>();
+		JavaModelUtil.setComplianceOptions(options9, JavaCore.VERSION_9);
+		options9.put(JavaCore.COMPILER_PB_MISSING_OVERRIDE_ANNOTATION, JavaCore.ERROR);
+		options9.put(JavaCore.COMPILER_PB_MISSING_DEPRECATED_ANNOTATION, JavaCore.ERROR);
+		fJProject.setOptions(options9);
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		String str = """
+				package test1;
+				public final class C {
+				    /**
+				     * @deprecated
+				     */
+				    @Override
+				    public String toString() {
+				        return null;
+				    }
+				}
+				""";
+
+		ICompilationUnit cu = pack1.createCompilationUnit("C.java", str, false, null);
+
+		String expected1 = """
+				package test1;
+				public final class C {
+				    /**
+				     * @deprecated
+				     */
+				    @Deprecated
+					@Override
+				    public String toString() {
+				        return null;
+				    }
+				}
+				""";
+		Expected e1 = new Expected("Add missing @Deprecated annotation", expected1);
+		assertCodeActionExists(cu, e1);
+	}
+
+
+	@Test
+	public void testMissingFieldDeprecationAnnotation() throws Exception {
+		Map<String, String> options9 = new HashMap<>();
+		JavaModelUtil.setComplianceOptions(options9, JavaCore.VERSION_9);
+		options9.put(JavaCore.COMPILER_PB_MISSING_OVERRIDE_ANNOTATION, JavaCore.ERROR);
+		options9.put(JavaCore.COMPILER_PB_MISSING_DEPRECATED_ANNOTATION, JavaCore.ERROR);
+		fJProject.setOptions(options9);
+
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		String str = """
+				package test1;
+				public final class C {
+				    /**
+				     * @deprecated
+				     */
+				    public String name;
+				}
+				""";
+		ICompilationUnit cu = pack1.createCompilationUnit("C.java", str, false, null);
+
+		String str1 = """
+				package test1;
+				public final class C {
+				    /**
+				     * @deprecated
+				     */
+				    @Deprecated
+					public String name;
+				}
+				""";
+		Expected e1 = new Expected("Add missing @Deprecated annotation", str1);
+		assertCodeActionExists(cu, e1);
+	}
+
+	@Test
+	public void testMissingOverrideAnnotation() throws Exception {
+		Map<String, String> options9 = new HashMap<>();
+		JavaModelUtil.setComplianceOptions(options9, JavaCore.VERSION_9);
+		options9.put(JavaCore.COMPILER_PB_MISSING_OVERRIDE_ANNOTATION, JavaCore.ERROR);
+		options9.put(JavaCore.COMPILER_PB_MISSING_DEPRECATED_ANNOTATION, JavaCore.ERROR);
+		fJProject.setOptions(options9);
+
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		String str = """
+				package test1;
+				public final class C {
+				    public String toString() {
+				        return null;
+				    }
+				}
+				""";
+		ICompilationUnit cu = pack1.createCompilationUnit("C.java", str, false, null);
+
+		String str1 = """
+				package test1;
+				public final class C {
+				    @Override
+					public String toString() {
+				        return null;
+				    }
+				}
+				""";
+		Expected e1 = new Expected("Add missing @Override annotation", str1);
+		assertCodeActionExists(cu, e1);
+	}
+
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/TypeArgumentMismatchCorrectionTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/TypeArgumentMismatchCorrectionTest.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.correction;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author jjohnstn
+ *
+ */
+public class TypeArgumentMismatchCorrectionTest extends AbstractQuickFixTest {
+	private IJavaProject fJProject;
+	private IPackageFragmentRoot fSourceFolder;
+
+	@BeforeEach
+	public void setup() throws Exception {
+		fJProject = newEmptyProject();
+		fJProject.setOptions(TestOptions.getDefaultOptions());
+		fSourceFolder = fJProject.getPackageFragmentRoot(fJProject.getProject().getFolder("src"));
+	}
+
+	@Test
+	public void testNonGenericType() throws Exception {
+		Map<String, String> options9 = new HashMap<>();
+		JavaModelUtil.setComplianceOptions(options9, JavaCore.VERSION_9);
+		options9.put(JavaCore.COMPILER_PB_MISSING_OVERRIDE_ANNOTATION, JavaCore.ERROR);
+		options9.put(JavaCore.COMPILER_PB_MISSING_DEPRECATED_ANNOTATION, JavaCore.ERROR);
+		fJProject.setOptions(options9);
+
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		String str = """
+				package test1;
+				class E {
+					int x = 0;
+				}
+				public final class C {
+				    public String foo() {
+				    	System.out.println(new E<String>());
+				    }
+				}
+				""";
+		ICompilationUnit cu = pack1.createCompilationUnit("C.java", str, false, null);
+
+		String str1 = """
+				package test1;
+				class E {
+					int x = 0;
+				}
+				public final class C {
+				    public String foo() {
+				    	System.out.println(new E());
+				    }
+				}
+				""";
+		Expected e1 = new Expected("Remove type arguments", str1);
+		assertCodeActionExists(cu, e1);
+	}
+
+}


### PR DESCRIPTION
- add new methods to ModifierCorrectionSubProcessor and enable quick-fixes that call them in QuickFixProcessor
- add new TypeArgumentMismatchSubProcessor class and enable quick-fix that uses it
- add new tests to ModifierCorrectionsQuickFixTest and add new TypeArgumentMismatchCorrectionTest