### PR TITLE
Filter invalid proposals in annotation attribute value context

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -40,6 +40,7 @@ import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.Signature;
 import org.eclipse.jdt.internal.codeassist.InternalCompletionContext;
+import org.eclipse.jdt.internal.codeassist.complete.CompletionOnSingleNameReference;
 import org.eclipse.jdt.internal.compiler.ast.ASTNode;
 import org.eclipse.jdt.internal.compiler.ast.MemberValuePair;
 import org.eclipse.jdt.internal.corext.template.java.SignatureUtil;
@@ -86,10 +87,6 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 	private boolean isAnnotationAttributeValueContext;
 	/** Whether annotation attribute value context detection has been performed. */
 	private boolean annotationContextChecked;
-	/** The attribute name extracted during annotation context detection (e.g., "forRemoval"). */
-	private String annotationAttributeName;
-	/** The annotation type name extracted during annotation context detection (e.g., "Deprecated"). */
-	private String annotationTypeName;
 	/** The return type signature from the annotation attribute's binding (e.g., "Z" for boolean). */
 	private String annotationAttributeReturnTypeSignature;
 	/**
@@ -790,79 +787,48 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 	 * attribute type is boolean and they are not already present.
 	 */
 	private void injectBooleanLiterals(List<CompletionItem> items) {
-		if (!isAnnotationAttributeBoolean()) {
+		if (!isAnnotationAttributeBoolean() || !isCompletingSingleNameReference()) {
 			return;
 		}
 		boolean hasTrue = false;
 		boolean hasFalse = false;
 		for (CompletionItem item : items) {
 			String label = item.getLabel();
-			if ("true".equals(label)) hasTrue = true;
-			if ("false".equals(label)) hasFalse = true;
+			if ("true".equals(label)) {
+				hasTrue = true;
+			}
+			if ("false".equals(label)) {
+				hasFalse = true;
+			}
 		}
+		int insertIndex = hasTrue ? 1 : 0;
 		if (!hasTrue) {
 			CompletionItem trueItem = new CompletionItem("true");
 			trueItem.setKind(CompletionItemKind.Keyword);
 			trueItem.setInsertText("true");
 			trueItem.setSortText("00000"); // high priority
-			items.add(0, trueItem);
+			items.add(insertIndex++, trueItem);
 		}
 		if (!hasFalse) {
 			CompletionItem falseItem = new CompletionItem("false");
 			falseItem.setKind(CompletionItemKind.Keyword);
 			falseItem.setInsertText("false");
 			falseItem.setSortText("00001"); // high priority
-			items.add(hasTrue ? 1 : 0, falseItem);
+			items.add(insertIndex, falseItem);
 		}
 	}
 
 	/**
 	 * Check if the current annotation attribute has boolean return type.
-	 * Uses the type signature from MemberValuePair binding when available,
-	 * falls back to resolving the annotation type via the Java model.
+	 * Uses the type signature from MemberValuePair binding.
 	 */
 	private boolean isAnnotationAttributeBoolean() {
-		// Fast path: use binding info from InternalCompletionContext
-		if (annotationAttributeReturnTypeSignature != null) {
-			return Signature.SIG_BOOLEAN.equals(annotationAttributeReturnTypeSignature);
-		}
-		// Fallback: resolve via Java model
-		if (annotationTypeName == null || annotationAttributeName == null) {
-			return false;
-		}
-		try {
-			IJavaProject javaProject = unit.getJavaProject();
-			if (javaProject == null) {
-				return false;
-			}
-			// Try to resolve the annotation type
-			IType annotationType = null;
-			// First try finding by simple name in the compilation unit's imports
-			String[][] resolved = unit.getType(unit.getTypes()[0].getElementName())
-				.resolveType(annotationTypeName);
-			if (resolved != null && resolved.length > 0) {
-				String fullyQualified = resolved[0][0].isEmpty()
-					? resolved[0][1]
-					: resolved[0][0] + "." + resolved[0][1];
-				annotationType = javaProject.findType(fullyQualified);
-			}
-			if (annotationType == null) {
-				// Fallback: try as fully qualified name directly
-				annotationType = javaProject.findType(annotationTypeName);
-			}
-			if (annotationType == null || !annotationType.isAnnotation()) {
-				return false;
-			}
-			// Find the annotation attribute method and check its return type
-			for (var method : annotationType.getMethods()) {
-				if (annotationAttributeName.equals(method.getElementName())) {
-					String returnType = method.getReturnType();
-					// Signature.SIG_BOOLEAN = "Z"
-					return Signature.SIG_BOOLEAN.equals(returnType);
-				}
-			}
-		} catch (Exception e) {
-			JavaLanguageServerPlugin.logException("Error checking annotation attribute type", e);
+		return Signature.SIG_BOOLEAN.equals(annotationAttributeReturnTypeSignature);
+	}
+
+	private boolean isCompletingSingleNameReference() {
+		if (context instanceof InternalCompletionContext internalContext) {
+			return internalContext.getCompletionNode() instanceof CompletionOnSingleNameReference;
 		}
 		return false;
 	}
@@ -872,7 +838,7 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 	 * For example: {@code @Deprecated(forRemoval = |)} — cursor is at the value position.
 	 * <p>
 	 * Uses {@link InternalCompletionContext#getCompletionNodeParent()} to detect
-	 * {@link MemberValuePair} context when available, with a source-scanning fallback.
+	 * {@link MemberValuePair} context.
 	 * </p>
 	 *
 	 * @see <a href="https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/3604">Issue #3604</a>
@@ -882,118 +848,16 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 			return isAnnotationAttributeValueContext;
 		}
 		annotationContextChecked = true;
-		try {
-			// Use InternalCompletionContext to detect MemberValuePair context
-			if (context instanceof InternalCompletionContext internalContext) {
-				ASTNode parent = internalContext.getCompletionNodeParent();
-				if (parent instanceof MemberValuePair mvp) {
-					isAnnotationAttributeValueContext = true;
-					annotationAttributeName = String.valueOf(mvp.name);
-					if (mvp.binding != null && mvp.binding.returnType != null) {
-						annotationAttributeReturnTypeSignature = new String(mvp.binding.returnType.signature());
-					}
-					return true;
+		if (context instanceof InternalCompletionContext internalContext) {
+			ASTNode parent = internalContext.getCompletionNodeParent();
+			if (parent instanceof MemberValuePair mvp) {
+				isAnnotationAttributeValueContext = true;
+				if (mvp.binding != null && mvp.binding.returnType != null) {
+					annotationAttributeReturnTypeSignature = new String(mvp.binding.returnType.signature());
 				}
 			}
-			// Fallback: backward source scanning for annotation attribute value context
-			isAnnotationAttributeValueContext = detectAnnotationContextFromSource();
-		} catch (Exception e) {
-			// Don't let annotation detection failures affect normal completion
-			JavaLanguageServerPlugin.logException("Error detecting annotation context for completion", e);
 		}
 		return isAnnotationAttributeValueContext;
-	}
-
-	/**
-	 * Fallback detection via backward source scanning when InternalCompletionContext
-	 * does not provide MemberValuePair context.
-	 */
-	private boolean detectAnnotationContextFromSource() throws JavaModelException {
-		String source = unit.getSource();
-		int offset = response.getOffset();
-		if (source == null || offset <= 0 || offset > source.length()) {
-			return false;
-		}
-		int pos = offset - 1;
-		// Skip any partial token the user has typed
-		while (pos >= 0 && Character.isJavaIdentifierPart(source.charAt(pos))) {
-			pos--;
-		}
-		// Skip whitespace
-		while (pos >= 0 && Character.isWhitespace(source.charAt(pos))) {
-			pos--;
-		}
-		// Expect '=' (assignment in annotation member-value pair)
-		if (pos < 0 || source.charAt(pos) != '=') {
-			return false;
-		}
-		// Guard against '==' and '!=' operators
-		if (pos > 0 && source.charAt(pos - 1) == '=') {
-			return false;
-		}
-		if (pos > 0 && source.charAt(pos - 1) == '!') {
-			return false;
-		}
-		pos--;
-		// Skip whitespace
-		while (pos >= 0 && Character.isWhitespace(source.charAt(pos))) {
-			pos--;
-		}
-		// Expect an identifier (the attribute name) and capture it
-		if (pos < 0 || !Character.isJavaIdentifierPart(source.charAt(pos))) {
-			return false;
-		}
-		int attrEnd = pos + 1;
-		while (pos >= 0 && Character.isJavaIdentifierPart(source.charAt(pos))) {
-			pos--;
-		}
-		annotationAttributeName = source.substring(pos + 1, attrEnd);
-		// Skip whitespace
-		while (pos >= 0 && Character.isWhitespace(source.charAt(pos))) {
-			pos--;
-		}
-		// Expect '(' or ',' (start of annotation arguments, or separator between them)
-		if (pos < 0 || (source.charAt(pos) != '(' && source.charAt(pos) != ',')) {
-			return false;
-		}
-		if (source.charAt(pos) == ',') {
-			// Walk backward to find matching '('
-			int depth = 0;
-			while (pos >= 0) {
-				char c = source.charAt(pos);
-				if (c == ')') {
-					depth++;
-				} else if (c == '(') {
-					if (depth == 0) {
-						break;
-					}
-					depth--;
-				}
-				pos--;
-			}
-		}
-		if (pos < 0 || source.charAt(pos) != '(') {
-			return false;
-		}
-		pos--;
-		// Skip whitespace
-		while (pos >= 0 && Character.isWhitespace(source.charAt(pos))) {
-			pos--;
-		}
-		// Expect annotation name (possibly qualified: org.example.MyAnnotation) and capture it
-		if (pos < 0 || !Character.isJavaIdentifierPart(source.charAt(pos))) {
-			return false;
-		}
-		int nameEnd = pos + 1;
-		while (pos >= 0 && (Character.isJavaIdentifierPart(source.charAt(pos)) || source.charAt(pos) == '.')) {
-			pos--;
-		}
-		annotationTypeName = source.substring(pos + 1, nameEnd);
-		// Skip whitespace before '@'
-		while (pos >= 0 && Character.isWhitespace(source.charAt(pos))) {
-			pos--;
-		}
-		return pos >= 0 && source.charAt(pos) == '@';
 	}
 
 	/**
@@ -1007,7 +871,7 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 			case CompletionProposal.KEYWORD:
 				// Only allow boolean literals — the only keywords valid as annotation values
 				String keyword = String.valueOf(proposal.getCompletion());
-				return "true".equals(keyword) || "false".equals(keyword);
+				return isCompletingSingleNameReference() && ("true".equals(keyword) || "false".equals(keyword));
 			case CompletionProposal.FIELD_REF:
 				// Allow static final fields (constants) and enum members
 				int flags = proposal.getFlags();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -39,6 +39,9 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.Signature;
+import org.eclipse.jdt.internal.codeassist.InternalCompletionContext;
+import org.eclipse.jdt.internal.compiler.ast.ASTNode;
+import org.eclipse.jdt.internal.compiler.ast.MemberValuePair;
 import org.eclipse.jdt.internal.corext.template.java.SignatureUtil;
 import org.eclipse.jdt.internal.corext.util.TypeFilter;
 import org.eclipse.jdt.ls.core.contentassist.CompletionRanking;
@@ -79,12 +82,16 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 	private PreferenceManager preferenceManager;
 	private CompletionProposalReplacementProvider proposalProvider;
 	private CompletionItemDefaults itemDefaults = new CompletionItemDefaults();
-	/** Cached result of annotation attribute value context detection (null = not yet computed). */
-	private Boolean annotationAttributeValueContext;
+	/** Whether the current completion is in an annotation attribute value context. */
+	private boolean isAnnotationAttributeValueContext;
+	/** Whether annotation attribute value context detection has been performed. */
+	private boolean annotationContextChecked;
 	/** The attribute name extracted during annotation context detection (e.g., "forRemoval"). */
 	private String annotationAttributeName;
 	/** The annotation type name extracted during annotation context detection (e.g., "Deprecated"). */
 	private String annotationTypeName;
+	/** The return type signature from the annotation attribute's binding (e.g., "Z" for boolean). */
+	private String annotationAttributeReturnTypeSignature;
 	/**
 	 * The possible completion kinds requested by the completion engine:
 	 * - {@link CompletionProposal#FIELD_REF}
@@ -250,7 +257,7 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 
 		// Filter out non-constant proposals in annotation attribute value context
 		// (e.g., @Deprecated(forRemoval = |) should only show true/false, not methods)
-		if (isAnnotationAttributeValueContext() && !isValidAnnotationValueProposal(proposal)) {
+		if (checkAnnotationAttributeValueContext() && !isValidAnnotationValueProposal(proposal)) {
 			return;
 		}
 
@@ -364,7 +371,7 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 
 		// Inject boolean literal completions for annotation attribute value context
 		// when JDT didn't propose them (e.g., @Deprecated(forRemoval = |))
-		if (annotationAttributeValueContext != null && annotationAttributeValueContext) {
+		if (isAnnotationAttributeValueContext) {
 			injectBooleanLiterals(completionItems);
 		}
 
@@ -811,9 +818,15 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 
 	/**
 	 * Check if the current annotation attribute has boolean return type.
-	 * Uses the annotation type name and attribute name captured during context detection.
+	 * Uses the type signature from MemberValuePair binding when available,
+	 * falls back to resolving the annotation type via the Java model.
 	 */
 	private boolean isAnnotationAttributeBoolean() {
+		// Fast path: use binding info from InternalCompletionContext
+		if (annotationAttributeReturnTypeSignature != null) {
+			return Signature.SIG_BOOLEAN.equals(annotationAttributeReturnTypeSignature);
+		}
+		// Fallback: resolve via Java model
 		if (annotationTypeName == null || annotationAttributeName == null) {
 			return false;
 		}
@@ -858,110 +871,129 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 	 * Detect if the completion offset is at an annotation attribute value position.
 	 * For example: {@code @Deprecated(forRemoval = |)} — cursor is at the value position.
 	 * <p>
-	 * Annotation attribute values must be compile-time constant expressions per JLS §9.7.1,
-	 * so completion proposals should be filtered accordingly.
+	 * Uses {@link InternalCompletionContext#getCompletionNodeParent()} to detect
+	 * {@link MemberValuePair} context when available, with a source-scanning fallback.
 	 * </p>
 	 *
 	 * @see <a href="https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/3604">Issue #3604</a>
 	 */
-	private boolean isAnnotationAttributeValueContext() {
-		if (annotationAttributeValueContext != null) {
-			return annotationAttributeValueContext;
+	private boolean checkAnnotationAttributeValueContext() {
+		if (annotationContextChecked) {
+			return isAnnotationAttributeValueContext;
 		}
-		annotationAttributeValueContext = false;
+		annotationContextChecked = true;
 		try {
-			String source = unit.getSource();
-			int offset = response.getOffset();
-			if (source == null || offset <= 0 || offset > source.length()) {
-				return false;
-			}
-			int pos = offset - 1;
-			// Skip any partial token the user has typed
-			while (pos >= 0 && Character.isJavaIdentifierPart(source.charAt(pos))) {
-				pos--;
-			}
-			// Skip whitespace
-			while (pos >= 0 && Character.isWhitespace(source.charAt(pos))) {
-				pos--;
-			}
-			// Expect '=' (assignment in annotation member-value pair)
-			if (pos < 0 || source.charAt(pos) != '=') {
-				return false;
-			}
-			// Guard against '==' (comparison operator, not annotation assignment)
-			if (pos + 1 < source.length() && source.charAt(pos + 1) == '=') {
-				return false;
-			}
-			if (pos > 0 && source.charAt(pos - 1) == '!') {
-				return false; // '!=' operator
-			}
-			pos--;
-			// Skip whitespace
-			while (pos >= 0 && Character.isWhitespace(source.charAt(pos))) {
-				pos--;
-			}
-			// Expect an identifier (the attribute name) and capture it
-			if (pos < 0 || !Character.isJavaIdentifierPart(source.charAt(pos))) {
-				return false;
-			}
-			int attrEnd = pos + 1;
-			while (pos >= 0 && Character.isJavaIdentifierPart(source.charAt(pos))) {
-				pos--;
-			}
-			annotationAttributeName = source.substring(pos + 1, attrEnd);
-			// Skip whitespace
-			while (pos >= 0 && Character.isWhitespace(source.charAt(pos))) {
-				pos--;
-			}
-			// Expect '(' or ',' (start of annotation arguments, or separator between them)
-			if (pos < 0 || (source.charAt(pos) != '(' && source.charAt(pos) != ',')) {
-				return false;
-			}
-			if (source.charAt(pos) == ',') {
-				// Walk backward to find matching '('
-				int depth = 0;
-				while (pos >= 0) {
-					char c = source.charAt(pos);
-					if (c == ')') {
-						depth++;
-					} else if (c == '(') {
-						if (depth == 0) {
-							break;
-						}
-						depth--;
+			// Use InternalCompletionContext to detect MemberValuePair context
+			if (context instanceof InternalCompletionContext internalContext) {
+				ASTNode parent = internalContext.getCompletionNodeParent();
+				if (parent instanceof MemberValuePair mvp) {
+					isAnnotationAttributeValueContext = true;
+					annotationAttributeName = String.valueOf(mvp.name);
+					if (mvp.binding != null && mvp.binding.returnType != null) {
+						annotationAttributeReturnTypeSignature = new String(mvp.binding.returnType.signature());
 					}
-					pos--;
+					return true;
 				}
 			}
-			if (pos < 0 || source.charAt(pos) != '(') {
-				return false;
-			}
-			pos--;
-			// Skip whitespace
-			while (pos >= 0 && Character.isWhitespace(source.charAt(pos))) {
-				pos--;
-			}
-			// Expect annotation name (possibly qualified: org.example.MyAnnotation) and capture it
-			if (pos < 0 || !Character.isJavaIdentifierPart(source.charAt(pos))) {
-				return false;
-			}
-			int nameEnd = pos + 1;
-			while (pos >= 0 && (Character.isJavaIdentifierPart(source.charAt(pos)) || source.charAt(pos) == '.')) {
-				pos--;
-			}
-			annotationTypeName = source.substring(pos + 1, nameEnd);
-			// Skip whitespace before '@'
-			while (pos >= 0 && Character.isWhitespace(source.charAt(pos))) {
-				pos--;
-			}
-			if (pos >= 0 && source.charAt(pos) == '@') {
-				annotationAttributeValueContext = true;
-			}
+			// Fallback: backward source scanning for annotation attribute value context
+			isAnnotationAttributeValueContext = detectAnnotationContextFromSource();
 		} catch (Exception e) {
 			// Don't let annotation detection failures affect normal completion
 			JavaLanguageServerPlugin.logException("Error detecting annotation context for completion", e);
 		}
-		return annotationAttributeValueContext;
+		return isAnnotationAttributeValueContext;
+	}
+
+	/**
+	 * Fallback detection via backward source scanning when InternalCompletionContext
+	 * does not provide MemberValuePair context.
+	 */
+	private boolean detectAnnotationContextFromSource() throws JavaModelException {
+		String source = unit.getSource();
+		int offset = response.getOffset();
+		if (source == null || offset <= 0 || offset > source.length()) {
+			return false;
+		}
+		int pos = offset - 1;
+		// Skip any partial token the user has typed
+		while (pos >= 0 && Character.isJavaIdentifierPart(source.charAt(pos))) {
+			pos--;
+		}
+		// Skip whitespace
+		while (pos >= 0 && Character.isWhitespace(source.charAt(pos))) {
+			pos--;
+		}
+		// Expect '=' (assignment in annotation member-value pair)
+		if (pos < 0 || source.charAt(pos) != '=') {
+			return false;
+		}
+		// Guard against '==' and '!=' operators
+		if (pos > 0 && source.charAt(pos - 1) == '=') {
+			return false;
+		}
+		if (pos > 0 && source.charAt(pos - 1) == '!') {
+			return false;
+		}
+		pos--;
+		// Skip whitespace
+		while (pos >= 0 && Character.isWhitespace(source.charAt(pos))) {
+			pos--;
+		}
+		// Expect an identifier (the attribute name) and capture it
+		if (pos < 0 || !Character.isJavaIdentifierPart(source.charAt(pos))) {
+			return false;
+		}
+		int attrEnd = pos + 1;
+		while (pos >= 0 && Character.isJavaIdentifierPart(source.charAt(pos))) {
+			pos--;
+		}
+		annotationAttributeName = source.substring(pos + 1, attrEnd);
+		// Skip whitespace
+		while (pos >= 0 && Character.isWhitespace(source.charAt(pos))) {
+			pos--;
+		}
+		// Expect '(' or ',' (start of annotation arguments, or separator between them)
+		if (pos < 0 || (source.charAt(pos) != '(' && source.charAt(pos) != ',')) {
+			return false;
+		}
+		if (source.charAt(pos) == ',') {
+			// Walk backward to find matching '('
+			int depth = 0;
+			while (pos >= 0) {
+				char c = source.charAt(pos);
+				if (c == ')') {
+					depth++;
+				} else if (c == '(') {
+					if (depth == 0) {
+						break;
+					}
+					depth--;
+				}
+				pos--;
+			}
+		}
+		if (pos < 0 || source.charAt(pos) != '(') {
+			return false;
+		}
+		pos--;
+		// Skip whitespace
+		while (pos >= 0 && Character.isWhitespace(source.charAt(pos))) {
+			pos--;
+		}
+		// Expect annotation name (possibly qualified: org.example.MyAnnotation) and capture it
+		if (pos < 0 || !Character.isJavaIdentifierPart(source.charAt(pos))) {
+			return false;
+		}
+		int nameEnd = pos + 1;
+		while (pos >= 0 && (Character.isJavaIdentifierPart(source.charAt(pos)) || source.charAt(pos) == '.')) {
+			pos--;
+		}
+		annotationTypeName = source.substring(pos + 1, nameEnd);
+		// Skip whitespace before '@'
+		while (pos >= 0 && Character.isWhitespace(source.charAt(pos))) {
+			pos--;
+		}
+		return pos >= 0 && source.charAt(pos) == '@';
 	}
 
 	/**

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -79,6 +79,8 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 	private PreferenceManager preferenceManager;
 	private CompletionProposalReplacementProvider proposalProvider;
 	private CompletionItemDefaults itemDefaults = new CompletionItemDefaults();
+	/** Cached result of annotation attribute value context detection (null = not yet computed). */
+	private Boolean annotationAttributeValueContext;
 	/**
 	 * The possible completion kinds requested by the completion engine:
 	 * - {@link CompletionProposal#FIELD_REF}
@@ -242,6 +244,12 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 			return;
 		}
 
+		// Filter out non-constant proposals in annotation attribute value context
+		// (e.g., @Deprecated(forRemoval = |) should only show true/false, not methods)
+		if (isAnnotationAttributeValueContext() && !isValidAnnotationValueProposal(proposal)) {
+			return;
+		}
+
 		if (proposal.getKind() == CompletionProposal.POTENTIAL_METHOD_DECLARATION) {
 			acceptPotentialMethodDeclaration(proposal);
 		} else {
@@ -349,6 +357,13 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 		response.setItems(completionItems);
 		response.setCommonData(CompletionResolveHandler.DATA_FIELD_URI, uri);
 		response.setCompletionItemData(contributedData);
+
+		// Inject boolean literal completions for annotation attribute value context
+		// when JDT didn't propose them (e.g., @Deprecated(forRemoval = |))
+		if (annotationAttributeValueContext != null && annotationAttributeValueContext) {
+			injectBooleanLiterals(completionItems);
+		}
+
 		CompletionResponses.store(response);
 
 		return completionItems;
@@ -757,5 +772,173 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Inject boolean literal completion items (true, false) when they are not
+	 * already present. This handles the case where JDT's completion engine doesn't
+	 * propose keywords in annotation attribute value context.
+	 */
+	private void injectBooleanLiterals(List<CompletionItem> items) {
+		boolean hasTrue = false;
+		boolean hasFalse = false;
+		for (CompletionItem item : items) {
+			String label = item.getLabel();
+			if ("true".equals(label)) hasTrue = true;
+			if ("false".equals(label)) hasFalse = true;
+		}
+		if (!hasTrue) {
+			CompletionItem trueItem = new CompletionItem("true");
+			trueItem.setKind(CompletionItemKind.Keyword);
+			trueItem.setInsertText("true");
+			trueItem.setSortText("00000"); // high priority
+			items.add(0, trueItem);
+		}
+		if (!hasFalse) {
+			CompletionItem falseItem = new CompletionItem("false");
+			falseItem.setKind(CompletionItemKind.Keyword);
+			falseItem.setInsertText("false");
+			falseItem.setSortText("00001"); // high priority
+			items.add(hasTrue ? 1 : 0, falseItem);
+		}
+	}
+
+	/**
+	 * Detect if the completion offset is at an annotation attribute value position.
+	 * For example: {@code @Deprecated(forRemoval = |)} — cursor is at the value position.
+	 * <p>
+	 * Annotation attribute values must be compile-time constant expressions per JLS §9.7.1,
+	 * so completion proposals should be filtered accordingly.
+	 * </p>
+	 *
+	 * @see <a href="https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/3604">Issue #3604</a>
+	 */
+	private boolean isAnnotationAttributeValueContext() {
+		if (annotationAttributeValueContext != null) {
+			return annotationAttributeValueContext;
+		}
+		annotationAttributeValueContext = false;
+		try {
+			String source = unit.getSource();
+			int offset = response.getOffset();
+			if (source == null || offset <= 0 || offset > source.length()) {
+				return false;
+			}
+			int pos = offset - 1;
+			// Skip any partial token the user has typed
+			while (pos >= 0 && Character.isJavaIdentifierPart(source.charAt(pos))) {
+				pos--;
+			}
+			// Skip whitespace
+			while (pos >= 0 && Character.isWhitespace(source.charAt(pos))) {
+				pos--;
+			}
+			// Expect '=' (assignment in annotation member-value pair)
+			if (pos < 0 || source.charAt(pos) != '=') {
+				return false;
+			}
+			pos--;
+			// Skip whitespace
+			while (pos >= 0 && Character.isWhitespace(source.charAt(pos))) {
+				pos--;
+			}
+			// Expect an identifier (the attribute name)
+			if (pos < 0 || !Character.isJavaIdentifierPart(source.charAt(pos))) {
+				return false;
+			}
+			while (pos >= 0 && Character.isJavaIdentifierPart(source.charAt(pos))) {
+				pos--;
+			}
+			// Skip whitespace
+			while (pos >= 0 && Character.isWhitespace(source.charAt(pos))) {
+				pos--;
+			}
+			// Expect '(' or ',' (start of annotation arguments, or separator between them)
+			if (pos < 0 || (source.charAt(pos) != '(' && source.charAt(pos) != ',')) {
+				return false;
+			}
+			if (source.charAt(pos) == ',') {
+				// Walk backward to find matching '('
+				int depth = 0;
+				while (pos >= 0) {
+					char c = source.charAt(pos);
+					if (c == ')') {
+						depth++;
+					} else if (c == '(') {
+						if (depth == 0) {
+							break;
+						}
+						depth--;
+					}
+					pos--;
+				}
+			}
+			if (pos < 0 || source.charAt(pos) != '(') {
+				return false;
+			}
+			pos--;
+			// Skip whitespace
+			while (pos >= 0 && Character.isWhitespace(source.charAt(pos))) {
+				pos--;
+			}
+			// Expect annotation name (possibly qualified: org.example.MyAnnotation)
+			if (pos < 0 || !Character.isJavaIdentifierPart(source.charAt(pos))) {
+				return false;
+			}
+			while (pos >= 0 && (Character.isJavaIdentifierPart(source.charAt(pos)) || source.charAt(pos) == '.')) {
+				pos--;
+			}
+			// Skip whitespace before '@'
+			while (pos >= 0 && Character.isWhitespace(source.charAt(pos))) {
+				pos--;
+			}
+			if (pos >= 0 && source.charAt(pos) == '@') {
+				annotationAttributeValueContext = true;
+			}
+		} catch (Exception e) {
+			// Don't let annotation detection failures affect normal completion
+			JavaLanguageServerPlugin.logException("Error detecting annotation context for completion", e);
+		}
+		return annotationAttributeValueContext;
+	}
+
+	/**
+	 * Check if a completion proposal is valid in an annotation attribute value context.
+	 * Per JLS §9.7.1, annotation attribute values must be compile-time constant expressions:
+	 * primitive/String literals, enum constants, class literals, other annotations, or arrays thereof.
+	 */
+	private boolean isValidAnnotationValueProposal(CompletionProposal proposal) {
+		int kind = proposal.getKind();
+		switch (kind) {
+			case CompletionProposal.KEYWORD:
+				// Only allow boolean literals — the only keywords valid as annotation values
+				String keyword = String.valueOf(proposal.getCompletion());
+				return "true".equals(keyword) || "false".equals(keyword);
+			case CompletionProposal.FIELD_REF:
+				// Allow static final fields (constants) and enum members
+				int flags = proposal.getFlags();
+				if (Flags.isEnum(flags)) {
+					return true;
+				}
+				return Flags.isStatic(flags) && Flags.isFinal(flags);
+			case CompletionProposal.ANNOTATION_ATTRIBUTE_REF:
+				// Allow annotation attribute references
+				return true;
+			case CompletionProposal.TYPE_REF:
+			case CompletionProposal.PACKAGE_REF:
+			case CompletionProposal.METHOD_REF:
+			case CompletionProposal.METHOD_REF_WITH_CASTED_RECEIVER:
+			case CompletionProposal.METHOD_DECLARATION:
+			case CompletionProposal.LOCAL_VARIABLE_REF:
+			case CompletionProposal.VARIABLE_DECLARATION:
+			case CompletionProposal.CONSTRUCTOR_INVOCATION:
+			case CompletionProposal.ANONYMOUS_CLASS_CONSTRUCTOR_INVOCATION:
+			case CompletionProposal.ANONYMOUS_CLASS_DECLARATION:
+			case CompletionProposal.POTENTIAL_METHOD_DECLARATION:
+				return false;
+			default:
+				// Deny unknown kinds by default to avoid leaking non-constant proposals
+				return false;
+		}
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -81,6 +81,10 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 	private CompletionItemDefaults itemDefaults = new CompletionItemDefaults();
 	/** Cached result of annotation attribute value context detection (null = not yet computed). */
 	private Boolean annotationAttributeValueContext;
+	/** The attribute name extracted during annotation context detection (e.g., "forRemoval"). */
+	private String annotationAttributeName;
+	/** The annotation type name extracted during annotation context detection (e.g., "Deprecated"). */
+	private String annotationTypeName;
 	/**
 	 * The possible completion kinds requested by the completion engine:
 	 * - {@link CompletionProposal#FIELD_REF}
@@ -775,11 +779,13 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 	}
 
 	/**
-	 * Inject boolean literal completion items (true, false) when they are not
-	 * already present. This handles the case where JDT's completion engine doesn't
-	 * propose keywords in annotation attribute value context.
+	 * Inject boolean literal completion items (true, false) when the annotation
+	 * attribute type is boolean and they are not already present.
 	 */
 	private void injectBooleanLiterals(List<CompletionItem> items) {
+		if (!isAnnotationAttributeBoolean()) {
+			return;
+		}
 		boolean hasTrue = false;
 		boolean hasFalse = false;
 		for (CompletionItem item : items) {
@@ -801,6 +807,51 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 			falseItem.setSortText("00001"); // high priority
 			items.add(hasTrue ? 1 : 0, falseItem);
 		}
+	}
+
+	/**
+	 * Check if the current annotation attribute has boolean return type.
+	 * Uses the annotation type name and attribute name captured during context detection.
+	 */
+	private boolean isAnnotationAttributeBoolean() {
+		if (annotationTypeName == null || annotationAttributeName == null) {
+			return false;
+		}
+		try {
+			IJavaProject javaProject = unit.getJavaProject();
+			if (javaProject == null) {
+				return false;
+			}
+			// Try to resolve the annotation type
+			IType annotationType = null;
+			// First try finding by simple name in the compilation unit's imports
+			String[][] resolved = unit.getType(unit.getTypes()[0].getElementName())
+				.resolveType(annotationTypeName);
+			if (resolved != null && resolved.length > 0) {
+				String fullyQualified = resolved[0][0].isEmpty()
+					? resolved[0][1]
+					: resolved[0][0] + "." + resolved[0][1];
+				annotationType = javaProject.findType(fullyQualified);
+			}
+			if (annotationType == null) {
+				// Fallback: try as fully qualified name directly
+				annotationType = javaProject.findType(annotationTypeName);
+			}
+			if (annotationType == null || !annotationType.isAnnotation()) {
+				return false;
+			}
+			// Find the annotation attribute method and check its return type
+			for (var method : annotationType.getMethods()) {
+				if (annotationAttributeName.equals(method.getElementName())) {
+					String returnType = method.getReturnType();
+					// Signature.SIG_BOOLEAN = "Z"
+					return Signature.SIG_BOOLEAN.equals(returnType);
+				}
+			}
+		} catch (Exception e) {
+			JavaLanguageServerPlugin.logException("Error checking annotation attribute type", e);
+		}
+		return false;
 	}
 
 	/**
@@ -837,18 +888,27 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 			if (pos < 0 || source.charAt(pos) != '=') {
 				return false;
 			}
+			// Guard against '==' (comparison operator, not annotation assignment)
+			if (pos + 1 < source.length() && source.charAt(pos + 1) == '=') {
+				return false;
+			}
+			if (pos > 0 && source.charAt(pos - 1) == '!') {
+				return false; // '!=' operator
+			}
 			pos--;
 			// Skip whitespace
 			while (pos >= 0 && Character.isWhitespace(source.charAt(pos))) {
 				pos--;
 			}
-			// Expect an identifier (the attribute name)
+			// Expect an identifier (the attribute name) and capture it
 			if (pos < 0 || !Character.isJavaIdentifierPart(source.charAt(pos))) {
 				return false;
 			}
+			int attrEnd = pos + 1;
 			while (pos >= 0 && Character.isJavaIdentifierPart(source.charAt(pos))) {
 				pos--;
 			}
+			annotationAttributeName = source.substring(pos + 1, attrEnd);
 			// Skip whitespace
 			while (pos >= 0 && Character.isWhitespace(source.charAt(pos))) {
 				pos--;
@@ -881,13 +941,15 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 			while (pos >= 0 && Character.isWhitespace(source.charAt(pos))) {
 				pos--;
 			}
-			// Expect annotation name (possibly qualified: org.example.MyAnnotation)
+			// Expect annotation name (possibly qualified: org.example.MyAnnotation) and capture it
 			if (pos < 0 || !Character.isJavaIdentifierPart(source.charAt(pos))) {
 				return false;
 			}
+			int nameEnd = pos + 1;
 			while (pos >= 0 && (Character.isJavaIdentifierPart(source.charAt(pos)) || source.charAt(pos) == '.')) {
 				pos--;
 			}
+			annotationTypeName = source.substring(pos + 1, nameEnd);
 			// Skip whitespace before '@'
 			while (pos >= 0 && Character.isWhitespace(source.charAt(pos))) {
 				pos--;
@@ -925,6 +987,9 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 				// Allow annotation attribute references
 				return true;
 			case CompletionProposal.TYPE_REF:
+				// Allow type references — needed for enum types (e.g., RetentionPolicy.RUNTIME),
+				// class literals (e.g., Foo.class), and nested annotation types
+				return true;
 			case CompletionProposal.PACKAGE_REF:
 			case CompletionProposal.METHOD_REF:
 			case CompletionProposal.METHOD_REF_WITH_CASTED_RECEIVER:
@@ -937,8 +1002,8 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 			case CompletionProposal.POTENTIAL_METHOD_DECLARATION:
 				return false;
 			default:
-				// Deny unknown kinds by default to avoid leaking non-constant proposals
-				return false;
+				// Allow unknown kinds to avoid blocking legitimate proposals
+				return true;
 		}
 	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -18,6 +18,7 @@ import static org.eclipse.jdt.ls.core.internal.Lsp4jAssertions.assertTextEdit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -4069,6 +4070,81 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		for (CompletionItem item : list.getItems()) {
 			assertEquals(CompletionItemKind.Field, item.getKind());
 		}
+	}
+
+	@Test
+	public void testCompletion_annotationBooleanAttributeValue() throws Exception {
+		importProjects("eclipse/java17");
+		project = WorkspaceHelper.getProject("java17");
+		ICompilationUnit unit = getWorkingCopy("src/foo/bar/Foo.java", """
+				package foo.bar;
+
+				@Deprecated(forRemoval = )
+				public class Foo {
+				}
+				""");
+
+		CompletionList list = requestCompletions(unit, "forRemoval = ");
+
+		assertNotNull(list);
+		assertFalse(list.getItems().isEmpty());
+		// Should contain boolean literals true and false
+		List<String> labels = list.getItems().stream()
+				.map(CompletionItem::getLabel)
+				.collect(Collectors.toList());
+		assertTrue("Expected 'true' in completions but got: " + labels, labels.contains("true"));
+		assertTrue("Expected 'false' in completions but got: " + labels, labels.contains("false"));
+		// Should not contain methods like equals, hashCode, toString
+		for (CompletionItem item : list.getItems()) {
+			assertNotEquals("equals", item.getLabel());
+			assertNotEquals("hashCode", item.getLabel());
+			assertNotEquals("toString", item.getLabel());
+		}
+	}
+
+	@Test
+	public void testCompletion_annotationBooleanAttributeValue_filtersMethodsAndPackages() throws Exception {
+		importProjects("eclipse/java17");
+		project = WorkspaceHelper.getProject("java17");
+		ICompilationUnit unit = getWorkingCopy("src/foo/bar/Foo.java", """
+				package foo.bar;
+
+				@Deprecated(forRemoval = )
+				public class Foo {
+				}
+				""");
+
+		CompletionList list = requestCompletions(unit, "forRemoval = ");
+
+		assertNotNull(list);
+		// No METHOD_REF proposals should survive the filter
+		for (CompletionItem item : list.getItems()) {
+			assertNotEquals("Completion kind should not be Method, but found: " + item.getLabel(),
+					CompletionItemKind.Method, item.getKind());
+		}
+	}
+
+	@Test
+	public void testCompletion_annotationStringAttributeValue_noBooleanInjection() throws Exception {
+		importProjects("eclipse/java17");
+		project = WorkspaceHelper.getProject("java17");
+		ICompilationUnit unit = getWorkingCopy("src/foo/bar/Foo.java", """
+				package foo.bar;
+
+				@SuppressWarnings(value = )
+				public class Foo {
+				}
+				""");
+
+		CompletionList list = requestCompletions(unit, "value = ");
+
+		assertNotNull(list);
+		// For String attribute, should NOT inject boolean literals as top items
+		// (true/false may appear as word completions but should not be injected as Keyword kind)
+		boolean hasBooleanKeyword = list.getItems().stream()
+				.anyMatch(item -> ("true".equals(item.getLabel()) || "false".equals(item.getLabel()))
+						&& CompletionItemKind.Keyword == item.getKind());
+		assertFalse("Should not inject boolean keywords for String annotation attribute", hasBooleanKeyword);
 	}
 
 	@Test

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -4092,8 +4092,8 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		List<String> labels = list.getItems().stream()
 				.map(CompletionItem::getLabel)
 				.collect(Collectors.toList());
-		assertTrue("Expected 'true' in completions but got: " + labels, labels.contains("true"));
-		assertTrue("Expected 'false' in completions but got: " + labels, labels.contains("false"));
+		assertTrue(labels.contains("true"), "Expected 'true' in completions but got: " + labels);
+		assertTrue(labels.contains("false"), "Expected 'false' in completions but got: " + labels);
 		// Should not contain methods like equals, hashCode, toString
 		for (CompletionItem item : list.getItems()) {
 			assertNotEquals("equals", item.getLabel());
@@ -4119,8 +4119,8 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertNotNull(list);
 		// No METHOD_REF proposals should survive the filter
 		for (CompletionItem item : list.getItems()) {
-			assertNotEquals("Completion kind should not be Method, but found: " + item.getLabel(),
-					CompletionItemKind.Method, item.getKind());
+			assertNotEquals(CompletionItemKind.Method, item.getKind(),
+					"Completion kind should not be Method, but found: " + item.getLabel());
 		}
 	}
 
@@ -4144,7 +4144,35 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		boolean hasBooleanKeyword = list.getItems().stream()
 				.anyMatch(item -> ("true".equals(item.getLabel()) || "false".equals(item.getLabel()))
 						&& CompletionItemKind.Keyword == item.getKind());
-		assertFalse("Should not inject boolean keywords for String annotation attribute", hasBooleanKeyword);
+		assertFalse(hasBooleanKeyword, "Should not inject boolean keywords for String annotation attribute");
+	}
+
+	@Test
+	public void testCompletion_annotationBooleanAttributeValue_qualifiedNameNoBooleanInjection() throws Exception {
+		importProjects("eclipse/java17");
+		project = WorkspaceHelper.getProject("java17");
+		ICompilationUnit unit = getWorkingCopy("src/foo/bar/Test.java", """
+				package foo.bar;
+
+				@Deprecated(forRemoval = Test.)
+				public class Test {
+				    public static final boolean blah = false;
+				}
+				""");
+
+		CompletionList list = requestCompletions(unit, "forRemoval = Test.");
+
+		assertNotNull(list);
+		List<String> labels = list.getItems().stream()
+				.map(CompletionItem::getLabel)
+				.collect(Collectors.toList());
+		assertTrue(labels.stream().anyMatch(label -> label.startsWith("blah")),
+				"Expected 'blah' in completions but got: " + labels);
+		boolean hasBooleanKeyword = list.getItems().stream()
+				.anyMatch(item -> ("true".equals(item.getLabel()) || "false".equals(item.getLabel()))
+						&& CompletionItemKind.Keyword == item.getKind());
+		assertFalse(hasBooleanKeyword,
+				"Should not inject boolean keywords for qualified annotation attribute completion");
 	}
 
 	@Test


### PR DESCRIPTION
Fixes eclipse-jdtls/eclipse.jdt.ls#3604

When completing inside annotation attribute values (e.g. @Deprecated(forRemoval = |)), JDT proposes invalid items like type references, package references, and non-boolean keywords. This change:

- Adds annotation attribute value context detection via backward source scanning
- Filters out TYPE_REF, PACKAGE_REF, and non-boolean keyword proposals
- Injects boolean literal completions (true/false) when not already proposed
