### PR TITLE
Add import quick assist for qualified types

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/CorrectionMessages.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/CorrectionMessages.java
@@ -68,6 +68,7 @@ public final class CorrectionMessages extends NLS {
 	public static String QuickAssistProcessor_inline_local_description;
 	public static String QuickAssistProcessor_name_extension_from_class;
 	public static String QuickAssistProcessor_name_extension_from_interface;
+	public static String QuickAssistProcessor_add_import;
 	public static String QuickAssistProcessor_convert_to_static_import;
 	public static String QuickAssistProcessor_convert_to_static_import_replace_all;
 	public static String RefactorProcessor_extract_interface;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/CorrectionMessages.properties
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/CorrectionMessages.properties
@@ -394,6 +394,7 @@ QuickAssistProcessor_createmethodinsuper_description=Create ''{1}()'' in super t
 QuickAssistProcessor_move_exception_to_separate_catch_block=Move exception to separate catch block
 QuickAssistProcessor_move_exceptions_to_separate_catch_block=Move exceptions to separate catch block
 
+QuickAssistProcessor_add_import=Add import
 QuickAssistProcessor_convert_to_static_import=Convert to static import
 QuickAssistProcessor_convert_to_static_import_replace_all=Convert to static import (replace all occurrences)
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/RefactorProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/RefactorProcessor.java
@@ -56,8 +56,12 @@ import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.MethodReference;
 import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.Name;
+import org.eclipse.jdt.core.dom.NameQualifiedType;
+import org.eclipse.jdt.core.dom.ParameterizedType;
 import org.eclipse.jdt.core.dom.QualifiedName;
+import org.eclipse.jdt.core.dom.QualifiedType;
 import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SimpleType;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.StructuralPropertyDescriptor;
@@ -68,9 +72,11 @@ import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.TypeLocation;
 import org.eclipse.jdt.core.manipulation.ChangeCorrectionProposalCore;
 import org.eclipse.jdt.core.manipulation.CleanUpOptionsCore;
 import org.eclipse.jdt.internal.core.manipulation.StubUtility;
+import org.eclipse.jdt.internal.corext.codemanipulation.ContextSensitiveImportRewriteContext;
 import org.eclipse.jdt.internal.corext.dom.ASTNodeFactory;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.Bindings;
@@ -195,6 +201,11 @@ public class RefactorProcessor {
 				}
 
 				getAddStaticImportProposals(context, coveringNode, proposals);
+				if (monitor != null && monitor.isCanceled()) {
+					return Collections.emptyList();
+				}
+
+				getAddImportProposal(context, coveringNode, proposals);
 				if (monitor != null && monitor.isCanceled()) {
 					return Collections.emptyList();
 				}
@@ -974,6 +985,72 @@ public class RefactorProcessor {
 		}
 
 		return true;
+	}
+
+	private static boolean getAddImportProposal(IInvocationContext context, ASTNode node, Collection<ProposalKindWrapper> proposals) {
+		Type type = getQualifiedType(node);
+		if (type == null) {
+			return false;
+		}
+
+		ITypeBinding binding = type.resolveBinding();
+		if (binding == null || binding.isPrimitive() || binding.isArray() || binding.isAnonymous() || binding.isNullType()) {
+			return false;
+		}
+
+		if (proposals == null) {
+			return true;
+		}
+
+		try {
+			ImportRewrite importRewrite = StubUtility.createImportRewrite(context.getCompilationUnit(), true);
+			Type importedType = importRewrite.addImport(binding, type.getAST(), new ContextSensitiveImportRewriteContext(type, importRewrite), TypeLocation.OTHER);
+			if (isQualifiedType(importedType)) {
+				return false;
+			}
+
+			ASTRewrite astRewrite = ASTRewrite.create(type.getAST());
+			astRewrite.replace(type, importedType, null);
+
+			ASTRewriteRemoveImportsCorrectionProposalCore proposal = new ASTRewriteRemoveImportsCorrectionProposalCore(CorrectionMessages.QuickAssistProcessor_add_import, context.getCompilationUnit(), astRewrite,
+					IProposalRelevance.ADD_STATIC_IMPORT);
+			proposal.setImportRewrite(importRewrite);
+			proposals.add(CodeActionHandler.wrap(proposal, CodeActionKind.Refactor));
+		} catch (IllegalArgumentException e) {
+			JavaLanguageServerPlugin.logException("Failed to get add import proposal", e);
+			return false;
+		} catch (JavaModelException e) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private static Type getQualifiedType(ASTNode node) {
+		ASTNode current = node;
+		while (current != null) {
+			if (current instanceof ParameterizedType parameterizedType && isQualifiedType(parameterizedType.getType())) {
+				return parameterizedType;
+			}
+			if (current instanceof Type type && isQualifiedType(type)) {
+				if (type.getParent() instanceof ParameterizedType parameterizedType && parameterizedType.getType() == type) {
+					return parameterizedType;
+				}
+				return type;
+			}
+			if (current instanceof Statement || current instanceof MethodDeclaration || current instanceof AbstractTypeDeclaration || current instanceof AnonymousClassDeclaration || current instanceof CompilationUnit) {
+				return null;
+			}
+			current = current.getParent();
+		}
+		return null;
+	}
+
+	private static boolean isQualifiedType(Type type) {
+		if (type instanceof SimpleType simpleType) {
+			return simpleType.getName().isQualifiedName();
+		}
+		return type instanceof QualifiedType || type instanceof NameQualifiedType;
 	}
 
 	private static boolean isDirectlyAccessible(ASTNode nameNode, ITypeBinding declaringClass) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/AddImportQuickAssistTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/AddImportQuickAssistTest.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.correction;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.ls.core.internal.CodeActionUtil;
+import org.eclipse.lsp4j.CodeActionKind;
+import org.eclipse.lsp4j.Range;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class AddImportQuickAssistTest extends AbstractQuickFixTest {
+	private IJavaProject fJProject;
+	private IPackageFragmentRoot fSourceFolder;
+
+	@BeforeEach
+	public void setup() throws Exception {
+		fJProject = newEmptyProject();
+		fJProject.setOptions(TestOptions.getDefaultOptions());
+		fSourceFolder = fJProject.getPackageFragmentRoot(fJProject.getProject().getFolder("src"));
+	}
+
+	@Test
+	public void testAddImportForQualifiedType() throws Exception {
+		IPackageFragment dependencyPack = fSourceFolder.createPackageFragment("com.example", false, null);
+		StringBuilder buf = new StringBuilder();
+		buf.append("package com.example;\n");
+		buf.append("public class Todo {\n");
+		buf.append("}\n");
+		dependencyPack.createCompilationUnit("Todo.java", buf.toString(), false, null);
+
+		IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Example {\n");
+		buf.append("    void test() {\n");
+		buf.append("        com.example.Todo todo = new Todo();\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu = pack.createCompilationUnit("Example.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("\n");
+		buf.append("import com.example.Todo;\n");
+		buf.append("\n");
+		buf.append("public class Example {\n");
+		buf.append("    void test() {\n");
+		buf.append("        Todo todo = new Todo();\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		Expected e1 = new Expected("Add import", buf.toString(), CodeActionKind.Refactor);
+
+		Range selection = CodeActionUtil.getRange(cu, "com.example.Todo");
+		assertCodeActions(cu, selection, e1);
+	}
+
+	@Test
+	public void testAddImportForParameterizedQualifiedType() throws Exception {
+		IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Example {\n");
+		buf.append("    java.util.Map<String, Integer> values;\n");
+		buf.append("}\n");
+		ICompilationUnit cu = pack.createCompilationUnit("Example.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("\n");
+		buf.append("import java.util.Map;\n");
+		buf.append("\n");
+		buf.append("public class Example {\n");
+		buf.append("    Map<String, Integer> values;\n");
+		buf.append("}\n");
+		Expected e1 = new Expected("Add import", buf.toString(), CodeActionKind.Refactor);
+
+		Range selection = CodeActionUtil.getRange(cu, "java.util.Map");
+		assertCodeActions(cu, selection, e1);
+	}
+}


### PR DESCRIPTION
Expose the existing import rewrite behavior through code actions when a qualified type reference is selected.

Fixes #3781