### PR TITLE
Quote path name in jdtls.bat script

### DIFF
--- a/org.eclipse.jdt.ls.product/scripts/jdtls.bat
+++ b/org.eclipse.jdt.ls.product/scripts/jdtls.bat
@@ -1,3 +1,3 @@
 @echo off
-python %~dp0/jdtls %*
+python "%~dp0/jdtls" %*
 pause


### PR DESCRIPTION
This allows launching jdtls using the script even if the username has a space in it.

I tested this manually on a test account I made on Windows.

Fixes #3783