### PR TITLE
Use decorator token type for annotations (#3210)

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/TokenType.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/TokenType.java
@@ -36,7 +36,7 @@ public enum TokenType {
 	KEYWORD(SemanticTokenTypes.Keyword),
 
 	// Custom token types
-	ANNOTATION("annotation"),
+	ANNOTATION("decorator"),
 	ANNOTATION_MEMBER("annotationMember"),
 	RECORD("record"),
 	RECORD_COMPONENT("recordComponent");

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/TokenType.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/TokenType.java
@@ -34,9 +34,9 @@ public enum TokenType {
 	PARAMETER(SemanticTokenTypes.Parameter),
 	MODIFIER(SemanticTokenTypes.Modifier),
 	KEYWORD(SemanticTokenTypes.Keyword),
+	ANNOTATION(SemanticTokenTypes.Decorator),
 
 	// Custom token types
-	ANNOTATION("decorator"),
 	ANNOTATION_MEMBER("annotationMember"),
 	RECORD("record"),
 	RECORD_COMPONENT("recordComponent");

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SemanticTokensHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SemanticTokensHandlerTest.java
@@ -290,7 +290,7 @@ public class SemanticTokensHandlerTest extends AbstractProjectsManagerBasedTest 
 
 	@Test
 	public void testSemanticTokens_Types() throws JavaModelException {
-		TokenAssertionHelper.beginAssertion(getURI("Types.java"), "class", "interface", "enum", "annotation", "decorator", "record", "typeParameter", "keyword", "modifier")
+		TokenAssertionHelper.beginAssertion(getURI("Types.java"), "class", "interface", "enum", "decorator", "record", "typeParameter", "keyword", "modifier")
 			.assertNextToken("public", "modifier")
 			.assertNextToken("class", "modifier")
 			.assertNextToken("Types", "class", "public", "declaration")
@@ -325,7 +325,7 @@ public class SemanticTokensHandlerTest extends AbstractProjectsManagerBasedTest 
 			.assertNextToken("interface", "modifier")
 			.assertNextToken("SomeInterface", "interface", "static", "declaration")
 			.assertNextToken("SomeEnum", "enum", "static", "readonly", "declaration")
-			.assertNextToken("SomeAnnotation", "annotation", "static", "declaration")
+				.assertNextToken("SomeAnnotation", "decorator", "static", "declaration")
 			.assertNextToken("Class", "class", "public", "readonly", "generic")
 			.assertNextToken("record", "modifier")
 			.assertNextToken("SomeRecord", "record", "static", "readonly", "declaration")

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SemanticTokensHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SemanticTokensHandlerTest.java
@@ -162,7 +162,7 @@ public class SemanticTokensHandlerTest extends AbstractProjectsManagerBasedTest 
 			.assertNextToken("Constructors", "class", "public")
 			.assertNextToken("InnerClass", "class", "protected")
 			.assertNextToken("i2", "variable", "declaration")
-			.assertNextToken("SomeAnnotation", "annotation", "public")
+				.assertNextToken("SomeAnnotation", "decorator", "public")
 			.assertNextToken("Constructors", "class", "public")
 			.assertNextToken("InnerClass", "class", "protected", "constructor")
 
@@ -290,7 +290,7 @@ public class SemanticTokensHandlerTest extends AbstractProjectsManagerBasedTest 
 
 	@Test
 	public void testSemanticTokens_Types() throws JavaModelException {
-		TokenAssertionHelper.beginAssertion(getURI("Types.java"), "class", "interface", "enum", "annotation", "record", "typeParameter", "keyword", "modifier")
+		TokenAssertionHelper.beginAssertion(getURI("Types.java"), "class", "interface", "enum", "annotation", "decorator", "record", "typeParameter", "keyword", "modifier")
 			.assertNextToken("public", "modifier")
 			.assertNextToken("class", "modifier")
 			.assertNextToken("Types", "class", "public", "declaration")
@@ -311,7 +311,7 @@ public class SemanticTokensHandlerTest extends AbstractProjectsManagerBasedTest 
 			.assertNextToken("String", "class", "public", "readonly", "typeArgument")
 			.assertNextToken("Integer", "class", "public", "readonly", "typeArgument")
 
-			.assertNextToken("SomeAnnotation", "annotation", "static")
+				.assertNextToken("SomeAnnotation", "decorator", "static")
 			.assertNextToken("Types", "class", "public")
 			.assertNextToken("class", "keyword")
 			.assertNextToken("public", "modifier")

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SemanticTokensHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SemanticTokensHandlerTest.java
@@ -375,10 +375,10 @@ public class SemanticTokensHandlerTest extends AbstractProjectsManagerBasedTest 
 
 	@Test
 	public void testSemanticTokens_Annotations() throws JavaModelException {
-		TokenAssertionHelper.beginAssertion(getURI("Annotations.java"), "annotation", "annotationMember")
-			.assertNextToken("SomeAnnotation", "annotation", "public")
-			.assertNextToken("SuppressWarnings", "annotation", "public")
-			.assertNextToken("SuppressWarnings", "annotation", "public")
+		TokenAssertionHelper.beginAssertion(getURI("Annotations.java"), "decorator", "annotationMember")
+			.assertNextToken("SomeAnnotation", "decorator", "public")
+			.assertNextToken("SuppressWarnings", "decorator", "public")
+			.assertNextToken("SuppressWarnings", "decorator", "public")
 			.assertNextToken("value", "annotationMember", "public", "abstract")
 		.endAssertion();
 	}


### PR DESCRIPTION
Replaced the semantic token type `annotation` with the standard LSP token type `decorator` for Java annotations.

Also updated semantic token tests accordingly.
