### PR TITLE
Run CodeQL on pull requests

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ on:
     branches: [ '**' ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "master" ]
+    branches: [ "main" ]
   schedule:
     - cron: '20 18 * * 2'
 


### PR DESCRIPTION
Currently, it's set up to run on pull requests to 'master', but we use 'main' as the main branch.

Fixes #3793