### PR TITLE
fix: detect build files located exactly at maxDepth

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/BasicFileDetector.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/BasicFileDetector.java
@@ -168,6 +168,21 @@ public class BasicFileDetector {
 			}
 
 			@Override
+			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+				if (monitor.isCanceled()) {
+					return TERMINATE;
+				}
+				Objects.requireNonNull(file);
+				// Directories located exactly at maxDepth are reported here instead of
+				// preVisitDirectory, because Files.walkFileTree does not open them. We still
+				// need to inspect them so that projects exactly maxDepth levels deep are detected.
+				if (attrs.isDirectory() && !isExcluded(file) && hasTargetFile(file)) {
+					directories.add(file);
+				}
+				return CONTINUE;
+			}
+
+			@Override
 			public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
 				Objects.requireNonNull(file);
 				if (exc instanceof FileSystemLoopException) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/BasicFileDetectorTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/BasicFileDetectorTest.java
@@ -183,10 +183,27 @@ public class BasicFileDetectorTest {
 		BasicFileDetector detector = new BasicFileDetector(Paths.get("projects/buildfiles/parent"), "buildfile")
 				.includeNested(false).maxDepth(2);
 		Collection<Path> dirs = detector.scan(null);
+		// maxDepth(2) finds build files up to 2 levels deep (inclusive). Directories
+		// located exactly at maxDepth are reported through visitFile, not preVisitDirectory.
+		assertEquals(3, dirs.size(), "Found " + dirs);
+		List<String> missingDirs = separatorsToSystem(list("projects/buildfiles/parent/1_1",
+				"projects/buildfiles/parent/1_0/0_2_0", "projects/buildfiles/parent/1_0/0_2_1"));
+		dirs.stream().map(Path::toString).forEach(missingDirs::remove);
+		assertEquals(0, missingDirs.size(), "Directories were not detected" + missingDirs);
+	}
+
+	@Test
+	public void testScanBuildFileAtMaxDepthBoundary() throws Exception {
+		// Regression test for https://github.com/redhat-developer/vscode-java/issues/4364:
+		// a build file located exactly at maxDepth levels deep must be detected.
+		BasicFileDetector detector = new BasicFileDetector(Paths.get("projects/buildfiles/parent"), "buildfile")
+				.includeNested(false).maxDepth(1);
+		Collection<Path> dirs = detector.scan(null);
 		assertEquals(1, dirs.size(), "Found " + dirs);
 		assertEquals(FilenameUtils.separatorsToSystem("projects/buildfiles/parent/1_1"),
 				dirs.iterator().next().toString());
 	}
+
 
     @Test
 	public void testScanSymbolicLinks() throws Exception {


### PR DESCRIPTION
## Problem

`BasicFileDetector` (used during automatic project import to discover build files such as `pom.xml`, `build.gradle`, `.project`) fails to detect project directories located *exactly* `maxDepth` levels deep.

The detector only checks for the target build file inside `preVisitDirectory`. However, `Files.walkFileTree(dir, options, maxDepth, visitor)` does **not** open directories located exactly at `maxDepth` — it reports them through `visitFile` instead. As a result, the target-file check never runs for those directories, so a project sitting exactly `maxDepth` levels deep is silently skipped.

With the default `maxDepth = 5`, this means a Maven project 5 folders deep is never imported, while the same project 4 folders deep imports fine.

Reported in redhat-developer/vscode-java#4364.

## Fix

Add a `visitFile` override that applies the same exclusion and target-file checks to directories reported at the depth boundary, so `maxDepth(N)` genuinely finds build files up to N levels deep (matching the class's documented behavior).

## Verification

Reproduced with the reporter's sample project (`1/2/3/4/test/pom.xml`): before the fix, `maxDepth=5` detects nothing; after the fix it is detected.

- Updated `testScanNestedBuildFilesDepth2` to reflect that `maxDepth(2)` now correctly includes depth-2 build files.
- Added `testScanBuildFileAtMaxDepthBoundary` as a regression test for this issue.
