### PR TITLE
Remove o.e.jdt.launching.macosx from products

### DIFF
--- a/org.eclipse.jdt.ls.product/languageServer.product
+++ b/org.eclipse.jdt.ls.product/languageServer.product
@@ -51,7 +51,6 @@
       <plugin id="org.eclipse.jdt.core"/>
 	  <plugin id="org.eclipse.jdt.core.javac"/>
       <plugin id="org.eclipse.jdt.launching"/>
-      <plugin id="org.eclipse.jdt.launching.macosx"/>
       <plugin id="org.eclipse.jdt.ls.core"/>
       <plugin id="org.eclipse.jdt.ls.filesystem"/>
       <plugin id="org.eclipse.jdt.ls.logback.appender" fragment="true"/>

--- a/org.eclipse.jdt.ls.product/syntaxServer.product
+++ b/org.eclipse.jdt.ls.product/syntaxServer.product
@@ -44,7 +44,6 @@
       <plugin id="org.eclipse.equinox.security.win32" fragment="true"/>
       <plugin id="org.eclipse.jdt.core"/>
       <plugin id="org.eclipse.jdt.launching"/>
-      <plugin id="org.eclipse.jdt.launching.macosx"/>
       <plugin id="org.eclipse.jdt.ls.core"/>
       <plugin id="org.eclipse.jdt.ls.filesystem"/>
       <plugin id="org.eclipse.osgi"/>


### PR DESCRIPTION
It's been inlined into o.e.jdt.launching (see https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/855)

Fixes the build