### PR TITLE
Fix intermittent build failure in `GradleProjectImportTest.testAndroidProjectSupportChanged`

### DIFF
--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporterTest.java
@@ -707,13 +707,24 @@ public class GradleProjectImporterTest extends AbstractGradleBasedTest{
 			this.preferences.setAndroidSupportEnabled(false);
 			for (IProject project : projects) {
 				projectsManager.updateProject(project, true);
+				waitForBackgroundJobs();
 			}
-			waitForBackgroundJobs();
 			// regardless of ANDROID_HOME, the number of cpe is 2 since android support is disabled
 			assertEquals(2, javaProject.getRawClasspath().length);
 		} finally {
 			this.preferences.setAndroidSupportEnabled(false);
 		}
+	}
+
+	@Test
+	public void testAndroidProjectSupportDisabled() throws Exception {
+		List<IProject> projects = importProjects("gradle/android");
+		assertEquals(2, projects.size());
+		IProject androidAppProject = WorkspaceHelper.getProject("app");
+		assertNotNull(androidAppProject);
+		IJavaProject javaProject = JavaCore.create(androidAppProject);
+		IClasspathEntry[] classpathEntries = javaProject.getRawClasspath();
+		assertEquals(2, classpathEntries.length);
 	}
 
 	@Test


### PR DESCRIPTION
What follows is my theory of why this works:

The failure is caused by a race condition. Two projects are refreshed, then we wait for a background build job to complete. It could detect the first project finishing the rebuild, or the second project finishing. If we detect the first one finishing rebuild instead of the second one, the classpath will be different than expected.

This race condition is addressed by refreshing the project one at a time, waiting for the build to finish for each project before moving to the next one.

Fixes #3810