### PR TITLE
Prevent setter generation for record components

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/codemanipulation/GenerateGetterSetterOperation.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/codemanipulation/GenerateGetterSetterOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2018-2021 Microsoft Corporation and others.
+* Copyright (c) 2018-2026 Microsoft Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License 2.0
 * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
 *
 * Contributors:
 *     Microsoft Corporation - initial API and implementation
+*     IBM Corporation - Generate only Getters for Records
 *******************************************************************************/
 
 package org.eclipse.jdt.ls.core.internal.codemanipulation;
@@ -87,7 +88,7 @@ public class GenerateGetterSetterOperation {
 			if (!Flags.isEnum(flags)) {
 				boolean isStatic = Flags.isStatic(flags);
 				boolean generateGetter = (GetterSetterUtil.getGetter(field) == null);
-				boolean generateSetter = (!Flags.isFinal(flags) && GetterSetterUtil.getSetter(field) == null);
+				boolean generateSetter = (!Flags.isFinal(flags) && GetterSetterUtil.getSetter(field) == null) && !type.isRecord();
 				switch (kind) {
 					case BOTH:
 						if (generateGetter || generateSetter) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/codemanipulation/GenerateGetterAndSetterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/codemanipulation/GenerateGetterAndSetterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -698,6 +698,39 @@ public class GenerateGetterAndSetterTest extends AbstractSourceTestCase {
 							"	}\r\n" +
 							"	final String field1 = null;/*|*/\r\n" +
 							"	public B() {\r\n" +
+							"	}\r\n" +
+							"}";
+			/* @formatter:on */
+
+			compareSource(expected, unit.getSource());
+		} finally {
+			preferences.setCodeGenerationInsertionLocation(oldValue);
+		}
+	}
+
+	@Test
+	public void testRecordComponentsGenerateGetterOnly() throws Exception {
+		String oldValue = preferences.getCodeGenerationInsertionLocation();
+		try {
+			//@formatter:off
+			ICompilationUnit unit = fPackageP.createCompilationUnit("R.java", "package p;\r\n" +
+				"\r\n" +
+				"public record R(String name) {\r\n" +
+				"}", true, null);
+			//@formatter:on
+			IType record = unit.getType("R");
+			runAndApplyOperation(record);
+
+			/* @formatter:off */
+			String expected ="package p;\r\n" +
+							"\r\n" +
+					        "public record R(String name) {\r\n" +
+							"\r\n" +
+							"	/**\r\n" +
+							"	 * @return Returns the name.\r\n" +
+							"	 */\r\n" +
+							"	public String name() {\r\n" +
+							"		return name;\r\n" +
 							"	}\r\n" +
 							"}";
 			/* @formatter:on */


### PR DESCRIPTION
This fix ensures that record components only generate getters while preventing setter generation, respecting their immutable nature similar to eclipse.

Before : 
<img width="1080" height="608" alt="bef" src="https://github.com/user-attachments/assets/f99c2e54-d357-4431-b994-7feb8da66280" />


After : (Shows only for getter)
<img width="414" height="316" alt="Screenshot 2026-06-18 at 4 00 43 PM" src="https://github.com/user-attachments/assets/f0667a23-5e2c-49e2-a9b6-cd56189bb9c3" />
