### PR TITLE
Do not offer override/implement actions for annotation types

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017-2022 Microsoft Corporation and others.
+* Copyright (c) 2017-2026 Microsoft Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License 2.0
 * which accompanies this distribution, and is available at
@@ -173,14 +173,18 @@ public class SourceAssistProcessor {
 		}
 
 		if (!UNSUPPORTED_RESOURCES.contains(cu.getResource().getName())) {
-			// Override/Implement Methods QuickAssist
-			if (isInTypeDeclaration) {
-				Optional<Either<Command, CodeAction>> quickAssistOverrideMethods = getOverrideMethodsAction(params, JavaCodeActionKind.QUICK_ASSIST);
-				addSourceActionCommand($, params.getContext(), quickAssistOverrideMethods);
+			try {
+				// Override/Implement Methods QuickAssist
+				if (isInTypeDeclaration) {
+					Optional<Either<Command, CodeAction>> quickAssistOverrideMethods = getOverrideMethodsAction(params, JavaCodeActionKind.QUICK_ASSIST, type);
+					addSourceActionCommand($, params.getContext(), quickAssistOverrideMethods);
+				}
+				// Override/Implement Methods Source Action
+				Optional<Either<Command, CodeAction>> sourceOverrideMethods = getOverrideMethodsAction(params, JavaCodeActionKind.SOURCE_OVERRIDE_METHODS, type);
+				addSourceActionCommand($, params.getContext(), sourceOverrideMethods);
+			} catch (JavaModelException e) {
+				JavaLanguageServerPlugin.logException("Failed to generate Override/Implement Methods source action", e);
 			}
-			// Override/Implement Methods Source Action
-			Optional<Either<Command, CodeAction>> sourceOverrideMethods = getOverrideMethodsAction(params, JavaCodeActionKind.SOURCE_OVERRIDE_METHODS);
-			addSourceActionCommand($, params.getContext(), sourceOverrideMethods);
 		}
 
 		List<String> fieldNames = CodeActionUtility.getFieldNames(coveredNodes, coveringNode);
@@ -356,8 +360,8 @@ public class SourceAssistProcessor {
 		return OrganizeImportsHandler.organizeImports(context.getCompilationUnit(), isAdvancedOrganizeImportsSupported ? OrganizeImportsHandler.getChooseImportsFunction(uri.toString(), restoreExistingImports) : null, restoreExistingImports, monitor);
 	}
 
-	private Optional<Either<Command, CodeAction>> getOverrideMethodsAction(CodeActionParams params, String kind) {
-		if (!preferenceManager.getClientPreferences().isOverrideMethodsPromptSupported()) {
+	private Optional<Either<Command, CodeAction>> getOverrideMethodsAction(CodeActionParams params, String kind, IType type) throws JavaModelException {
+		if (!preferenceManager.getClientPreferences().isOverrideMethodsPromptSupported() || type == null || type.isAnnotation()) {
 			return Optional.empty();
 		}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/OverrideMethodsActionTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/OverrideMethodsActionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Microsoft Corporation and others.
+ * Copyright (c) 2021-2026 Microsoft Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     Microsoft Corporation - initial API and implementation
+ *     IBM Corporation - Tests for Override methods in Annotations
  *******************************************************************************/
 
 package org.eclipse.jdt.ls.core.internal.handlers;
@@ -33,7 +34,6 @@ import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -79,6 +79,21 @@ public class OverrideMethodsActionTest extends AbstractCompilationUnitBasedTest 
 		codeActions = server.codeAction(params).join();
 		assertNotNull(codeActions);
 		quickAssistActions = CodeActionHandlerTest.findActions(codeActions, JavaCodeActionKind.QUICK_ASSIST);
+		assertFalse(CodeActionHandlerTest.commandExists(quickAssistActions, SourceAssistProcessor.COMMAND_ID_ACTION_OVERRIDEMETHODSPROMPT));
+	}
+
+	@Test
+	public void testOverrideMethodsForAnnotations() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
+				"\r\n" +
+				"public @interface MyAnnotation {}"
+				, true, null);
+		//@formatter:on
+		CodeActionParams params = CodeActionUtil.constructCodeActionParams(unit, "A");
+		List<Either<Command, CodeAction>> codeActions = server.codeAction(params).join();
+		assertNotNull(codeActions);
+		List<Either<Command, CodeAction>> quickAssistActions = CodeActionHandlerTest.findActions(codeActions, JavaCodeActionKind.QUICK_ASSIST);
 		assertFalse(CodeActionHandlerTest.commandExists(quickAssistActions, SourceAssistProcessor.COMMAND_ID_ACTION_OVERRIDEMETHODSPROMPT));
 	}
 }


### PR DESCRIPTION
Prevent showing "Override/Implement Methods" quick fixes for annotation types.

Before :
<img width="1080" height="608" alt="AnoBefore" src="https://github.com/user-attachments/assets/68519cf1-80c1-4cae-9da2-113cbbd97cef" />


After :

<img width="1080" height="608" alt="AfterAno" src="https://github.com/user-attachments/assets/c3b8baf1-d3f1-4675-9a2e-3a3eb4ec39b0" />
