### PR TITLE
Report syntax server test failures in GitHub Actions

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -60,6 +60,7 @@ jobs:
           -Dorg.gradle.daemon=false
           -Dorg.gradle.daemon.idletimeout=10000
           -Djdt.ls.test.delete.debug=true
+          -Dmaven.test.failure.ignore=true
           -B
           -U
           -e

--- a/scripts/PrintTestResults.java
+++ b/scripts/PrintTestResults.java
@@ -41,9 +41,28 @@ public class PrintTestResults {
 
 			Map<String, TestCase> headResult = new HashMap<>();
 
-			try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(
-					Paths.get("").resolve("org.eclipse.jdt.ls.tests").resolve("target").resolve("surefire-reports"),
-					"*.xml")) {
+			try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(Paths.get("org.eclipse.jdt.ls.tests").resolve("target").resolve("surefire-reports"), "*.xml")) {
+				dirStream.forEach(path -> {
+					try {
+						TestSuite testSuiteResult = (TestSuite) unmarshaller.unmarshal(path.toFile());
+						for (TestCase testCase : testSuiteResult.testCases) {
+							headResult.put(testCase.classname + "." + testCase.name, testCase);
+						}
+					} catch (JAXBException | ClassCastException e) {
+						error("failed when parsing XML test results: " + e.getLocalizedMessage());
+						e.printStackTrace();
+						System.exit(1);
+						return;
+					}
+				});
+			} catch (IOException e) {
+				error("failed to read test result files: " + e.getLocalizedMessage());
+				e.printStackTrace();
+				System.exit(1);
+				return;
+			}
+
+			try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(Paths.get("org.eclipse.jdt.ls.tests.syntaxserver").resolve("target").resolve("surefire-reports"), "*.xml")) {
 				dirStream.forEach(path -> {
 					try {
 						TestSuite testSuiteResult = (TestSuite) unmarshaller.unmarshal(path.toFile());


### PR DESCRIPTION
They aren't being run currently, since the build is set to abort after the regular test bundle fails and skips the syntaxserver test bundle. I also missed collecting them in the reporter script. This PR addresses both of these.