### PR TITLE
Add Javadoc quick fix support for overridden methods

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/CodeTemplatePreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/CodeTemplatePreferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Microsoft Corporation. and others.
+ * Copyright (c) 2020, 2026 Microsoft Corporation. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     Microsoft Corporation - initial API and implementation
+ *     IBM Corporation - Pattern for overriden methods
  *******************************************************************************/
 
 package org.eclipse.jdt.ls.core.internal.preferences;
@@ -138,7 +139,7 @@ public class CodeTemplatePreferences {
 	/**
 	 * Default value for override comments
 	 */
-	public static final String CODETEMPLATE_OVERRIDECOMMENT_DEFAULT = "";
+	public static final String CODETEMPLATE_OVERRIDECOMMENT_DEFAULT = "/** (non-Javadoc)\n" + " * ${see_to_overridden}\n" + " */";
 
 	/**
 	 * Default value for method comments

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/JavadocQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/JavadocQuickFixTest.java
@@ -1138,4 +1138,73 @@ public class JavadocQuickFixTest extends AbstractQuickFixTest {
 		assertCodeActions(cu, e1);
 	}
 
+	@Test
+	public void testAddJavadocForOverriddenMethod() throws Exception {
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("/**\n");
+		buf.append(" */\n");
+		buf.append("public class E {\n");
+		buf.append("    @Override\n");
+		buf.append("    public String toString() {\n");
+		buf.append("        return \"E []\";\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("/**\n");
+		buf.append(" */\n");
+		buf.append("public class E {\n");
+		buf.append("    /** (non-Javadoc)\n");
+		buf.append("     * @see java.lang.Object#toString()\n");
+		buf.append("     */\n");
+		buf.append("    @Override\n");
+		buf.append("    public String toString() {\n");
+		buf.append("        return \"E []\";\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		Expected e1 = new Expected("Add Javadoc comment", buf.toString());
+		assertCodeActions(cu, e1);
+	}
+
+	@Test
+	public void testAddJavadocForOverriddenMethodInRecord() throws Exception {
+		Map<String, String> options17 = new HashMap<>(fJProject1.getOptions(false));
+		JavaModelUtil.setComplianceOptions(options17, JavaCore.VERSION_17);
+		fJProject1.setOptions(options17);
+
+	    IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+	    StringBuilder buf = new StringBuilder();
+	    buf.append("package test1;\n");
+	    buf.append("/**\n");
+	    buf.append(" */\n");
+	    buf.append("public record Person(String name, int age) {\n");
+	    buf.append("    @Override\n");
+	    buf.append("    public String toString() {\n");
+	    buf.append("        return name + \" (\" + age + \")\";\n");
+	    buf.append("    }\n");
+	    buf.append("}\n");
+	    ICompilationUnit cu = pack1.createCompilationUnit("Person.java", buf.toString(), false, null);
+
+	    buf = new StringBuilder();
+	    buf.append("package test1;\n");
+	    buf.append("/**\n");
+	    buf.append(" */\n");
+	    buf.append("public record Person(String name, int age) {\n");
+	    buf.append("    /** (non-Javadoc)\n");
+		buf.append("     * @see java.lang.Record#toString()\n");
+	    buf.append("     */\n");
+	    buf.append("    @Override\n");
+	    buf.append("    public String toString() {\n");
+	    buf.append("        return name + \" (\" + age + \")\";\n");
+	    buf.append("    }\n");
+	    buf.append("}\n");
+	    Expected e1 = new Expected("Add Javadoc comment", buf.toString());
+	    assertCodeActions(cu, e1);
+	}
+
+
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/LocalCorrectionQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/LocalCorrectionQuickFixTest.java
@@ -3775,11 +3775,17 @@ public class LocalCorrectionQuickFixTest extends AbstractQuickFixTest {
 					String x;
 					int y;
 
+					/** (non-Javadoc)
+					 * @see java.lang.Object#hashCode()
+					 */
 					@Override
 					public int hashCode() {
 						return Objects.hash(x);
 					}
 
+					/** (non-Javadoc)
+					 * @see java.lang.Object#equals(java.lang.Object)
+					 */
 					@Override
 					public boolean equals(Object obj) {
 						if (this == obj) {
@@ -3797,6 +3803,7 @@ public class LocalCorrectionQuickFixTest extends AbstractQuickFixTest {
 					}
 				}
 				""";
+
 
 		String after2 = """
 				package test1;
@@ -3862,11 +3869,17 @@ public class LocalCorrectionQuickFixTest extends AbstractQuickFixTest {
 					String x;
 					int y;
 
+					/** (non-Javadoc)
+					 * @see java.lang.Object#hashCode()
+					 */
 					@Override
 					public int hashCode() {
 						return Objects.hash(x, Integer.valueOf(y));
 					}
 
+					/** (non-Javadoc)
+					 * @see java.lang.Object#equals(java.lang.Object)
+					 */
 					@Override
 					public boolean equals(Object obj) {
 						if (this == obj) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionResolveHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionResolveHandlerTest.java
@@ -355,11 +355,15 @@ public class CodeActionResolveHandlerTest extends AbstractCompilationUnitBasedTe
 		buf.append("    private void hello() {\n");
 		buf.append("    }\n");
 		buf.append("\n");
+		buf.append("    /** (non-Javadoc)\n");
+		buf.append("     * @see java.lang.Object#toString()\n");
+		buf.append("     */\n");
 		buf.append("    @Override\n");
 		buf.append("    public String toString() {\n");
 		buf.append("        return \"E []\";\n");
 		buf.append("    }\n");
 		buf.append("}\n");
+
 		assertEquals(buf.toString(), actual);
 	}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateToStringHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateToStringHandlerTest.java
@@ -231,6 +231,9 @@ public class GenerateToStringHandlerTest extends AbstractSourceTestCase {
 				+ "	int id;\r\n"
 				+ "	List<String> aList;\r\n"
 				+ "	String[] arrays;\r\n"
+				+ "	/** (non-Javadoc)\r\n"
+				+ "	 * @see java.lang.Object#toString()\r\n"
+				+ "	 */\r\n"
 				+ "	@Override\r\n"
 				+ "	public String toString() {\r\n"
 				+ "		final int maxLen = 10;\r\n"
@@ -257,6 +260,7 @@ public class GenerateToStringHandlerTest extends AbstractSourceTestCase {
 				+ "		return builder.toString();\r\n"
 				+ "	}\r\n"
 				+ "}";
+
 		/* @formatter:on */
 
 		compareSource(expected, unit.getSource());

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HashCodeEqualsHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HashCodeEqualsHandlerTest.java
@@ -418,6 +418,9 @@ public class HashCodeEqualsHandlerTest extends AbstractSourceTestCase {
 				"	double rate;\r\n" +
 				"	Cloneable[] anArray;\r\n" +
 				"	List<String> aList;\r\n" +
+				"	/** (non-Javadoc)\r\n" +
+				"	 * @see java.lang.Object#hashCode()\r\n" +
+				"	 */\r\n" +
 				"	@Override\r\n" +
 				"	public int hashCode() {\r\n" +
 				"		final int prime = 31;\r\n" +
@@ -431,6 +434,9 @@ public class HashCodeEqualsHandlerTest extends AbstractSourceTestCase {
 				"		result = prime * result + ((aList == null) ? 0 : aList.hashCode());\r\n" +
 				"		return result;\r\n" +
 				"	}\r\n" +
+				"	/** (non-Javadoc)\r\n" +
+				"	 * @see java.lang.Object#equals(java.lang.Object)\r\n" +
+				"	 */\r\n" +
 				"	@Override\r\n" +
 				"	public boolean equals(Object obj) {\r\n" +
 				"		if (this == obj)\r\n" +
@@ -459,6 +465,7 @@ public class HashCodeEqualsHandlerTest extends AbstractSourceTestCase {
 				"		return true;\r\n" +
 				"	}\r\n" +
 				"}";
+
 		/* @formatter:on */
 
 		compareSource(expected, unit.getSource());


### PR DESCRIPTION
Enable the "`Add Javadoc comment`" quick fix for methods that override parent methods. The generated Javadoc includes (non-Javadoc) marker and @see reference to the parent method.

<img width="1080" height="608" alt="OverMe" src="https://github.com/user-attachments/assets/2827b5d6-e06e-4d23-a91a-b26bd7aef3a5" />
