### PR TITLE
Add Rename Quick Fix for Lambda Redeclarations

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
@@ -433,6 +433,8 @@ public class QuickFixProcessor {
 			case IProblem.DuplicateMethod:
 			case IProblem.DuplicateTypeVariable:
 			case IProblem.DuplicateNestedType:
+			case IProblem.LambdaRedeclaresLocal:
+			case IProblem.LambdaRedeclaresArgument:
 				LocalCorrectionsSubProcessor.addInvalidVariableNameProposals(context, problem, proposals);
 				break;
 			case IProblem.NoMessageSendOnArrayType:

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/LocalCorrectionQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/LocalCorrectionQuickFixTest.java
@@ -3927,4 +3927,85 @@ public class LocalCorrectionQuickFixTest extends AbstractQuickFixTest {
 		assertCodeActions(cu, e1, e2);
 	}
 
+	@Test
+	public void testLambdaRedeclares1() throws Exception {
+		Map<String, String> options = fJProject1.getOptions(true);
+		options.put(JavaCore.COMPILER_PB_LOCAL_VARIABLE_HIDING, JavaCore.ERROR);
+		fJProject1.setOptions(options);
+
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		String source = """
+				package test1;
+				import java.util.function.Consumer;
+
+				public class E {
+				    public void foo() {
+				        int count = 0;
+				        Consumer<Integer> consumer = count -> {
+				            System.out.println(count);
+				        };
+				    }
+				}
+				""";
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E1.java", source, false, null);
+
+		String expected = """
+				package test1;
+				import java.util.function.Consumer;
+
+				public class E {
+				    public void foo() {
+				        int count = 0;
+				        Consumer<Integer> consumer = count1 -> {
+				            System.out.println(count1);
+				        };
+				    }
+				}
+				""";
+
+		Expected e1 = new Expected("Rename 'count'", expected);
+
+		assertCodeActions(cu, e1);
+	}
+
+	@Test
+	public void testLambdaRedeclares2() throws Exception {
+		Map<String, String> options = fJProject1.getOptions(true);
+		options.put(JavaCore.COMPILER_PB_LOCAL_VARIABLE_HIDING, JavaCore.ERROR);
+		fJProject1.setOptions(options);
+
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		String source = """
+				package test1;
+				class HidingExample {
+				    public void process() {
+				        int offset = 10;
+				        Runnable task = () -> {
+				            int offset = 20;
+				        };
+				    }
+				}
+				""";
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E1.java", source, false, null);
+
+		String expected = """
+				package test1;
+				class HidingExample {
+				    public void process() {
+				        int offset = 10;
+				        Runnable task = () -> {
+				            int offset1 = 20;
+				        };
+				    }
+				}
+				""";
+
+		Expected e1 = new Expected("Rename 'offset'", expected);
+
+		assertCodeActions(cu, e1);
+	}
 }


### PR DESCRIPTION
Added handling for IProblem.LambdaRedeclaresLocal and IProblem.LambdaRedeclaresArgument in QuickFixProcessor to show rename suggestions when lambda parameters conflict with local variables or method arguments.

<img width="1080" height="608" alt="lambdaQuick" src="https://github.com/user-attachments/assets/f7c9032f-c3dd-40e5-95af-c51be664f288" />
