### PR TITLE
Fix #3881: support reference CodeLens for fields

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeLensHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeLensHandler.java
@@ -219,6 +219,8 @@ public class CodeLensHandler {
 				if (parentType != null && !JDTUtils.isUnnamedClass(parentType) && overlaps(((ISourceReference) parentType).getNameRange(), ((ISourceReference) element).getNameRange())) {
 					continue;
 				}
+			} else if (element.getElementType() == IJavaElement.FIELD && preferenceManager.getPreferences().isReferencesCodeLensIncludeFields()) {
+				// allow field reference CodeLens
 			} else {//neither a type nor a method, we bail
 				continue;
 			}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeLensPreferenceChangeListener.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeLensPreferenceChangeListener.java
@@ -24,6 +24,7 @@ public class CodeLensPreferenceChangeListener implements IPreferencesChangeListe
 	@Override
 	public void preferencesChange(Preferences oldPreferences, Preferences newPreferences) {
 		if (oldPreferences.isReferencesCodeLensEnabled() != newPreferences.isReferencesCodeLensEnabled()
+				|| oldPreferences.isReferencesCodeLensIncludeFields() != newPreferences.isReferencesCodeLensIncludeFields()
 				|| !Objects.equals(oldPreferences.getImplementationsCodeLens(), newPreferences.getImplementationsCodeLens())) {
 			refresh();
 		}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -243,6 +243,10 @@ public class Preferences {
 	public static final String IMPLEMENTATIONS_CODE_LENS_KEY = "java.implementationCodeLens";
 
 	/**
+	 * Preference key to enable/disable reference code lenses for fields.
+	 */
+	public static final String REFERENCES_CODE_LENS_INCLUDE_FIELDS_KEY = "java.referencesCodeLens.includeFields";
+	/**
 	 * Preference key to enable/disable formatter.
 	 */
 	public static final String JAVA_FORMAT_ENABLED_KEY = "java.format.enabled";
@@ -750,6 +754,7 @@ public class Preferences {
 	private List<String> diagnosticFilter;
 	private SearchScope searchScope;
 	private boolean inlayHintsSuppressedWhenSameNameNumberedParameter;
+	private boolean referencesCodeLensIncludeFields;
 
 	static {
 		JAVA_IMPORT_EXCLUSIONS_DEFAULT = new LinkedList<>();
@@ -940,6 +945,7 @@ public class Preferences {
 		eclipseDownloadSources = false;
 		mavenUpdateSnapshots = false;
 		referencesCodeLensEnabled = true;
+		referencesCodeLensIncludeFields = false;
 		implementationsCodeLens = "none";
 		javaFormatEnabled = true;
 		javaQuickFixShowAt = LINE;
@@ -1182,6 +1188,7 @@ public class Preferences {
 		prefs.validateAllOpenBuffersOnChanges = this.validateAllOpenBuffersOnChanges;
 		prefs.chainCompletionEnabled = this.chainCompletionEnabled;
 		prefs.searchScope = this.searchScope;
+		prefs.referencesCodeLensIncludeFields = this.referencesCodeLensIncludeFields;
 
 		// Deep copy collections
 		prefs.gradleArguments = this.gradleArguments != null ? new ArrayList<>(this.gradleArguments) : null;
@@ -1350,6 +1357,11 @@ public class Preferences {
 		if (containsKey(configuration, REFERENCES_CODE_LENS_ENABLED_KEY)) {
 			boolean referenceCodelensEnabled = getBoolean(configuration, REFERENCES_CODE_LENS_ENABLED_KEY, existing.referencesCodeLensEnabled);
 			prefs.setReferencesCodelensEnabled(referenceCodelensEnabled);
+		}
+
+		if (containsKey(configuration, REFERENCES_CODE_LENS_INCLUDE_FIELDS_KEY)) {
+			boolean referenceCodelensIncludeFields = getBoolean(configuration, REFERENCES_CODE_LENS_INCLUDE_FIELDS_KEY, existing.referencesCodeLensIncludeFields);
+			prefs.setReferencesCodeLensIncludeFields(referenceCodelensIncludeFields);
 		}
 
 		if (containsKey(configuration, IMPLEMENTATIONS_CODE_LENS_KEY)) {
@@ -2068,6 +2080,11 @@ public class Preferences {
 		return this;
 	}
 
+	private Preferences setReferencesCodeLensIncludeFields(boolean enabled) {
+		this.referencesCodeLensIncludeFields = enabled;
+		return this;
+	}
+
 	public Preferences setImportGradleEnabled(boolean enabled) {
 		this.importGradleEnabled = enabled;
 		return this;
@@ -2419,6 +2436,10 @@ public class Preferences {
 
 	public boolean isReferencesCodeLensEnabled() {
 		return referencesCodeLensEnabled;
+	}
+
+	public boolean isReferencesCodeLensIncludeFields() {
+		return referencesCodeLensIncludeFields;
 	}
 
 	public boolean isImportGradleEnabled() {

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/java/FooWithField.java
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/java/FooWithField.java
@@ -1,0 +1,6 @@
+package java;
+
+public class FooWithField {
+	
+	private String name;
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeLensHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeLensHandlerTest.java
@@ -161,6 +161,29 @@ public class CodeLensHandlerTest extends AbstractProjectsManagerBasedTest {
 	}
 
 	@Test
+	public void testGetCodeLensSymbolsIncludeFields() throws Exception {
+		Preferences preferences = Preferences.createFrom(Collections.singletonMap(Preferences.REFERENCES_CODE_LENS_INCLUDE_FIELDS_KEY, "true"));
+		Mockito.reset(preferenceManager);
+		when(preferenceManager.getPreferences()).thenReturn(preferences);
+		handler = new CodeLensHandler(preferenceManager);
+
+		String payload = createCodeLensSymbolsRequest("src/java/FooWithField.java");
+		CodeLensParams codeLensParams = getParams(payload);
+		String uri = codeLensParams.getTextDocument().getUri();
+		assertFalse(uri.isEmpty());
+
+		List<CodeLens> result = handler.getCodeLensSymbols(uri, monitor);
+
+		assertEquals(2, result.size(), "Found " + result);
+
+		CodeLens cl = result.get(0);
+		assertRange(4, 16, 20, cl.getRange());
+
+		cl = result.get(1);
+		assertRange(2, 13, 25, cl.getRange());
+	}
+
+	@Test
 	@SuppressWarnings("unchecked")
 	public void testGetCodeLensSymbolsForClass() throws Exception {
 		Preferences implementationsCodeLenses = Preferences.createFrom(Collections.singletonMap(Preferences.IMPLEMENTATIONS_CODE_LENS_KEY, "types"));


### PR DESCRIPTION
This change adds an optional java.referencesCodeLens.includeFields setting (default false) to enable reference CodeLens for fields. When enabled, fields show reference CodeLens alongside the existing type and method CodeLens. The change also refreshes CodeLens when the setting changes and includes tests covering the new behavior.

Fixes https://github.com/redhat-developer/vscode-java/issues/3881