### PR TITLE
Reconcile stale auto-enabled preview features for invisible projects

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JVMConfigurator.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JVMConfigurator.java
@@ -348,4 +348,45 @@ public class JVMConfigurator implements IVMInstallChangedListener {
 		}
 	}
 
+	/**
+	 * Reset preview feature options that jdt.ls auto-enabled for an invisible project but that became
+	 * invalid after the bundled compiler advanced to a newer Java release (preview enabled at a
+	 * non-latest compliance fails the whole build). Only options that look auto-enabled by jdt.ls
+	 * (enabled, with the preview-report severity set to {@code ignore}) on a project whose compliance
+	 * is below {@link JavaCore#latestSupportedJavaVersion()} are reset; deliberate user settings,
+	 * managed projects, projects with a linked (user-owned) settings folder and projects on the
+	 * latest JDK are left untouched.
+	 *
+	 * @param javaProject the unmanaged project to reconcile.
+	 * @return {@code true} if the preview options were reset.
+	 */
+	public static boolean reconcilePreviewFeatureSettings(IJavaProject javaProject) {
+		if (javaProject == null || !ProjectUtils.isUnmanagedFolder(javaProject.getProject())) {
+			return false;
+		}
+		// A linked settings folder holds user-owned prefs on disk that jdt.ls never auto-enabled;
+		// don't reconcile (and don't write back into) those, mirroring configureJVMSettings.
+		if (ProjectUtils.isSettingsFolderLinked(javaProject.getProject())) {
+			return false;
+		}
+		if (!JavaCore.ENABLED.equals(javaProject.getOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, true))) {
+			return false;
+		}
+		// Only reconcile settings that were auto-enabled (and silenced) by jdt.ls, not ones a user set on purpose.
+		if (!JavaCore.IGNORE.equals(javaProject.getOption(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES, true))) {
+			return false;
+		}
+		String compliance = javaProject.getOption(JavaCore.COMPILER_COMPLIANCE, true);
+		if (compliance == null || JavaCore.compareJavaVersions(compliance, JavaCore.latestSupportedJavaVersion()) >= 0) {
+			// The project is still on the latest supported version, enabling preview is valid.
+			return false;
+		}
+		Hashtable<String, String> defaultOptions = JavaCore.getDefaultOptions();
+		javaProject.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, defaultOptions.get(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES));
+		javaProject.setOption(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES, defaultOptions.get(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES));
+		JavaLanguageServerPlugin.logInfo("Reset stale preview feature settings for project " + javaProject.getProject().getName()
+				+ " (compliance " + compliance + " is below the latest supported Java version " + JavaCore.latestSupportedJavaVersion() + ").");
+		return true;
+	}
+
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporter.java
@@ -62,6 +62,7 @@ import org.eclipse.jdt.ls.core.internal.AbstractProjectImporter;
 import org.eclipse.jdt.ls.core.internal.IConstants;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.JVMConfigurator;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.ResourceUtils;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
@@ -156,6 +157,10 @@ public class InvisibleProjectImporter extends AbstractProjectImporter {
 		}
 
 		IJavaProject javaProject = JavaCore.create(invisibleProject);
+
+		// Reset stale preview feature settings that would otherwise break the build after the bundled
+		// compiler advances to a newer Java release. See https://github.com/redhat-developer/vscode-java/issues/4420
+		JVMConfigurator.reconcilePreviewFeatureSettings(javaProject);
 
 		IFolder workspaceLinkFolder = invisibleProject.getFolder(ProjectUtils.WORKSPACE_LINK);
 		PreferenceManager preferencesManager = JavaLanguageServerPlugin.getPreferencesManager();

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporterTest.java
@@ -47,6 +47,7 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.ls.core.internal.JavaProjectHelper;
+import org.eclipse.jdt.ls.core.internal.JVMConfigurator;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.ResourceUtils;
 import org.eclipse.jdt.ls.core.internal.TestVMType;
@@ -231,6 +232,57 @@ public class InvisibleProjectImporterTest extends AbstractInvisibleProjectBasedT
 		} finally {
 			TestVMType.setTestJREAsDefault(defaultJVM);
 		}
+	}
+
+	@Test
+	public void testStalePreviewFeaturesAreReset() throws Exception {
+		// Use a fixture without a .settings folder so it isn't linked: jdt.ls only auto-enables preview
+		// (the state this reconciles) when the settings folder is not linked.
+		IProject invisibleProject = copyAndImportFolder("singlefile/java14", "foo/bar/Foo.java");
+		assertTrue(invisibleProject.exists());
+		IJavaProject javaProject = JavaCore.create(invisibleProject);
+		// Simulate the state left behind after the bundled compiler advanced to a newer "latest":
+		// preview was auto-enabled (and silenced) by jdt.ls at a compliance that is no longer the latest.
+		String olderThanLatest = JavaCore.getAllVersions().get(JavaCore.getAllVersions().size() - 2);
+		javaProject.setOption(JavaCore.COMPILER_COMPLIANCE, olderThanLatest);
+		javaProject.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+		javaProject.setOption(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES, JavaCore.IGNORE);
+
+		assertTrue(JVMConfigurator.reconcilePreviewFeatureSettings(javaProject));
+
+		assertEquals(JavaCore.DISABLED, javaProject.getOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, true));
+		assertEquals(JavaCore.getDefaultOptions().get(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES),
+				javaProject.getOption(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES, true));
+	}
+
+	@Test
+	public void testPreviewFeaturesKeptWhenOnLatestJDK() throws Exception {
+		IProject invisibleProject = copyAndImportFolder("singlefile/java14", "foo/bar/Foo.java");
+		assertTrue(invisibleProject.exists());
+		IJavaProject javaProject = JavaCore.create(invisibleProject);
+		javaProject.setOption(JavaCore.COMPILER_COMPLIANCE, JavaCore.latestSupportedJavaVersion());
+		javaProject.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+		javaProject.setOption(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES, JavaCore.IGNORE);
+
+		assertFalse(JVMConfigurator.reconcilePreviewFeatureSettings(javaProject));
+
+		assertEquals(JavaCore.ENABLED, javaProject.getOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, true));
+	}
+
+	@Test
+	public void testExplicitPreviewFeaturesNotReset() throws Exception {
+		IProject invisibleProject = copyAndImportFolder("singlefile/java14", "foo/bar/Foo.java");
+		assertTrue(invisibleProject.exists());
+		IJavaProject javaProject = JavaCore.create(invisibleProject);
+		String olderThanLatest = JavaCore.getAllVersions().get(JavaCore.getAllVersions().size() - 2);
+		javaProject.setOption(JavaCore.COMPILER_COMPLIANCE, olderThanLatest);
+		javaProject.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+		// A deliberate user setting keeps the default report severity (warning), not ignore.
+		javaProject.setOption(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES, JavaCore.WARNING);
+
+		assertFalse(JVMConfigurator.reconcilePreviewFeatureSettings(javaProject));
+
+		assertEquals(JavaCore.ENABLED, javaProject.getOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, true));
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #3832

jdt.ls auto-enables preview features (and sets the preview-report severity to `ignore`) for an invisible project when its Java version equals `latestSupportedJavaVersion()`, and persists that. After a compiler bump the "latest" moves forward, so the project ends up with preview enabled at a non-latest compliance and the build fails with `Preview features enabled at an invalid source release level`. `configureJVMSettings` isn't re-run for an existing invisible project on reload, so it never self-heals — only renaming the folder (a fresh import) works around it.

This adds `JVMConfigurator.reconcilePreviewFeatureSettings`, called from `InvisibleProjectImporter`, which resets the preview options to their defaults only when:

- the project is an unmanaged folder,
- the options look auto-enabled by jdt.ls (`enablePreview=enabled` **and** report severity `ignore`),
- and the compliance is below `latestSupportedJavaVersion()`.

Managed projects (Maven/Gradle), deliberate user settings (which keep the default `warning` severity) and projects legitimately on the latest JDK are left untouched. This complements #3131/#3137, which only notifies the client but doesn't reconcile the value jdt.ls set itself.

Downstream report: redhat-developer/vscode-java#4420.

Tests: added coverage in `InvisibleProjectImporterTest` for reset when below latest, kept when on the latest JDK, and not reset when the user set preview explicitly.
