### PR TITLE
perf: batch DigestStore serialization during Maven/Gradle project import

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/DigestStore.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/DigestStore.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -63,19 +64,40 @@ public class DigestStore {
 	 *             if a digest cannot be computed
 	 */
 	public boolean updateDigest(Path p) throws CoreException {
+		return updateDigests(Arrays.asList(p));
+	}
+
+	/**
+	 * Updates the digests for the given paths.
+	 *
+	 * @param paths
+	 *            Paths to the files in question
+	 * @return whether at least one file is considered changed and the associated
+	 *         project should be updated
+	 * @throws CoreException
+	 *             if a digest cannot be computed
+	 */
+	public boolean updateDigests(Collection<Path> paths) throws CoreException {
 		try {
-			String digest = computeDigest(p);
+			Map<String, String> digests = new HashMap<>();
+			for (Path path : paths) {
+				digests.put(path.toString(), computeDigest(path));
+			}
 			synchronized (fileDigests) {
-				if (!digest.equals(fileDigests.get(p.toString()))) {
-					fileDigests.put(p.toString(), digest);
-					serializeFileDigests();
-					return true;
-				} else {
-					return false;
+				boolean changed = false;
+				for (Map.Entry<String, String> entry : digests.entrySet()) {
+					if (!entry.getValue().equals(fileDigests.get(entry.getKey()))) {
+						fileDigests.put(entry.getKey(), entry.getValue());
+						changed = true;
+					}
 				}
+				if (changed) {
+					serializeFileDigests();
+				}
+				return changed;
 			}
 		} catch (NoSuchAlgorithmException | IOException e) {
-			throw new CoreException(StatusFactory.newErrorStatus("Exception updating digest for " + p, e));
+			throw new CoreException(StatusFactory.newErrorStatus("Exception updating digest for " + paths, e));
 		}
 
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
@@ -246,26 +246,30 @@ public class GradleProjectImporter extends AbstractProjectImporter {
 			checkWrapperChecksum(directory);
 		}
 		// store the digest for the imported gradle projects.
+		List<Path> digestPaths = new ArrayList<>();
 		ProjectUtils.getGradleProjects().forEach(project -> {
 			File buildFile = project.getFile(BUILD_GRADLE_DESCRIPTOR).getLocation().toFile();
 			File settingsFile = project.getFile(SETTINGS_GRADLE_DESCRIPTOR).getLocation().toFile();
 			File buildKtsFile = project.getFile(BUILD_GRADLE_KTS_DESCRIPTOR).getLocation().toFile();
 			File settingsKtsFile = project.getFile(SETTINGS_GRADLE_KTS_DESCRIPTOR).getLocation().toFile();
+			if (buildFile.exists()) {
+				digestPaths.add(buildFile.toPath());
+			} else if (buildKtsFile.exists()) {
+				digestPaths.add(buildKtsFile.toPath());
+			}
+			if (settingsFile.exists()) {
+				digestPaths.add(settingsFile.toPath());
+			} else if (settingsKtsFile.exists()) {
+				digestPaths.add(settingsKtsFile.toPath());
+			}
+		});
+		if (!digestPaths.isEmpty()) {
 			try {
-				if (buildFile.exists()) {
-					JavaLanguageServerPlugin.getDigestStore().updateDigest(buildFile.toPath());
-				} else if (buildKtsFile.exists()) {
-					JavaLanguageServerPlugin.getDigestStore().updateDigest(buildKtsFile.toPath());
-				}
-				if (settingsFile.exists()) {
-					JavaLanguageServerPlugin.getDigestStore().updateDigest(settingsFile.toPath());
-				} else if (settingsKtsFile.exists()) {
-					JavaLanguageServerPlugin.getDigestStore().updateDigest(settingsKtsFile.toPath());
-				}
+				JavaLanguageServerPlugin.getDigestStore().updateDigests(digestPaths);
 			} catch (CoreException e) {
 				JavaLanguageServerPlugin.logException("Failed to update digest for gradle build file", e);
 			}
-		});
+		}
 		for (IProject gradleProject : ProjectUtils.getGradleProjects()) {
 			gradleProject.deleteMarkers(COMPATIBILITY_MARKER_ID, true, IResource.DEPTH_ZERO);
 			gradleProject.deleteMarkers(GRADLE_UPGRADE_WRAPPER_MARKER_ID, true, IResource.DEPTH_INFINITE);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporter.java
@@ -171,6 +171,7 @@ public class MavenProjectImporter extends AbstractProjectImporter {
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
 		Collection<IProject> projects = new LinkedHashSet<>();
 		Collection<MavenProjectInfo> toImport = new LinkedHashSet<>();
+		Collection<java.nio.file.Path> toUpdateDigest = new LinkedHashSet<>();
 		long lastWorkspaceStateSaved = getLastWorkspaceStateModified();
 		Set<String> artifactIds = new LinkedHashSet<>();
 		//Separate existing projects from new ones
@@ -188,7 +189,7 @@ public class MavenProjectImporter extends AbstractProjectImporter {
 				}
 			}
 			if (container == null) {
-				digestStore.updateDigest(pom.toPath());
+				toUpdateDigest.add(pom.toPath());
 				toImport.add(projectInfo);
 				artifactIds.add(projectInfo.getModel().getArtifactId());
 			} else {
@@ -198,7 +199,7 @@ public class MavenProjectImporter extends AbstractProjectImporter {
 					projects.add(container.getProject());
 				} else if (project != null) {
 					//Project doesn't have the Maven nature, so we (re)import it
-					digestStore.updateDigest(pom.toPath());
+					toUpdateDigest.add(pom.toPath());
 					// need to delete project due to m2e failing to create if linked and not the same name
 					project.delete(IProject.FORCE | IProject.NEVER_DELETE_PROJECT_CONTENT, subMonitor.split(5));
 					toImport.add(projectInfo);
@@ -206,6 +207,9 @@ public class MavenProjectImporter extends AbstractProjectImporter {
 				}
 			}
 
+		}
+		if (!toUpdateDigest.isEmpty()) {
+			digestStore.updateDigests(toUpdateDigest);
 		}
 		if (!toImport.isEmpty()) {
 			ProjectImportConfiguration importConfig = new ProjectImportConfiguration();

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporterTest.java
@@ -175,6 +175,29 @@ public class MavenProjectImporterTest extends AbstractMavenBasedTest {
 	}
 
 	@Test
+	public void testDigestStoreBatchUpdate() throws Exception {
+		Path stateLocation = Files.createTempDirectory("digest-store-test");
+		try {
+			Path first = stateLocation.resolve("first-pom.xml");
+			Path second = stateLocation.resolve("second-pom.xml");
+			Files.write(first, List.of("first"));
+			Files.write(second, List.of("second"));
+
+			DigestStore digestStore = new DigestStore(stateLocation.toFile());
+			assertTrue(digestStore.updateDigests(List.of(first, second)));
+			assertFalse(digestStore.updateDigests(List.of(first, second)));
+
+			DigestStore persistedDigestStore = new DigestStore(stateLocation.toFile());
+			assertFalse(persistedDigestStore.updateDigests(List.of(first, second)));
+
+			Files.write(first, List.of("changed"));
+			assertTrue(persistedDigestStore.updateDigests(List.of(first, second)));
+		} finally {
+			FileUtils.deleteDirectory(stateLocation.toFile());
+		}
+	}
+
+	@Test
 	public void testPreexistingIProjectDifferentName() throws Exception {
 		File from = new File(getSourceProjectDirectory(), "maven/salut");
 		Path projectDir = Files.createTempDirectory("testImportDifferentName");


### PR DESCRIPTION
#### Summary

During project import, `DigestStore.updateDigest(Path)` was called once per build file, and each call that detected a change serialized the **entire** digest map to disk via `ObjectOutputStream`. For a workspace with N modules this produced O(N) full-map serializations during a single import (and O(N²) cumulative bytes written as the map grows), all on the import thread.

This change adds a batched API and uses it in the import paths so the digest map is serialized **at most once** per import, instead of once per changed build file.

#### Changes

- **`DigestStore`**: add `updateDigests(Collection<Path>)`, which computes all requested digests, applies changes under the existing `synchronized` block, and serializes the map only once if anything changed. `updateDigest(Path)` now delegates to it, so existing per-file callers keep identical behavior (including the boolean "changed" return).
- **`MavenProjectImporter`**: collect the POM paths of new/re-imported projects during classification and flush them with a single `updateDigests(...)` call after the loop, instead of calling `updateDigest(...)` per project.
- **`GradleProjectImporter`**: collect the `build.gradle(.kts)` / `settings.gradle(.kts)` paths across all imported Gradle projects and seed them with a single `updateDigests(...)` call.

The build-support / file-change paths (`MavenBuildSupport`, `GradleBuildSupport`, `StandardProjectsManager`) intentionally keep using the per-file `updateDigest(Path)` boolean gate — their behavior is unchanged.

#### Testing

- Added `MavenProjectImporterTest.testDigestStoreBatchUpdate` covering batch update, no-op when unchanged, persistence across a new `DigestStore` instance, and change detection after a file edit.
- `./mvnw verify` for `org.eclipse.jdt.ls.tests` (`MavenProjectImporterTest`: 35 tests, 0 failures).
- Manual end-to-end: built a local server, packaged the VS Code extension, and imported real Maven and Gradle projects — both imported and built with no errors, and `.file-digests` contained the expected build-file entries.