### PR TITLE
Fix stray bin folder race on deleted .classpath (partial fix for flaky MavenProjectMetadataFileTest)

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectsManager.java
@@ -243,7 +243,7 @@ public class StandardProjectsManager extends ProjectsManager {
 		if (configureNeeded) {
 			configureSettings(preferenceManager.getPreferences());
 		}
-		IResource resource = JDTUtils.getFileOrFolder(uriString);
+		IResource resource = getResourceForChange(uriString, changeType);
 		if (resource == null) {
 			return;
 		}
@@ -309,6 +309,37 @@ public class StandardProjectsManager extends ProjectsManager {
 		} catch (CoreException e) {
 			JavaLanguageServerPlugin.logException("Problem refreshing workspace", e);
 		}
+	}
+
+	/**
+	 * Resolves the {@link IResource} for the given change notification.
+	 *
+	 * For most changes we delegate to {@link JDTUtils#getFileOrFolder(String)},
+	 * which eagerly calls {@code IContainer#refreshLocal(DEPTH_ONE, null)} on the
+	 * parent container to disambiguate files from folders.
+	 *
+	 * That eager refresh is harmful for a deleted {@code .classpath} file: it
+	 * notifies the JDT Core resource-change listeners that the classpath file is
+	 * gone *before* {@link IBuildSupport#fileChanged(IResource, CHANGE_TYPE, IProgressMonitor)}
+	 * gets a chance to remove the Java nature and regenerate the correct
+	 * classpath, causing JDT Core to fall back to a default classpath (and create
+	 * a stray {@code bin} output folder) in between. See
+	 * https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/1443 and
+	 * https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/1251.
+	 *
+	 * To avoid the race, a deleted {@code .classpath} file is resolved without
+	 * triggering that premature refresh; {@link IBuildSupport#refresh(IResource, CHANGE_TYPE, IProgressMonitor)}
+	 * already performs the equivalent (and correctly ordered) refresh once it has
+	 * restored the classpath.
+	 */
+	private IResource getResourceForChange(String uriString, CHANGE_TYPE changeType) {
+		if (changeType == CHANGE_TYPE.DELETED) {
+			IFile file = JDTUtils.findFile(uriString);
+			if (file != null && IJavaProject.CLASSPATH_FILE_NAME.equals(file.getName())) {
+				return file;
+			}
+		}
+		return JDTUtils.getFileOrFolder(uriString);
 	}
 
 	private void appendBuildFileMarker(IResource resource) throws CoreException {


### PR DESCRIPTION
## What
Fixes one confirmed root cause behind the long-standing flaky `MavenProjectMetadataFileTest` failures (e.g. seen in #3839's CI): a race between `StandardProjectsManager.fileChanged()`'s eager resource refresh and `IBuildSupport.refresh()`'s classpath recovery logic for `DELETED` `.classpath` events.

## Root cause
`fileChanged()` called `JDTUtils.getFileOrFolder(uriString)`, which eagerly calls `IContainer#refreshLocal(DEPTH_ONE, null)`. For a deleted `.classpath` file, this notifies JDT Core's classpath machinery that the file is gone **before** `IBuildSupport.refresh()` gets a chance to recover/regenerate the correct classpath. In that window, JDT Core briefly falls back to a default classpath and creates a stray `bin` output folder — which is exactly the symptom asserted against in `MavenProjectMetadataFileTest#testDeleteClasspath`.

This matches long-standing reports in #1443 and #1251.

## Fix
Resolve deleted `.classpath` files via `JDTUtils.findFile()` instead, which does not perform the premature refresh. `IBuildSupport.refresh()` already performs the equivalent (and correctly ordered) refresh once it has restored the classpath.

## Verification
Reproduced locally via:
```
.\mvnw.cmd -o -pl org.eclipse.jdt.ls.tests -am integration-test "-Dtest=MavenProjectMetadataFileTest" "-DfailIfNoTests=false"
```
Confirmed this change eliminates the stray-`bin`-folder assertion failure, reproducibly across multiple runs.

## Note: second, deeper issue remains
While investigating, I found a second, unrelated root cause affecting `testMetadataFileSync` and part of `testDeleteClasspath` — an EFS-redirect/resource-tree synchronization gap in `org.eclipse.jdt.ls.filesystem` (active when `java.import.generatesMetadataFilesAtProjectRoot=false`). I've documented detailed findings (including instrumented trace evidence from `eclipse.jdt.core`) in a follow-up issue rather than bundling an unverified fix here, since it needs live debugging to pin down precisely. This PR only contains the confirmed, verified fix.
