### PR TITLE
Suppress 'Assign parameter to field' proposal for record constructors

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/QuickAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/QuickAssistProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -349,9 +349,10 @@ public class QuickAssistProcessor {
 
 		ITypeBinding parentType = Bindings.getBindingOfParentType(node);
 		if (parentType != null) {
-			if (parentType.isInterface()) {
+			if (parentType.isInterface() || parentType.isRecord()) {
 				return false;
 			}
+
 			// assign to existing fields
 			CompilationUnit root = context.getASTRoot();
 			IVariableBinding[] declaredFields = parentType.getDeclaredFields();

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/AssignToFieldQuickAssistTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/AssignToFieldQuickAssistTest.java
@@ -284,4 +284,18 @@ public class AssignToFieldQuickAssistTest extends AbstractQuickFixTest {
 		Range selection = CodeActionUtil.getRange(cu, "int p2", 0);
 		assertCodeActions(cu, selection, e1, e2, e3);
 	}
+
+	@Test
+	public void testNoAssignParamToFieldForRecords() throws Exception {
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public record E((int p) {\n");
+		buf.append("    public  E(int p) {\n");
+		buf.append("    this.p = p;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+		assertCodeActionNotExists(cu, "Assign parameter to new field");
+	}
 }


### PR DESCRIPTION
Do not offer 'Assign parameter to new field' quick assist when the enclosing type is a record.

Before : 
<img width="1080" height="608" alt="ls" src="https://github.com/user-attachments/assets/dd83f5cc-d930-44b5-acad-46683574ffca" />

After: 
<img width="327" height="310" alt="image" src="https://github.com/user-attachments/assets/4305a54f-5fd2-420a-97f4-1c41e7ecc7f9" />
