### PR TITLE
fix: override JLSFile.childInfos() to include redirected metadata files

### DIFF
--- a/org.eclipse.jdt.ls.filesystem/src/org/eclipse/jdt/ls/core/internal/filesystem/JLSFile.java
+++ b/org.eclipse.jdt.ls.filesystem/src/org/eclipse/jdt/ls/core/internal/filesystem/JLSFile.java
@@ -14,10 +14,13 @@
 package org.eclipse.jdt.ls.core.internal.filesystem;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
+import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.internal.filesystem.local.LocalFile;
 import org.eclipse.core.runtime.IPath;
@@ -67,6 +70,55 @@ public class JLSFile extends LocalFile {
         }
 
         return childNameSet.toArray(String[]::new);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>
+     * Since the metadata files may be redirected into the workspace metadata area,
+     * we override this method to make sure the redirected files are reported as
+     * children. This mirrors {@link #childNames(int, IProgressMonitor)} and is
+     * required because {@link LocalFile#childInfos(int, IProgressMonitor)} performs
+     * a bulk directory listing of the physical location that bypasses both
+     * {@link #childNames(int, IProgressMonitor)} and {@link #getChild(String)},
+     * which would otherwise leave the redirected metadata files invisible to the
+     * resource refresh/synchronization.
+     * </p>
+     */
+    @Override
+    public IFileInfo[] childInfos(int options, IProgressMonitor monitor) {
+        IFileInfo[] childInfos = super.childInfos(options, monitor);
+        if (JLSFsUtils.generatesMetadataFilesAtProjectRoot()) {
+            return childInfos;
+        }
+
+        IPath filePath = new Path(this.filePath);
+        if (JLSFsUtils.isExcluded(filePath)) {
+            return childInfos;
+        }
+        String projectName = JLSFsUtils.getProjectNameIfLocationIsProjectRoot(filePath);
+        if (projectName == null) {
+            return childInfos;
+        }
+
+        Set<String> existingNames = new LinkedHashSet<>();
+        for (IFileInfo info : childInfos) {
+            existingNames.add(info.getName());
+        }
+
+        List<IFileInfo> result = null;
+        for (String fileName : JLSFsUtils.METADATA_NAMES) {
+            if (!existingNames.contains(fileName) &&
+                    JLSFsUtils.METADATA_FOLDER_PATH.append(projectName).append(fileName).toFile().exists()) {
+                if (result == null) {
+                    result = new ArrayList<>(Arrays.asList(childInfos));
+                }
+                result.add(getChild(fileName).fetchInfo());
+            }
+        }
+
+        return result == null ? childInfos : result.toArray(IFileInfo[]::new);
     }
 
     @Override


### PR DESCRIPTION
#### Summary

Fixes the flaky `MavenProjectMetadataFileTest` failures tracked in #3841 (`testMetadataFileSync` and `testDeleteClasspath`), which began appearing on Eclipse SDK I-builds from `I20260630-2300` onward and have been failing PR CI across the repo.

#### Root cause

When `java.import.generatesMetadataFilesAtProjectRoot` is `false`, `JLSFile` (our `LocalFile` subclass) redirects the project metadata files (`.project`, `.classpath`, `.settings`, `.factorypath`) into the workspace metadata area. It does this by overriding `childNames()`, `getChild()` and `getFileStore()`.

eclipse-platform [PR #2787](https://github.com/eclipse-platform/eclipse.platform/pull/2787) (first shipped in I-build `I20260630-2300`) added a new `LocalFile.childInfos(int, IProgressMonitor)` override that performs a **bulk native directory listing** of the physical location. That path bypasses both `childNames()` and `getChild()`, so the redirected metadata files became invisible to `org.eclipse.core.resources` refresh/synchronization (which uses `childInfos()` for efficiency). The result: `IFile.exists()` returns `false` and `getContents()` throws for the redirected `.classpath`, causing the two test failures.

#### Fix

Override `childInfos()` in `JLSFile`, mirroring the existing `childNames()` logic:

- Start from the fast native `super.childInfos()` result (preserving the #2787 performance improvement).
- Append `IFileInfo` entries for any redirected metadata files that exist in the metadata area but are not already present.
- A new array is only allocated when a redirected file actually needs to be appended; the common case returns `super.childInfos()` unchanged.
- Early guards (`generatesMetadataFilesAtProjectRoot()`, `isExcluded()`, `getProjectNameIfLocationIsProjectRoot()`) match `childNames()` exactly, so there is no behavior change when metadata files are kept at the project root.

This is fixed entirely on the jdt.ls side — no target-platform pinning and no dependency on an upstream change.

#### Testing

On the current (regressed) rolling I-build target platform, all filesystem tests pass:

- `MavenProjectMetadataFileTest` — 12/12
- `EclipseProjectMetadataFileTest` — 6/6
- `GradleProjectMetadataFileTest` — 8/8
- `InvisibleProjectMetadataFileTest` — 8/8
- `JLSFsUtilsTest` — 4/4

**Total: 38 tests, 0 failures, 0 errors.** Before this change, the same setup produced 1 failure + 1 error in `MavenProjectMetadataFileTest`.

Fixes #3841
