### PR TITLE
Add settings to customize the TODO comment in generated stubs

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
@@ -241,9 +241,23 @@ public class PreferenceManager {
 		} else {
 			templateChanged |= updateTemplate(CodeTemplatePreferences.CODETEMPLATE_TYPECOMMENT, content);
 		}
+
+		List<String> methodBody = preferences.getMethodBodyTemplate();
+		content = methodBody == null ? "" : String.join("\n", methodBody);
+		templateChanged |= updateTemplate(CodeTemplatePreferences.CODETEMPLATE_METHODBODY, content);
+
+		List<String> methodBodySuper = preferences.getMethodBodySuperTemplate();
+		content = methodBodySuper == null ? "" : String.join("\n", methodBodySuper);
+		templateChanged |= updateTemplate(CodeTemplatePreferences.CODETEMPLATE_METHODBODY_SUPER, content);
+
+		List<String> catchBody = preferences.getCatchBodyTemplate();
+		content = catchBody == null ? "" : String.join("\n", catchBody);
+		templateChanged |= updateTemplate(CodeTemplatePreferences.CODETEMPLATE_CATCHBODY, content);
+
 		if (templateChanged) {
 			reloadTemplateStore();
 		}
+
 		Hashtable<String, String> options = JavaCore.getOptions();
 		preferences.updateTabSizeInsertSpaces(options);
 		if (!Objects.equals(options, JavaCore.getOptions())) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -503,6 +503,12 @@ public class Preferences {
 	public static final String JAVA_TEMPLATES_FILEHEADER = "java.templates.fileHeader";
 	// Specifies the type comment snippets for new Java type.
 	public static final String JAVA_TEMPLATES_TYPECOMMENT = "java.templates.typeComment";
+	// Specifies the method body snippet for unimplemented methods.
+	public static final String JAVA_TEMPLATES_METHODBODY = "java.templates.methodBody";
+	// Specifies the method body snippet for overridden methods that call super.
+	public static final String JAVA_TEMPLATES_METHODBODY_SUPER = "java.templates.methodBodySuper";
+	// Specifies the catch block body snippet.
+	public static final String JAVA_TEMPLATES_CATCHBODY = "java.templates.catchBody";
 	// Project encoding settings
 	public static final String JAVA_PROJECT_ENCODING = "java.project.encoding";
 
@@ -725,6 +731,9 @@ public class Preferences {
 
 	private List<String> fileHeaderTemplate = new LinkedList<>();
 	private List<String> typeCommentTemplate = new LinkedList<>();
+	private List<String> methodBodyTemplate = new LinkedList<>();
+	private List<String> methodBodySuperTemplate = new LinkedList<>();
+	private List<String> catchBodyTemplate = new LinkedList<>();
 	private boolean insertSpaces;
 	private int tabSize;
 	private InlayHintsParameterMode inlayHintsParameterMode;
@@ -1203,6 +1212,9 @@ public class Preferences {
 		prefs.resourceFilters = this.resourceFilters != null ? new ArrayList<>(this.resourceFilters) : null;
 		prefs.fileHeaderTemplate = this.fileHeaderTemplate != null ? new LinkedList<>(this.fileHeaderTemplate) : null;
 		prefs.typeCommentTemplate = this.typeCommentTemplate != null ? new LinkedList<>(this.typeCommentTemplate) : null;
+		prefs.methodBodyTemplate = this.methodBodyTemplate != null ? new LinkedList<>(this.methodBodyTemplate) : null;
+		prefs.methodBodySuperTemplate = this.methodBodySuperTemplate != null ? new LinkedList<>(this.methodBodySuperTemplate) : null;
+		prefs.catchBodyTemplate = this.catchBodyTemplate != null ? new LinkedList<>(this.catchBodyTemplate) : null;
 		prefs.inlayHintsExclusionList = this.inlayHintsExclusionList != null ? new ArrayList<>(this.inlayHintsExclusionList) : null;
 		prefs.nonnullTypes = this.nonnullTypes != null ? new ArrayList<>(this.nonnullTypes) : null;
 		prefs.nullableTypes = this.nullableTypes != null ? new ArrayList<>(this.nullableTypes) : null;
@@ -1744,6 +1756,21 @@ public class Preferences {
 		if (containsKey(configuration, JAVA_TEMPLATES_TYPECOMMENT)) {
 			List<String> typeComment = getList(configuration, JAVA_TEMPLATES_TYPECOMMENT);
 			prefs.setTypeCommentTemplate(typeComment);
+		}
+
+		if (containsKey(configuration, JAVA_TEMPLATES_METHODBODY)) {
+			List<String> methodBody = getList(configuration, JAVA_TEMPLATES_METHODBODY);
+			prefs.setMethodBodyTemplate(methodBody);
+		}
+
+		if (containsKey(configuration, JAVA_TEMPLATES_METHODBODY_SUPER)) {
+			List<String> methodBodySuper = getList(configuration, JAVA_TEMPLATES_METHODBODY_SUPER);
+			prefs.setMethodBodySuperTemplate(methodBodySuper);
+		}
+
+		if (containsKey(configuration, JAVA_TEMPLATES_CATCHBODY)) {
+			List<String> catchBody = getList(configuration, JAVA_TEMPLATES_CATCHBODY);
+			prefs.setCatchBodyTemplate(catchBody);
 		}
 
 		if (containsKey(configuration, JAVA_REFERENCES_INCLUDE_ACCESSORS)) {
@@ -2817,6 +2844,33 @@ public class Preferences {
 
 	public Preferences setTypeCommentTemplate(List<String> typeCommentTemplate) {
 		this.typeCommentTemplate = typeCommentTemplate;
+		return this;
+	}
+
+	public List<String> getMethodBodyTemplate() {
+		return methodBodyTemplate;
+	}
+
+	public Preferences setMethodBodyTemplate(List<String> methodBodyTemplate) {
+		this.methodBodyTemplate = methodBodyTemplate;
+		return this;
+	}
+
+	public List<String> getMethodBodySuperTemplate() {
+		return methodBodySuperTemplate;
+	}
+
+	public Preferences setMethodBodySuperTemplate(List<String> methodBodySuperTemplate) {
+		this.methodBodySuperTemplate = methodBodySuperTemplate;
+		return this;
+	}
+
+	public List<String> getCatchBodyTemplate() {
+		return catchBodyTemplate;
+	}
+
+	public Preferences setCatchBodyTemplate(List<String> catchBodyTemplate) {
+		this.catchBodyTemplate = catchBodyTemplate;
 		return this;
 	}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManagerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManagerTest.java
@@ -409,4 +409,55 @@ public class PreferenceManagerTest {
 			assertEquals(false, preferenceManager.getPreferences().isTelemetryEnabled());
 		}
 	}
+
+	@Test
+	public void testUpdateMethodBodyTemplate() {
+		PreferenceManager.initialize();
+
+		Template template = JavaManipulation.getCodeTemplateStore().findTemplateById(CodeTemplateContextType.METHODSTUB_ID);
+		assertNotNull(template);
+		assertEquals(CodeTemplatePreferences.CODETEMPLATE_METHODBODY_DEFAULT, template.getPattern());
+
+		Preferences preferences = new Preferences();
+		preferences.setMethodBodyTemplate(Arrays.asList("throw new UnsupportedOperationException(\"Unimplemented method '${enclosing_method}'\");"));
+		preferenceManager.update(preferences);
+
+		template = JavaManipulation.getCodeTemplateStore().findTemplateById(CodeTemplateContextType.METHODSTUB_ID);
+		assertNotNull(template);
+		assertEquals("throw new UnsupportedOperationException(\"Unimplemented method '${enclosing_method}'\");", template.getPattern());
+	}
+
+	@Test
+	public void testUpdateMethodBodySuperTemplate() {
+		PreferenceManager.initialize();
+
+		Template template = JavaManipulation.getCodeTemplateStore().findTemplateById(CodeTemplateContextType.METHODSTUB_ALTERNATIVE_ID);
+		assertNotNull(template);
+		assertEquals(CodeTemplatePreferences.CODETEMPLATE_METHODBODY_SUPER_DEFAULT, template.getPattern());
+
+		Preferences preferences = new Preferences();
+		preferences.setMethodBodySuperTemplate(Arrays.asList("${body_statement}"));
+		preferenceManager.update(preferences);
+
+		template = JavaManipulation.getCodeTemplateStore().findTemplateById(CodeTemplateContextType.METHODSTUB_ALTERNATIVE_ID);
+		assertNotNull(template);
+		assertEquals("${body_statement}", template.getPattern());
+	}
+
+	@Test
+	public void testUpdateCatchBodyTemplate() {
+		PreferenceManager.initialize();
+
+		Template template = JavaManipulation.getCodeTemplateStore().findTemplateById(CodeTemplateContextType.CATCHBLOCK_ID);
+		assertNotNull(template);
+		assertEquals(CodeTemplatePreferences.CODETEMPLATE_CATCHBODY_DEFAULT, template.getPattern());
+
+		Preferences preferences = new Preferences();
+		preferences.setCatchBodyTemplate(Arrays.asList("${exception_var}.printStackTrace();"));
+		preferenceManager.update(preferences);
+
+		template = JavaManipulation.getCodeTemplateStore().findTemplateById(CodeTemplateContextType.CATCHBLOCK_ID);
+		assertNotNull(template);
+		assertEquals("${exception_var}.printStackTrace();", template.getPattern());
+	}
 }


### PR DESCRIPTION
Related to https://github.com/redhat-developer/vscode-java/issues/2963

This adds three new preferences, java.templates.methodBody,
java.templates.methodBodySuper, and java.templates.catchBody, so
people can customize or drop that comment for "Add unimplemented
methods", "Override/Implement Methods", and "Surround with
try/catch". Same idea as the existing java.templates.fileHeader/
typeComment settings, just extended to a few more templates.

Tested with the new PreferenceManagerTest cases, plus manually end to end ran through all three actions with the settings on and off to confirm the comment goes away when configured and stays put
otherwise.