### PR TITLE
Fix #2687: correct postfix completion text when selected by mouse click

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/PostfixTemplateEngine.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/PostfixTemplateEngine.java
@@ -46,6 +46,7 @@ import org.eclipse.lsp4j.CompletionItemKind;
 import org.eclipse.lsp4j.CompletionItemLabelDetails;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 public class PostfixTemplateEngine {
 	private static String Switch_Name = "switch"; //$NON-NLS-1$
@@ -105,18 +106,20 @@ public class PostfixTemplateEngine {
 			CompletionUtils.setInsertTextFormat(item, completionItemDefaults);
 			CompletionUtils.setInsertTextMode(item, completionItemDefaults);
 
-			String content = "";
-			if (isCompletionLazyResolveTextEditEnabled()) {
-				content = SnippetUtils.templateToSnippet(template.getPattern());
-			} else {
-				context.setActiveTemplateName(template.getName());
-				content = evaluateGenericTemplate(context, template);
+			context.setActiveTemplateName(template.getName());
+			String content = evaluateGenericTemplate(context, template);
+			if (content == null) {
+				continue;
 			}
-			setTextEdit(item, content, completionItemDefaults);
+			try {
+				Range insertionPoint = JDTUtils.toRange(compilationUnit, completionCtx.getOffset(), 0);
+				item.setTextEdit(Either.forLeft(new TextEdit(insertionPoint, content)));
+			} catch (JavaModelException e) {
+				JavaLanguageServerPlugin.logException(e.getMessage(), e);
+				continue;
+			}
 
-			if (!getClientPreferences().isResolveAdditionalTextEditsSupport()) {
-				setAdditionalTextEdit(item, compilationUnit, context, range, template);
-			}
+			setAdditionalTextEdit(item, compilationUnit, context, range, template);
 
 			if (isCompletionItemLabelDetailsSupport()) {
 				CompletionItemLabelDetails itemLabelDetails = new CompletionItemLabelDetails();
@@ -151,18 +154,10 @@ public class PostfixTemplateEngine {
 		return res;
 	}
 
-	private void setTextEdit(final CompletionItem item, String content, CompletionItemDefaults completionItemDefaults) {
-		if (getClientPreferences().isCompletionListItemDefaultsSupport() && completionItemDefaults.getEditRange() != null) {
-			item.setTextEditText(content);
-		} else {
-			item.setInsertText(content);
-		}
-	}
-
 	public static void setAdditionalTextEdit(final CompletionItem item, ICompilationUnit compilationUnit,
 			JavaPostfixContext context, Range range, Template template) {
 		List<TextEdit> additionalEdits = new ArrayList<>();
-		// use additional test edit to remove the code that needs to be replaced
+		// use additional text edit to remove the code that needs to be replaced
 		additionalEdits.add(new TextEdit(range, ""));
 		List<org.eclipse.text.edits.TextEdit> jdtTextEdits = context.getAdditionalTextEdits(template.getName());
 		if (jdtTextEdits != null && !jdtTextEdits.isEmpty()) {
@@ -246,9 +241,5 @@ public class PostfixTemplateEngine {
 
 	private ClientPreferences getClientPreferences() {
 		return JavaLanguageServerPlugin.getPreferencesManager().getClientPreferences();
-	}
-
-	private boolean isCompletionLazyResolveTextEditEnabled() {
-		return JavaLanguageServerPlugin.getPreferencesManager().getPreferences().isCompletionLazyResolveTextEditEnabled();
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
@@ -58,9 +58,6 @@ import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionItemKind;
 import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.MarkupKind;
-import org.eclipse.lsp4j.Range;
-import org.eclipse.lsp4j.TextEdit;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.osgi.util.NLS;
 
 import com.google.common.util.concurrent.SimpleTimeLimiter;
@@ -134,12 +131,6 @@ public class CompletionResolveHandler {
 					Template template = ((PostfixCompletionProposal) proposal).getTemplate();
 					postfixContext.setActiveTemplateName(template.getName());
 					String content = PostfixTemplateEngine.evaluateGenericTemplate(postfixContext, template);
-					int length = postfixContext.getEnd() - postfixContext.getStart();
-					Range range = JDTUtils.toRange(unit, postfixContext.getStart(), length);
-					if (manager.getPreferences().isCompletionLazyResolveTextEditEnabled()) {
-						TextEdit textEdit = new TextEdit(range, content);
-						param.setTextEdit(Either.forLeft(textEdit));
-					}
 
 					if (manager.getClientPreferences().isCompletionResolveDocumentSupport()) {
 						param.setDocumentation(SnippetUtils.beautifyDocument(content));
@@ -147,10 +138,6 @@ public class CompletionResolveHandler {
 
 					if (manager.getClientPreferences().isCompletionResolveDocumentSupport()) {
 						param.setDetail(template.getDescription());
-					}
-
-					if (manager.getClientPreferences().isResolveAdditionalTextEditsSupport()) {
-						PostfixTemplateEngine.setAdditionalTextEdit(param, unit, postfixContext, range, template);
 					}
 				}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/PostfixCompletionTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/PostfixCompletionTest.java
@@ -98,7 +98,7 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 			List<CompletionItem> items = new ArrayList<>(list.getItems());
 			CompletionItem item = items.get(0);
 			assertEquals("cast", item.getLabel());
-			assertEquals(item.getInsertText(), "((${1})${inner_expression})${0}");
+			assertEquals("((${1})a)${0}", item.getTextEdit().getLeft().getNewText());
 			assertEquals(item.getInsertTextFormat(), InsertTextFormat.Snippet);
 			Range range = item.getAdditionalTextEdits().get(0).getRange();
 			assertEquals(new Range(new Position(3, 2), new Position(3, 8)), range);
@@ -127,7 +127,7 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		List<CompletionItem> items = new ArrayList<>(list.getItems());
 		CompletionItem item = items.get(0);
 		assertEquals("assert", item.getLabel());
-		assertEquals(item.getInsertText(), "assert identifier;");
+		assertEquals("assert identifier;", item.getTextEdit().getLeft().getNewText());
 		assertEquals(item.getInsertTextFormat(), InsertTextFormat.Snippet);
 		Range range = item.getAdditionalTextEdits().get(0).getRange();
 		assertEquals(new Range(new Position(3, 2), new Position(3, 19)), range);
@@ -157,7 +157,7 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		assertEquals("cast", item.getLabel());
 		assertNull(item.getLabelDetails().getDetail());
 		assertEquals("Casts the expression to a new type", item.getLabelDetails().getDescription());
-		assertEquals(item.getInsertText(), "((${1})a)${0}");
+		assertEquals("((${1})a)${0}", item.getTextEdit().getLeft().getNewText());
 		assertEquals(item.getInsertTextFormat(), InsertTextFormat.Snippet);
 		assertEquals(item.getInsertTextMode(), InsertTextMode.AdjustIndentation);
 		Range range = item.getAdditionalTextEdits().get(0).getRange();
@@ -185,7 +185,7 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		List<CompletionItem> items = new ArrayList<>(list.getItems());
 		CompletionItem item = items.get(0);
 		assertEquals("if", item.getLabel());
-		assertEquals(item.getInsertText(), "if (a) {\n\t${0}\n}");
+		assertEquals("if (a) {\n\t${0}\n}", item.getTextEdit().getLeft().getNewText());
 		assertEquals(item.getInsertTextFormat(), InsertTextFormat.Snippet);
 		assertNull(item.getInsertTextMode());
 		Range range = item.getAdditionalTextEdits().get(0).getRange();
@@ -212,7 +212,7 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		List<CompletionItem> items = new ArrayList<>(list.getItems());
 		CompletionItem item = items.get(0);
 		assertEquals("else", item.getLabel());
-		assertEquals(item.getInsertText(), "if (!a) {\n\t${0}\n}");
+		assertEquals("if (!a) {\n\t${0}\n}", item.getTextEdit().getLeft().getNewText());
 		assertEquals(item.getInsertTextFormat(), InsertTextFormat.Snippet);
 		Range range = item.getAdditionalTextEdits().get(0).getRange();
 		assertEquals(new Range(new Position(3, 2), new Position(3, 8)), range);
@@ -238,7 +238,7 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		List<CompletionItem> items = new ArrayList<>(list.getItems());
 		CompletionItem item = items.get(0);
 		assertEquals("for", item.getLabel());
-		assertEquals(item.getInsertText(), "for (String ${1:a2} : a) {\n\t${0}\n}");
+		assertEquals("for (String ${1:a2} : a) {\n\t${0}\n}", item.getTextEdit().getLeft().getNewText());
 		assertEquals(item.getInsertTextFormat(), InsertTextFormat.Snippet);
 		Range range = item.getAdditionalTextEdits().get(0).getRange();
 		assertEquals(new Range(new Position(3, 2), new Position(3, 7)), range);
@@ -264,7 +264,7 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		List<CompletionItem> items = new ArrayList<>(list.getItems());
 		CompletionItem item = items.get(0);
 		assertEquals("fori", item.getLabel());
-		assertEquals(item.getInsertText(), "for (int ${1:a2} = 0; ${1:a2} < a.length; ${1:a2}++) {\n\t${0}\n}");
+		assertEquals("for (int ${1:a2} = 0; ${1:a2} < a.length; ${1:a2}++) {\n\t${0}\n}", item.getTextEdit().getLeft().getNewText());
 		assertEquals(item.getInsertTextFormat(), InsertTextFormat.Snippet);
 		Range range = item.getAdditionalTextEdits().get(0).getRange();
 		assertEquals(new Range(new Position(3, 2), new Position(3, 8)), range);
@@ -290,7 +290,7 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		List<CompletionItem> items = new ArrayList<>(list.getItems());
 		CompletionItem item = items.get(0);
 		assertEquals("forr", item.getLabel());
-		assertEquals(item.getInsertText(), "for (int ${1:a2} = a.length - 1; ${1:a2} >= 0; ${1:a2}--) {\n\t${0}\n}");
+		assertEquals("for (int ${1:a2} = a.length - 1; ${1:a2} >= 0; ${1:a2}--) {\n\t${0}\n}", item.getTextEdit().getLeft().getNewText());
 		assertEquals(item.getInsertTextFormat(), InsertTextFormat.Snippet);
 		Range range = item.getAdditionalTextEdits().get(0).getRange();
 		assertEquals(new Range(new Position(3, 2), new Position(3, 8)), range);
@@ -316,7 +316,7 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		List<CompletionItem> items = new ArrayList<>(list.getItems());
 		CompletionItem item = items.get(0);
 		assertEquals("nnull", item.getLabel());
-		assertEquals(item.getInsertText(), "if (a != null) {\n\t${0}\n}");
+		assertEquals("if (a != null) {\n\t${0}\n}", item.getTextEdit().getLeft().getNewText());
 		assertEquals(item.getInsertTextFormat(), InsertTextFormat.Snippet);
 		Range range = item.getAdditionalTextEdits().get(0).getRange();
 		assertEquals(new Range(new Position(3, 2), new Position(3, 9)), range);
@@ -342,7 +342,7 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		List<CompletionItem> items = new ArrayList<>(list.getItems());
 		CompletionItem item = items.get(0);
 		assertEquals("null", item.getLabel());
-		assertEquals(item.getInsertText(), "if (a == null) {\n\t${0}\n}");
+		assertEquals("if (a == null) {\n\t${0}\n}", item.getTextEdit().getLeft().getNewText());
 		assertEquals(item.getInsertTextFormat(), InsertTextFormat.Snippet);
 		Range range = item.getAdditionalTextEdits().get(0).getRange();
 		assertEquals(new Range(new Position(3, 2), new Position(3, 8)), range);
@@ -368,7 +368,7 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		List<CompletionItem> items = new ArrayList<>(list.getItems());
 		CompletionItem item = items.get(0);
 		assertEquals("opt", item.getLabel());
-		assertEquals(item.getInsertText(), "Optional.ofNullable(identifier)");
+		assertEquals("Optional.ofNullable(identifier)", item.getTextEdit().getLeft().getNewText());
 		assertEquals(item.getInsertTextFormat(), InsertTextFormat.Snippet);
 		Range range = item.getAdditionalTextEdits().get(0).getRange();
 		assertEquals(new Range(new Position(3, 2), new Position(3, 16)), range);
@@ -394,7 +394,7 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		List<CompletionItem> items = new ArrayList<>(list.getItems());
 		CompletionItem item = items.get(0);
 		assertEquals("not", item.getLabel());
-		assertEquals(item.getInsertText(), "!a");
+		assertEquals("!a", item.getTextEdit().getLeft().getNewText());
 		assertEquals(item.getInsertTextFormat(), InsertTextFormat.Snippet);
 		Range range = item.getAdditionalTextEdits().get(0).getRange();
 		assertEquals(new Range(new Position(3, 2), new Position(3, 7)), range);
@@ -420,7 +420,7 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		List<CompletionItem> items = new ArrayList<>(list.getItems());
 		CompletionItem item = items.get(0);
 		assertEquals("sysout", item.getLabel());
-		assertEquals(item.getInsertText(), "System.out.println(a);${0}");
+		assertEquals("System.out.println(a);${0}", item.getTextEdit().getLeft().getNewText());
 		assertEquals(item.getInsertTextFormat(), InsertTextFormat.Snippet);
 		Range range = item.getAdditionalTextEdits().get(0).getRange();
 		assertEquals(new Range(new Position(3, 2), new Position(3, 10)), range);
@@ -448,9 +448,9 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		CompletionItem ci = list.getItems().stream().filter(item -> item.getLabel().startsWith("sysout")).findFirst().orElse(null);
 		assertNotNull(ci);
 
-		assertEquals("System.out.println(new Test());${0}", ci.getTextEditText());
+		assertEquals("System.out.println(new Test());${0}", ci.getTextEdit().getLeft().getNewText());
 		//check that the fields covered by itemDefaults are set to null
-		assertNull(ci.getTextEdit());
+		assertNull(ci.getTextEditText());
 		assertNull(ci.getInsertTextFormat());
 		assertNull(ci.getInsertTextMode());
 		assertEquals(CompletionItemKind.Snippet, ci.getKind());
@@ -477,7 +477,7 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		List<CompletionItem> items = new ArrayList<>(list.getItems());
 		CompletionItem item = items.get(0);
 		assertEquals("sysout", item.getLabel());
-		assertEquals(item.getInsertText(), "System.out.println(foo);${0}");
+		assertEquals("System.out.println(foo);${0}", item.getTextEdit().getLeft().getNewText());
 		assertEquals(item.getInsertTextFormat(), InsertTextFormat.Snippet);
 		Range range = item.getAdditionalTextEdits().get(0).getRange();
 		assertEquals(new Range(new Position(4, 2), new Position(4, 12)), range);
@@ -504,7 +504,7 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		List<CompletionItem> items = new ArrayList<>(list.getItems());
 		CompletionItem item = items.get(0);
 		assertEquals("sysoutv", item.getLabel());
-		assertEquals(item.getInsertText(), "System.out.println(\"foo = \" + foo);${0}");
+		assertEquals("System.out.println(\"foo = \" + foo);${0}", item.getTextEdit().getLeft().getNewText());
 		assertEquals(item.getInsertTextFormat(), InsertTextFormat.Snippet);
 		Range range = item.getAdditionalTextEdits().get(0).getRange();
 		assertEquals(new Range(new Position(4, 2), new Position(4, 13)), range);
@@ -531,7 +531,7 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		List<CompletionItem> items = new ArrayList<>(list.getItems());
 		CompletionItem item = items.get(0);
 		assertEquals("sysouf", item.getLabel());
-		assertEquals(item.getInsertText(), "System.out.printf(\"\", foo);${0}");
+		assertEquals("System.out.printf(\"\", foo);${0}", item.getTextEdit().getLeft().getNewText());
 		assertEquals(item.getInsertTextFormat(), InsertTextFormat.Snippet);
 		Range range = item.getAdditionalTextEdits().get(0).getRange();
 		assertEquals(new Range(new Position(4, 2), new Position(4, 12)), range);
@@ -558,7 +558,7 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		List<CompletionItem> items = new ArrayList<>(list.getItems());
 		CompletionItem item = items.get(0);
 		assertEquals("syserr", item.getLabel());
-		assertEquals(item.getInsertText(), "System.err.println(foo);${0}");
+		assertEquals("System.err.println(foo);${0}", item.getTextEdit().getLeft().getNewText());
 		assertEquals(item.getInsertTextFormat(), InsertTextFormat.Snippet);
 		Range range = item.getAdditionalTextEdits().get(0).getRange();
 		assertEquals(new Range(new Position(4, 2), new Position(4, 12)), range);
@@ -583,7 +583,7 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 
 		CompletionItem item = list.getItems().stream().filter(i -> i.getKind() == CompletionItemKind.Snippet).findFirst().orElse(null);
 		assertEquals("format", item.getLabel());
-		assertEquals(item.getTextEditText(), "String.format(a, ${0});");
+		assertEquals("String.format(a, ${0});", item.getTextEdit().getLeft().getNewText());
 		Range range = item.getAdditionalTextEdits().get(0).getRange();
 		assertEquals(new Range(new Position(3, 2), new Position(3, 10)), range);
 	}
@@ -609,7 +609,7 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		List<CompletionItem> items = new ArrayList<>(list.getItems());
 		CompletionItem item = items.get(0);
 		assertEquals("throw", item.getLabel());
-		assertEquals(item.getInsertText(), "throw e;");
+		assertEquals("throw e;", item.getTextEdit().getLeft().getNewText());
 		assertEquals(item.getInsertTextFormat(), InsertTextFormat.Snippet);
 		Range range = item.getAdditionalTextEdits().get(0).getRange();
 		assertEquals(new Range(new Position(4, 2), new Position(4, 9)), range);
@@ -635,7 +635,7 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		List<CompletionItem> items = new ArrayList<>(list.getItems());
 		CompletionItem item = items.get(0);
 		assertEquals("var", item.getLabel());
-		assertEquals(item.getInsertText(), "String ${1:a2} = a;${0}");
+		assertEquals("String ${1:a2} = a;${0}", item.getTextEdit().getLeft().getNewText());
 		assertEquals(item.getInsertTextFormat(), InsertTextFormat.Snippet);
 		Range range = item.getAdditionalTextEdits().get(0).getRange();
 		assertEquals(new Range(new Position(3, 2), new Position(3, 7)), range);
@@ -662,7 +662,7 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		List<CompletionItem> items = new ArrayList<>(list.getItems());
 		CompletionItem item = items.get(0);
 		assertEquals("var", item.getLabel());
-		assertEquals(item.getInsertText(), "List<Object> ${1:emptyList} = Collections.emptyList();${0}");
+		assertEquals("List<Object> ${1:emptyList} = Collections.emptyList();${0}", item.getTextEdit().getLeft().getNewText());
 		assertEquals(item.getInsertTextFormat(), InsertTextFormat.Snippet);
 		List<TextEdit> additionalTextEdits = item.getAdditionalTextEdits();
 		Range range =additionalTextEdits.get(0).getRange();
@@ -690,7 +690,7 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		List<CompletionItem> items = new ArrayList<>(list.getItems());
 		CompletionItem item = items.get(0);
 		assertEquals("par", item.getLabel());
-		assertEquals(item.getInsertText(), "(a)");
+		assertEquals("(a)", item.getTextEdit().getLeft().getNewText());
 		assertEquals(item.getInsertTextFormat(), InsertTextFormat.Snippet);
 		Range range = item.getAdditionalTextEdits().get(0).getRange();
 		assertEquals(new Range(new Position(3, 2), new Position(3, 7)), range);
@@ -716,7 +716,7 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		List<CompletionItem> items = new ArrayList<>(list.getItems());
 		CompletionItem item = items.get(0);
 		assertEquals("while", item.getLabel());
-		assertEquals(item.getInsertText(), "while (a) {\n\t${0}\n}");
+		assertEquals("while (a) {\n\t${0}\n}", item.getTextEdit().getLeft().getNewText());
 		assertEquals(item.getInsertTextFormat(), InsertTextFormat.Snippet);
 		Range range = item.getAdditionalTextEdits().get(0).getRange();
 		assertEquals(new Range(new Position(3, 2), new Position(3, 9)), range);


### PR DESCRIPTION
sysout, syserr and the other postfix suggestions only built the
actual code when the editor asked for it in a separate step (resolve).
VS Code skips that step when you click with the mouse, so clicking
inserted broken placeholder text instead. Now the actual code is
ready right away, so clicking works the same as pressing Enter.