### PR TITLE
Do not offer Make Static action for default interface methods

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/RefactorProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/RefactorProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019, 2023 Microsoft Corporation and others.
+* Copyright (c) 2019, 2026 Microsoft Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License 2.0
 * which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IField;
 import org.eclipse.jdt.core.IJavaElement;
@@ -1284,7 +1285,13 @@ public class RefactorProcessor {
 		if (!(element instanceof IMethod method)){
 			return false;
 		}
-
+		try {
+			if (Flags.isDefaultMethod(method.getFlags())) {
+				return false;
+			}
+		} catch (JavaModelException e) {
+			return false;
+		}
 		MakeStaticRefactoring refactoring = new MakeStaticRefactoring(method);
 		try {
 			if (refactoring.checkInitialConditions(monitor).isOK()) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/MakeStaticTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/MakeStaticTest.java
@@ -187,4 +187,20 @@ public class MakeStaticTest extends AbstractSelectionTest {
 		assertCodeActions(cu, CodeActionUtil.getRange(cu, "bar(String foo)", 0), expected);
 
 	}
+	
+	@Test
+	public void testDefaultInterfaceMethodNotOffered() throws Exception {
+		IPackageFragment pack1 = testSourceFolder.createPackageFragment("", false, null);
+
+		String input = "public interface Foo {\n"
+				+ "\n"
+				+ "	default void bar() {\n"
+				+ "		System.out.println(\"bar\");\n"
+				+ "	}\n"
+				+ "}";
+
+		ICompilationUnit cu = pack1.createCompilationUnit("Foo.java", input, false, null);
+
+		assertCodeActionNotExists(cu, CodeActionUtil.getRange(cu, "bar()", 0), MAKE_STATIC);
+	}
 }


### PR DESCRIPTION
Prevent showing "Make Static" quick fix for default methods in interfaces.
Before:
<img width="1080" height="608" alt="now" src="https://github.com/user-attachments/assets/552c36d1-1ea5-42fa-8409-859eb76abbfb" />
