### PR TITLE
Support dynamic registration of type hierarchy capability

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -400,6 +400,9 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 		if (preferenceManager.getClientPreferences().isInlayHintDynamicRegistered()) {
 			registerCapability(Preferences.INLAY_HINT_ID, Preferences.INLAY_HINT);
 		}
+		if (preferenceManager.getClientPreferences().isTypeHierarchyDynamicRegistrationSupported()) {
+			registerCapability(Preferences.TYPE_HIERARCHY_ID, Preferences.TYPE_HIERARCHY);
+		}
 	}
 
 	/**

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -608,6 +608,7 @@ public class Preferences {
 	public static final String IMPLEMENTATION = "textDocument/implementation";
 	public static final String SELECTION_RANGE = "textDocument/selectionRange";
 	public static final String INLAY_HINT = "textDocument/inlayHint";
+	public static final String TYPE_HIERARCHY = "textDocument/prepareTypeHierarchy";
 
 	public static final String FORMATTING_ID = UUID.randomUUID().toString();
 	public static final String FORMATTING_ON_TYPE_ID = UUID.randomUUID().toString();
@@ -631,6 +632,7 @@ public class Preferences {
 	public static final String IMPLEMENTATION_ID = UUID.randomUUID().toString();
 	public static final String SELECTION_RANGE_ID = UUID.randomUUID().toString();
 	public static final String INLAY_HINT_ID = UUID.randomUUID().toString();
+	public static final String TYPE_HIERARCHY_ID = UUID.randomUUID().toString();
 
 	public static final Set<String> DISCOVERED_STATIC_IMPORTS = new LinkedHashSet<>();
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandlerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2019 Red Hat Inc. and others.
+ * Copyright (c) 2017-2026 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -234,12 +234,13 @@ public class InitHandlerTest extends AbstractProjectsManagerBasedTest {
 		when(mockCapabilies.isDocumentHighlightDynamicRegistered()).thenReturn(Boolean.TRUE);
 		when(mockCapabilies.isFoldgingRangeDynamicRegistered()).thenReturn(Boolean.TRUE);
 		when(mockCapabilies.isCompletionDynamicRegistered()).thenReturn(Boolean.TRUE);
+		when(mockCapabilies.isTypeHierarchyDynamicRegistrationSupported()).thenReturn(Boolean.TRUE);
 		InitializeResult result = initialize(true);
 		assertNull(result.getCapabilities().getDocumentSymbolProvider());
 		server.initialized(new InitializedParams());
 		waitForBackgroundJobs();
 		JobHelpers.waitForJobs(JDTLanguageServer.JAVA_LSP_INITIALIZE_WORKSPACE, monitor);
-		verify(client, times(9)).registerCapability(any());
+		verify(client, times(10)).registerCapability(any());
 		waitForBackgroundJobs();
 	}
 


### PR DESCRIPTION
- modify JDTLanguageServer.registerCapabilities() to register type hierarchy capability if type hierarchy dynamic registration is supported
- add new constants to Preferences.java
- modify InitHandlerTest.testRegisterDelayedCapability test
- fixes #3769