### PR TITLE
fix: restore lombok.config resolution for the Lombok agent

### DIFF
--- a/launch/jdt.ls.remote.server.launch
+++ b/launch/jdt.ls.remote.server.launch
@@ -128,6 +128,7 @@
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="org.eclipse.jdt.ls.core@default:default"/>
+        <setEntry value="org.eclipse.jdt.ls.compiler.batch.fragment@default:default"/>
         <setEntry value="org.eclipse.jdt.ls.filesystem@default:default"/>
         <setEntry value="org.eclipse.jdt.ls.logback.appender@default:false"/>
     </setAttribute>

--- a/launch/jdt.ls.socket-stream.launch
+++ b/launch/jdt.ls.socket-stream.launch
@@ -130,6 +130,7 @@
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="org.eclipse.jdt.ls.core@default:default"/>
+        <setEntry value="org.eclipse.jdt.ls.compiler.batch.fragment@default:default"/>
         <setEntry value="org.eclipse.jdt.ls.filesystem@default:default"/>
         <setEntry value="org.eclipse.jdt.ls.logback.appender@default:false"/>
     </setAttribute>

--- a/launch/jdt.ls.socket-stream.syntaxserver.launch
+++ b/launch/jdt.ls.socket-stream.syntaxserver.launch
@@ -110,6 +110,7 @@
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="org.eclipse.jdt.ls.core@default:default"/>
+        <setEntry value="org.eclipse.jdt.ls.compiler.batch.fragment@default:default"/>
         <setEntry value="org.eclipse.jdt.ls.filesystem@default:default"/>
     </setAttribute>
     <booleanAttribute key="show_selected_only" value="false"/>

--- a/org.eclipse.jdt.ls.compiler.batch.fragment/.project
+++ b/org.eclipse.jdt.ls.compiler.batch.fragment/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.jdt.ls.compiler.batch.fragment</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/org.eclipse.jdt.ls.compiler.batch.fragment/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.compiler.batch.fragment/META-INF/MANIFEST.MF
@@ -1,0 +1,11 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: %Bundle-Name
+Bundle-SymbolicName: org.eclipse.jdt.ls.compiler.batch.fragment;singleton:=true
+Bundle-Version: 1.61.0.qualifier
+Fragment-Host: org.eclipse.jdt.core.compiler.batch
+Automatic-Module-Name: org.eclipse.jdt.ls.compiler.batch.fragment
+Bundle-RequiredExecutionEnvironment: JavaSE-21
+Import-Package: org.eclipse.core.resources,
+ org.eclipse.core.runtime
+Bundle-Vendor: %Bundle-Vendor

--- a/org.eclipse.jdt.ls.compiler.batch.fragment/about.html
+++ b/org.eclipse.jdt.ls.compiler.batch.fragment/about.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+	<title>About</title>
+</head>
+
+<body lang="EN-US">
+	<h2>About This Content</h2>
+
+	<p>November 30, 2017</p>
+	<h3>License</h3>
+
+	<p>
+		The Eclipse Foundation makes available all content in this plug-in
+		(&quot;Content&quot;). Unless otherwise indicated below, the Content
+		is provided to you under the terms and conditions of the Eclipse
+		Public License Version 2.0 (&quot;EPL&quot;). A copy of the EPL is
+		available at <a href="https://www.eclipse.org/legal/epl-2.0">https://www.eclipse.org/legal/epl-2.0</a>.
+		For purposes of the EPL, &quot;Program&quot; will mean the Content.
+	</p>
+
+	<p>
+		If you did not receive this Content directly from the Eclipse
+		Foundation, the Content is being redistributed by another party
+		(&quot;Redistributor&quot;) and different terms and conditions may
+		apply to your use of any object code in the Content. Check the
+		Redistributor's license that was provided with the Content. If no such
+		license exists, contact the Redistributor. Unless otherwise indicated
+		below, the terms and conditions of the EPL still apply to any source
+		code in the Content and such source code may be obtained at <a
+			href="https://www.eclipse.org/">https://www.eclipse.org</a>.
+	</p>
+
+</body>
+
+</html>

--- a/org.eclipse.jdt.ls.compiler.batch.fragment/build.properties
+++ b/org.eclipse.jdt.ls.compiler.batch.fragment/build.properties
@@ -1,0 +1,4 @@
+bin.includes = META-INF/,\
+               plugin.properties,\
+               about.html
+src.includes = about.html

--- a/org.eclipse.jdt.ls.compiler.batch.fragment/plugin.properties
+++ b/org.eclipse.jdt.ls.compiler.batch.fragment/plugin.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2026 Microsoft Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Microsoft Corporation - initial API and implementation
+###############################################################################
+Bundle-Vendor = Eclipse.org
+Bundle-Name = JDT Language Server - Batch Compiler Fragment

--- a/org.eclipse.jdt.ls.compiler.batch.fragment/pom.xml
+++ b/org.eclipse.jdt.ls.compiler.batch.fragment/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.jdt.ls</groupId>
+		<artifactId>parent</artifactId>
+		<version>1.61.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>org.eclipse.jdt.ls.compiler.batch.fragment</artifactId>
+	<name>${base.name} :: Java LS Batch Compiler Fragment</name>
+	<packaging>eclipse-plugin</packaging>
+
+</project>

--- a/org.eclipse.jdt.ls.product/languageServer.product
+++ b/org.eclipse.jdt.ls.product/languageServer.product
@@ -52,6 +52,7 @@
 	  <plugin id="org.eclipse.jdt.core.javac"/>
       <plugin id="org.eclipse.jdt.launching"/>
       <plugin id="org.eclipse.jdt.ls.core"/>
+      <plugin id="org.eclipse.jdt.ls.compiler.batch.fragment" fragment="true"/>
       <plugin id="org.eclipse.jdt.ls.filesystem"/>
       <plugin id="org.eclipse.jdt.ls.logback.appender" fragment="true"/>
       <plugin id="org.eclipse.m2e.apt.core"/>

--- a/org.eclipse.jdt.ls.product/syntaxServer.product
+++ b/org.eclipse.jdt.ls.product/syntaxServer.product
@@ -45,6 +45,7 @@
       <plugin id="org.eclipse.jdt.core"/>
       <plugin id="org.eclipse.jdt.launching"/>
       <plugin id="org.eclipse.jdt.ls.core"/>
+      <plugin id="org.eclipse.jdt.ls.compiler.batch.fragment" fragment="true"/>
       <plugin id="org.eclipse.jdt.ls.filesystem"/>
       <plugin id="org.eclipse.osgi"/>
       <plugin id="org.eclipse.osgi.compatibility.state" fragment="true"/>

--- a/org.eclipse.jdt.ls.repository/category.xml
+++ b/org.eclipse.jdt.ls.repository/category.xml
@@ -9,6 +9,9 @@
    <bundle id="org.eclipse.jdt.ls.filesystem" version="0.0.0">
     <category name="jdt.ls" />
    </bundle>
+   <bundle id="org.eclipse.jdt.ls.compiler.batch.fragment" version="0.0.0">
+    <category name="jdt.ls" />
+   </bundle>
    <bundle id="org.eclipse.jdt.ls.logback.appender" version="0.0.0">
     <category name="jdt.ls" />
    </bundle>

--- a/org.eclipse.jdt.ls.tests/pom.xml
+++ b/org.eclipse.jdt.ls.tests/pom.xml
@@ -13,6 +13,27 @@
 	<packaging>eclipse-test-plugin</packaging>
 
 	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<dependency-resolution>
+						<extraRequirements>
+							<!-- widens the class visibility of the bundle hosting ECJ so that the
+							     Lombok agent can resolve lombok.config, see
+							     https://github.com/redhat-developer/vscode-java/issues/4461 -->
+							<requirement>
+								<type>eclipse-plugin</type>
+								<id>org.eclipse.jdt.ls.compiler.batch.fragment</id>
+								<versionRange>0.0.0</versionRange>
+							</requirement>
+						</extraRequirements>
+					</dependency-resolution>
+				</configuration>
+			</plugin>
+		</plugins>
 		<pluginManagement>
 			<plugins>
 				<plugin>

--- a/org.eclipse.jdt.ls.tests/projects/maven/mavenlombokconfig/lombok.config
+++ b/org.eclipse.jdt.ls.tests/projects/maven/mavenlombokconfig/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling = true
+lombok.accessors.chain = true

--- a/org.eclipse.jdt.ls.tests/projects/maven/mavenlombokconfig/pom.xml
+++ b/org.eclipse.jdt.ls.tests/projects/maven/mavenlombokconfig/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.sample</groupId>
+    <artifactId>mavenlombokconfig</artifactId>
+    <packaging>jar</packaging>
+    <version>1.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.32</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.8.0</version>
+            <configuration>
+                <source>11</source>
+                <target>11</target>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+</project>

--- a/org.eclipse.jdt.ls.tests/projects/maven/mavenlombokconfig/src/main/java/org/sample/Chained.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/mavenlombokconfig/src/main/java/org/sample/Chained.java
@@ -1,0 +1,13 @@
+package org.sample;
+
+import lombok.Data;
+
+/**
+ * The setters generated for this class only return {@code Chained} instead of
+ * {@code void} when the {@code lombok.config} sitting in the project root is
+ * picked up by Lombok.
+ */
+@Data
+public class Chained {
+    private String name;
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/LombokConfigurationTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/LombokConfigurationTest.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.Signature;
+import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Lombok resolves the {@code lombok.config} that applies to a source file by turning the
+ * workspace relative file name reported by ECJ into an absolute file system location, which
+ * requires {@code org.eclipse.core.resources} and {@code org.eclipse.core.runtime} to be
+ * visible from the class loader of the bundle hosting ECJ
+ * ({@code org.eclipse.jdt.core.compiler.batch}). When they are not, Lombok silently falls back
+ * to a bogus location and no {@code lombok.config} is ever read.
+ *
+ * @see <a href="https://github.com/redhat-developer/vscode-java/issues/4461">vscode-java#4461</a>
+ */
+public class LombokConfigurationTest extends AbstractProjectsManagerBasedTest {
+
+	// this test needs the Lombok agent (-javaagent:<lombok_jar>) to be meaningful
+	@Test
+	public void testLombokConfigIsApplied() throws Exception {
+		if (Boolean.getBoolean("jdt.ls.lombok.disabled")) {
+			return;
+		}
+		importProjects("maven/mavenlombokconfig");
+		IProject project = WorkspaceHelper.getProject("mavenlombokconfig");
+		IFile file = project.getFile("src/main/java/org/sample/Chained.java");
+		assertTrue(file.exists());
+		ICompilationUnit cu = JavaCore.createCompilationUnitFrom(file);
+		IType type = cu.getType("Chained");
+		IMethod setter = Stream.of(type.getMethods()).filter(m -> "setName".equals(m.getElementName())).findFirst().orElse(null);
+		if (setter == null) {
+			// the Lombok agent isn't installed in this JVM, nothing to check
+			return;
+		}
+		assertEquals("Chained", Signature.getSignatureSimpleName(setter.getReturnType()),
+				"'lombok.accessors.chain=true' from the project's lombok.config was not applied");
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
 		<module>org.eclipse.jdt.ls.target</module>
 		<module>org.eclipse.jdt.ls.core</module>
 		<module>org.eclipse.jdt.ls.filesystem</module>
+		<module>org.eclipse.jdt.ls.compiler.batch.fragment</module>
 		<module>org.eclipse.jdt.ls.tests</module>
 		<module>org.eclipse.jdt.ls.logback.appender</module>
 		<module>org.eclipse.jdt.ls.tests.syntaxserver</module>


### PR DESCRIPTION
## Problem

`lombok.config` is never applied by jdt.ls. None of the keys take effect — `lombok.accessors.chain`, `lombok.equalsandhashcode.callsuper`, `lombok.copyableAnnotations`, etc. all silently fall back to their defaults, while the same project compiles correctly with `javac`/Maven.

Reported downstream as [redhat-developer/vscode-java#4461](https://github.com/redhat-developer/vscode-java/issues/4461) and [redhat-developer/vscode-java#4467](https://github.com/redhat-developer/vscode-java/issues/4467).

## Root cause

Lombok resolves which `lombok.config` applies to a source file in [`EclipseAST.getAbsoluteFileLocation0()`](https://github.com/projectlombok/lombok/blob/master/src/core/lombok/eclipse/EclipseAST.java). ECJ hands it a workspace-relative name such as `/myproject/src/main/java/com/example/Main.java`, which Lombok maps to a real disk location via `ResourcesPlugin.getWorkspace().getRoot().getFile(new Path(path)).getLocationURI()`.

Lombok's classes are loaded by a `ShadowClassLoader` whose parent is the bundle class loader that first requested a `lombok.*` class — the bundle hosting ECJ. Since ECJ was split out into `org.eclipse.jdt.core.compiler.batch`, that bundle's manifest declares only `Export-Package`: no `Import-Package`, no `Require-Bundle`. So `org.eclipse.core.runtime.IPath` cannot be loaded, and the workspace-based resolution fails:

```
NoClassDefFoundError: org/eclipse/core/runtime/IPath
```

Lombok catches that and falls back to `new File(fileName).getAbsoluteFile()`, resolving the workspace-relative name against the process working directory. That path does not exist, so `FileSystemSourceCache.forUri` throws and the resolver returns no configuration at all — every key gets its default.

## Change

Adds `org.eclipse.jdt.ls.compiler.batch.fragment`, a fragment of `org.eclipse.jdt.core.compiler.batch` contributing:

```
Import-Package: org.eclipse.core.resources, org.eclipse.core.runtime
```

This restores class visibility for agents woven into ECJ without modifying the host bundle. The fragment carries no code — it exists purely for its manifest.

Registered in the root `pom.xml`, both `.product` files, `category.xml`, and the three dev `.launch` configs. The test runtime picks it up via `extraRequirements` in `org.eclipse.jdt.ls.tests/pom.xml`.

## Test

`LombokConfigurationTest` imports the new `maven/mavenlombokconfig` fixture, whose root `lombok.config` sets `lombok.accessors.chain=true`, and asserts the generated setter returns the declaring type rather than `void`. It fails without the fragment:

```
expected: <Chained> but was: <void>
```

and passes with it. The test no-ops when `jdt.ls.lombok.disabled` is set or when the Lombok agent isn't present, matching the existing Lombok tests.

## Note for upstream JDT

Any Eclipse-based product weaving an agent into ECJ hits this, not just jdt.ls — the Eclipse IDE included. A `DynamicImport-Package` or `Eclipse-BuddyPolicy: dependent` on `org.eclipse.jdt.core.compiler.batch` would fix it at the source; happy to open an issue against eclipse.jdt.core if that's preferred over carrying the fragment here.
