### PR TITLE
Add setting to make new classes package-private instead of public

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetCompletionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetCompletionProposal.java
@@ -121,7 +121,11 @@ public class SnippetCompletionProposal extends CompletionProposal {
 
 		boolean needsPublic(IProgressMonitor monitor) {
 			if (needsPublic == null) {
-				needsPublic = needsPublic(cu, getCompletionContext(), monitor);
+				if (JavaLanguageServerPlugin.getPreferencesManager().getPreferences().isPreferPackagePrivateVisibility()) {
+					needsPublic = false;
+				} else {
+					needsPublic = needsPublic(cu, getCompletionContext(), monitor);
+				}
 			}
 			return needsPublic;
 		}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -519,6 +519,8 @@ public class Preferences {
 
 	public static final String JAVA_EDIT_VALIDATE_ALL_OPEN_BUFFERS_ON_CHANGES = "java.edit.validateAllOpenBuffersOnChanges";
 	public static final String JAVA_DIAGNOSTIC_FILER = "java.diagnostic.filter";
+	// Specifies whether newly created top-level types (class/interface/enum/record) should be package-private instead of public.
+	public static final String JAVA_TEMPLATES_PREFER_PACKAGE_PRIVATE = "java.templates.preferPackagePrivateVisibility";
 	/**
 	 * The preferences for generating toString method.
 	 */
@@ -771,6 +773,7 @@ public class Preferences {
 	private boolean validateAllOpenBuffersOnChanges;
 	private boolean chainCompletionEnabled;
 	private List<String> diagnosticFilter;
+	private boolean preferPackagePrivateVisibility = false;
 	private SearchScope searchScope;
 	private boolean inlayHintsSuppressedWhenSameNameNumberedParameter;
 	private boolean referencesCodeLensIncludeFields;
@@ -1946,6 +1949,11 @@ public class Preferences {
 		if (containsKey(configuration, JAVA_DIAGNOSTIC_FILER)) {
 			List<String> diagnosticFilter = getList(configuration, JAVA_DIAGNOSTIC_FILER, existing.diagnosticFilter);
 			prefs.setDiagnosticFilter(diagnosticFilter);
+		}
+
+		if (containsKey(configuration, JAVA_TEMPLATES_PREFER_PACKAGE_PRIVATE)) {
+			boolean preferPackagePrivate = getBoolean(configuration, JAVA_TEMPLATES_PREFER_PACKAGE_PRIVATE, existing.preferPackagePrivateVisibility);
+			prefs.setPreferPackagePrivateVisibility(preferPackagePrivate);
 		}
 
 		if (containsKey(configuration, JAVA_CONFIGURATION_ASSOCIATIONS)) {
@@ -3390,6 +3398,15 @@ public class Preferences {
 
 	public void setDiagnosticFilter(List<String> diagnosticFilter) {
 		this.diagnosticFilter = diagnosticFilter;
+	}
+
+	public boolean isPreferPackagePrivateVisibility() {
+		return preferPackagePrivateVisibility;
+	}
+
+	public Preferences setPreferPackagePrivateVisibility(boolean preferPackagePrivateVisibility) {
+		this.preferPackagePrivateVisibility = preferPackagePrivateVisibility;
+		return this;
 	}
 
 	public List<String> getFilesAssociations() {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -17,8 +17,8 @@ import static org.eclipse.jdt.ls.core.internal.Lsp4jAssertions.assertPosition;
 import static org.eclipse.jdt.ls.core.internal.Lsp4jAssertions.assertTextEdit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -1489,6 +1489,59 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertEquals("class", item.getLabel());
 		String te = item.getInsertText();
 		assertEquals("/**\n * ${1:InnerTest}\n */\npublic class ${1:InnerTest} {\n\n\t${0}\n}", te);
+	}
+
+	@Test
+	public void testSnippet_class_with_package_packagePrivate() throws JavaModelException {
+		preferences.setPreferPackagePrivateVisibility(true);
+		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java", "package org.sample;\n");
+		CompletionList list = requestCompletions(unit, "package org.sample;\n");
+
+		assertNotNull(list);
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		assertFalse(items.isEmpty());
+		items.sort((i1, i2) -> (i1.getSortText().compareTo(i2.getSortText())));
+
+		CompletionItem item = items.get(0);
+		assertEquals("class", item.getLabel());
+		String te = item.getInsertText();
+		assertEquals("class Test {\n\n\t${0}\n}", te);
+	}
+
+	@Test
+	public void testSnippet_interface_with_package_packagePrivate() throws JavaModelException {
+		preferences.setPreferPackagePrivateVisibility(true);
+		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java", "package org.sample;\n");
+		CompletionList list = requestCompletions(unit, "package org.sample;\n");
+
+		assertNotNull(list);
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		assertFalse(items.isEmpty());
+		items.sort((i1, i2) -> (i1.getSortText().compareTo(i2.getSortText())));
+
+		CompletionItem item = items.get(1);
+		assertEquals("interface", item.getLabel());
+		String te = item.getInsertText();
+		assertEquals("interface Test {\n\n\t${0}\n}", te);
+	}
+
+	@Test
+	public void testSnippet_record_with_package_packagePrivate() throws Exception {
+		preferences.setPreferPackagePrivateVisibility(true);
+		importProjects("eclipse/records");
+		project = WorkspaceHelper.getProject("records");
+		ICompilationUnit unit = getWorkingCopy("src/main/java/org/sample/Test.java", "package org.sample;\n");
+		CompletionList list = requestCompletions(unit, "package org.sample;\n");
+
+		assertNotNull(list);
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		assertFalse(items.isEmpty());
+		items.sort((i1, i2) -> (i1.getSortText().compareTo(i2.getSortText())));
+
+		CompletionItem item = items.get(2);
+		assertEquals("record", item.getLabel());
+		String te = item.getInsertText();
+		assertEquals("record Test(${0}) {\n}", te);
 	}
 
 	@Test


### PR DESCRIPTION
This adds a new setting: java.templates.preferPackagePrivateVisibility
When turned on, new class/interface/record snippets won't add "public" anymore. They'll be package-private instead.