### PR TITLE
Preserve existing project metadata during import

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
@@ -237,6 +237,8 @@ public class PreferenceManager {
 		}
 		Preferences oldPreferences = this.preferences;
 		this.preferences = preferences;
+		IEclipsePreferences eclipsePreferences = InstanceScope.INSTANCE.getNode(IConstants.PLUGIN_ID);
+		eclipsePreferences.putBoolean(Preferences.PRESERVE_PROJECT_METADATA, preferences.isPreserveProjectMetadata());
 		preferencesChanged(oldPreferences, preferences); // listener will get latest preference from getPreferences()
 		// Update the templates according to the new preferences.
 		boolean templateChanged = false;
@@ -275,8 +277,7 @@ public class PreferenceManager {
 			JavaCore.setOptions(options);
 		}
 		List<String> resourceFilters = preferences.getResourceFilters();
-		IEclipsePreferences eclipsePreferences = InstanceScope.INSTANCE.getNode(IConstants.PLUGIN_ID);
-		// add the resourceFilters preference; the org.eclipse.jdt.ls.filesystem plugin uses it
+		// Add preferences consumed by the org.eclipse.jdt.ls.filesystem plugin.
 		eclipsePreferences.put(Preferences.JAVA_RESOURCE_FILTERS, String.join("::", resourceFilters));
 		// TODO serialize preferences
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -214,6 +214,11 @@ public class Preferences {
 	 */
 	public static final String GRADLE_ANNOTATION_PROCESSING_ENABLED = "java.import.gradle.annotationProcessing.enabled";
 	/**
+	 * Preference key to preserve existing project metadata outside the workspace
+	 * metadata area.
+	 */
+	public static final String PRESERVE_PROJECT_METADATA = "java.import.preserveProjectMetadata";
+	/**
 	 * Preference key to enable/disable maven importer.
 	 */
 	public static final String IMPORT_MAVEN_ENABLED = "java.import.maven.enabled";
@@ -670,6 +675,7 @@ public class Preferences {
 	private String gradleJavaHome;
 	private String gradleUserHome;
 	private boolean gradleAnnotationProcessingEnabled;
+	private boolean preserveProjectMetadata;
 	private boolean importMavenEnabled;
 	private boolean mavenOffline;
 	private boolean mavenDisableTestClasspathFlag;
@@ -967,6 +973,7 @@ public class Preferences {
 		gradleJavaHome = null;
 		gradleUserHome = null;
 		gradleAnnotationProcessingEnabled = true;
+		preserveProjectMetadata = false;
 		importMavenEnabled = true;
 		mavenOffline = false;
 		mavenDisableTestClasspathFlag = false;
@@ -1140,6 +1147,7 @@ public class Preferences {
 		prefs.gradleJavaHome = this.gradleJavaHome;
 		prefs.gradleUserHome = this.gradleUserHome;
 		prefs.gradleAnnotationProcessingEnabled = this.gradleAnnotationProcessingEnabled;
+		prefs.preserveProjectMetadata = this.preserveProjectMetadata;
 		prefs.importMavenEnabled = this.importMavenEnabled;
 		prefs.mavenOffline = this.mavenOffline;
 		prefs.mavenDisableTestClasspathFlag = this.mavenDisableTestClasspathFlag;
@@ -1358,6 +1366,11 @@ public class Preferences {
 		if (containsKey(configuration, GRADLE_ANNOTATION_PROCESSING_ENABLED)) {
 			boolean gradleAnnotationProcessingEnabled = getBoolean(configuration, GRADLE_ANNOTATION_PROCESSING_ENABLED, existing.gradleAnnotationProcessingEnabled);
 			prefs.setGradleAnnotationProcessingEnabled(gradleAnnotationProcessingEnabled);
+		}
+
+		if (containsKey(configuration, PRESERVE_PROJECT_METADATA)) {
+			boolean preserveProjectMetadata = getBoolean(configuration, PRESERVE_PROJECT_METADATA, existing.preserveProjectMetadata);
+			prefs.setPreserveProjectMetadata(preserveProjectMetadata);
 		}
 
 		if (containsKey(configuration, IMPORT_MAVEN_ENABLED)) {
@@ -2198,6 +2211,11 @@ public class Preferences {
 		return this;
 	}
 
+	public Preferences setPreserveProjectMetadata(boolean enabled) {
+		this.preserveProjectMetadata = enabled;
+		return this;
+	}
+
 	public Preferences setImportMavenEnabled(boolean enabled) {
 		this.importMavenEnabled = enabled;
 		return this;
@@ -2553,6 +2571,10 @@ public class Preferences {
 
 	public boolean isGradleWrapperEnabled() {
 		return gradleWrapperEnabled;
+	}
+
+	public boolean isPreserveProjectMetadata() {
+		return preserveProjectMetadata;
 	}
 
 	public boolean isImportMavenEnabled() {

--- a/org.eclipse.jdt.ls.filesystem/src/org/eclipse/jdt/ls/core/internal/filesystem/JLSFile.java
+++ b/org.eclipse.jdt.ls.filesystem/src/org/eclipse/jdt/ls/core/internal/filesystem/JLSFile.java
@@ -48,14 +48,31 @@ public class JLSFile extends LocalFile {
     @Override
     public String[] childNames(int options, IProgressMonitor monitor) {
         String[] childNames = super.childNames(options, monitor);
+        IPath filePath = new Path(this.filePath);
+        IPath preservedShadowRoot = getPreservedShadowRoot(filePath);
+        if (preservedShadowRoot == null && JLSFsUtils.isExcluded(filePath)) {
+            return childNames;
+        }
+        if (preservedShadowRoot != null) {
+            Set<String> childNameSet = new LinkedHashSet<>();
+            for (String childName : childNames) {
+                if (!ProjectMetadataStore.PROTECTED_METADATA_NAMES.contains(childName)
+                        || preservedShadowRoot.append(childName).toFile().exists()) {
+                    childNameSet.add(childName);
+                }
+            }
+            for (String fileName : ProjectMetadataStore.PROTECTED_METADATA_NAMES) {
+                if (preservedShadowRoot.append(fileName).toFile().exists()) {
+                    childNameSet.add(fileName);
+                }
+            }
+            childNames = childNameSet.toArray(String[]::new);
+        }
+
         if (JLSFsUtils.generatesMetadataFilesAtProjectRoot()) {
             return childNames;
         }
 
-        IPath filePath = new Path(this.filePath);
-        if (JLSFsUtils.isExcluded(filePath)) {
-            return childNames;
-        }
         String projectName = JLSFsUtils.getProjectNameIfLocationIsProjectRoot(filePath);
         if (projectName == null) {
             return childNames;
@@ -63,6 +80,9 @@ public class JLSFile extends LocalFile {
 
         Set<String> childNameSet = new LinkedHashSet<>(Arrays.asList(childNames));
         for (String fileName : JLSFsUtils.METADATA_NAMES) {
+            if (preservedShadowRoot != null && ProjectMetadataStore.PROTECTED_METADATA_NAMES.contains(fileName)) {
+                continue;
+            }
             if (!childNameSet.contains(fileName) &&
                     JLSFsUtils.METADATA_FOLDER_PATH.append(projectName).append(fileName).toFile().exists()) {
                 childNameSet.add(fileName);
@@ -89,14 +109,40 @@ public class JLSFile extends LocalFile {
     @Override
     public IFileInfo[] childInfos(int options, IProgressMonitor monitor) {
         IFileInfo[] childInfos = super.childInfos(options, monitor);
+        IPath filePath = new Path(this.filePath);
+        Set<String> physicalNames = new LinkedHashSet<>();
+        for (IFileInfo info : childInfos) {
+            physicalNames.add(info.getName());
+        }
+        IPath preservedShadowRoot = getPreservedShadowRoot(filePath);
+        if (preservedShadowRoot == null && JLSFsUtils.isExcluded(filePath)) {
+            return childInfos;
+        }
+        if (preservedShadowRoot != null) {
+            List<IFileInfo> result = new ArrayList<>();
+            for (IFileInfo info : childInfos) {
+                if (!ProjectMetadataStore.PROTECTED_METADATA_NAMES.contains(info.getName())) {
+                    result.add(info);
+                    continue;
+                }
+                IPath shadowChild = preservedShadowRoot.append(info.getName());
+                if (shadowChild.toFile().exists()) {
+                    result.add(new JLSFile(shadowChild.toFile()).fetchInfo());
+                }
+            }
+            for (String fileName : ProjectMetadataStore.PROTECTED_METADATA_NAMES) {
+                IPath shadowChild = preservedShadowRoot.append(fileName);
+                if (!physicalNames.contains(fileName) && shadowChild.toFile().exists()) {
+                    result.add(new JLSFile(shadowChild.toFile()).fetchInfo());
+                }
+            }
+            childInfos = result.toArray(IFileInfo[]::new);
+        }
+
         if (JLSFsUtils.generatesMetadataFilesAtProjectRoot()) {
             return childInfos;
         }
 
-        IPath filePath = new Path(this.filePath);
-        if (JLSFsUtils.isExcluded(filePath)) {
-            return childInfos;
-        }
         String projectName = JLSFsUtils.getProjectNameIfLocationIsProjectRoot(filePath);
         if (projectName == null) {
             return childInfos;
@@ -109,6 +155,9 @@ public class JLSFile extends LocalFile {
 
         List<IFileInfo> result = null;
         for (String fileName : JLSFsUtils.METADATA_NAMES) {
+            if (preservedShadowRoot != null && ProjectMetadataStore.PROTECTED_METADATA_NAMES.contains(fileName)) {
+                continue;
+            }
             if (!existingNames.contains(fileName) &&
                     JLSFsUtils.METADATA_FOLDER_PATH.append(projectName).append(fileName).toFile().exists()) {
                 if (result == null) {
@@ -124,7 +173,12 @@ public class JLSFile extends LocalFile {
     @Override
     public IFileStore getChild(String name) {
         IPath path = new Path(this.filePath).append(name);
-        if (JLSFsUtils.shouldStoreInMetadataArea(path) && !JLSFsUtils.isExcluded(path)) {
+        boolean excluded = JLSFsUtils.isExcluded(path);
+        IPath preservedPath = ProjectMetadataStore.getRedirectedPath(path);
+        if (preservedPath != null) {
+            return new JLSFile(preservedPath.toFile());
+        }
+        if (JLSFsUtils.shouldStoreInMetadataArea(path) && !excluded) {
             IPath containerPath = JLSFsUtils.getContainerPath(path);
             String projectName = JLSFsUtils.getProjectNameIfLocationIsProjectRoot(containerPath);
             if (projectName == null) {
@@ -142,7 +196,12 @@ public class JLSFile extends LocalFile {
     @Override
     public IFileStore getFileStore(IPath path) {
         IPath fullPath = new Path(this.filePath).append(path);
-        if (JLSFsUtils.shouldStoreInMetadataArea(fullPath) && !JLSFsUtils.isExcluded(fullPath)) {
+        boolean excluded = JLSFsUtils.isExcluded(fullPath);
+        IPath preservedPath = ProjectMetadataStore.getRedirectedPath(fullPath);
+        if (preservedPath != null) {
+            return new JLSFile(preservedPath.toFile());
+        }
+        if (JLSFsUtils.shouldStoreInMetadataArea(fullPath) && !excluded) {
             IPath containerPath = JLSFsUtils.getContainerPath(fullPath);
             String projectName = JLSFsUtils.getProjectNameIfLocationIsProjectRoot(containerPath);
             if (projectName == null) {
@@ -155,5 +214,9 @@ public class JLSFile extends LocalFile {
         }
 
         return new JLSFile(fullPath.toFile());
+    }
+
+    private static IPath getPreservedShadowRoot(IPath projectRoot) {
+        return ProjectMetadataStore.getShadowRoot(projectRoot);
     }
 }

--- a/org.eclipse.jdt.ls.filesystem/src/org/eclipse/jdt/ls/core/internal/filesystem/JLSFileSystem.java
+++ b/org.eclipse.jdt.ls.filesystem/src/org/eclipse/jdt/ls/core/internal/filesystem/JLSFileSystem.java
@@ -30,6 +30,10 @@ public class JLSFileSystem extends LocalFileSystem {
 
     @Override
     public IFileStore getStore(IPath path) {
+        IPath preservedPath = ProjectMetadataStore.getRedirectedPath(path);
+        if (preservedPath != null) {
+            return new JLSFile(preservedPath.toFile());
+        }
         if (JLSFsUtils.shouldStoreInMetadataArea(path)) {
             IPath containerPath = JLSFsUtils.getContainerPath(path);
             String projectName = JLSFsUtils.getProjectNameIfLocationIsProjectRoot(containerPath);
@@ -38,7 +42,7 @@ public class JLSFileSystem extends LocalFileSystem {
             }
             IPath redirectedPath = JLSFsUtils.getMetaDataFilePath(projectName, path);
             if (redirectedPath != null) {
-                return new JLSFile(redirectedPath.toFile()); 
+                return new JLSFile(redirectedPath.toFile());
             }
         }
         return new JLSFile(path.toFile());

--- a/org.eclipse.jdt.ls.filesystem/src/org/eclipse/jdt/ls/core/internal/filesystem/ProjectMetadataStore.java
+++ b/org.eclipse.jdt.ls.filesystem/src/org/eclipse/jdt/ls/core/internal/filesystem/ProjectMetadataStore.java
@@ -1,0 +1,230 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.filesystem;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Set;
+import java.util.UUID;
+
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.jdt.core.IJavaProject;
+
+/**
+ * Stores a private, writable snapshot of project metadata while leaving the
+ * original metadata at the project root untouched.
+ */
+public final class ProjectMetadataStore {
+
+	static final Set<String> PROTECTED_METADATA_NAMES = Set.of(
+			IProjectDescription.DESCRIPTION_FILE_NAME,
+			IJavaProject.CLASSPATH_FILE_NAME,
+			".settings");
+
+	private static final String CORE_PLUGIN_ID = "org.eclipse.jdt.ls.core";
+	private static final String PRESERVE_PROJECT_METADATA = "java.import.preserveProjectMetadata";
+	private static final String SHADOW_FOLDER = ".preserved";
+	private static final String COMPLETE_MARKER = ".complete";
+	private static final Object INITIALIZATION_LOCK = new Object();
+
+	private ProjectMetadataStore() {
+	}
+
+	/**
+	 * Returns the private location for protected metadata, initializing the entire
+	 * metadata snapshot before returning it. Returns {@code null} for paths that
+	 * are not protected or when preservation is disabled.
+	 */
+	static IPath getRedirectedPath(IPath location) {
+		if (!isPreservationEnabled() || location == null || isInMetadataArea(location)) {
+			return null;
+		}
+
+		try {
+			MetadataPath metadataPath = MetadataPath.from(location);
+			if (metadataPath == null || !isProjectMetadataRoot(metadataPath.projectRoot())) {
+				return null;
+			}
+			if (!isRegisteredProjectRoot(metadataPath.projectRoot()) && JLSFsUtils.isExcluded(location)) {
+				return null;
+			}
+			return ensureInitialized(metadataPath).append(metadataPath.relativePath());
+		} catch (IOException e) {
+			throw new IllegalStateException("Unable to preserve project metadata for " + location, e);
+		}
+	}
+
+	/**
+	 * Returns the private metadata root for an Eclipse project, initializing it on
+	 * first access.
+	 */
+	static IPath getShadowRoot(IPath projectRoot) {
+		if (!isPreservationEnabled() || projectRoot == null || isInMetadataArea(projectRoot)) {
+			return null;
+		}
+
+		try {
+			MetadataPath metadataPath = MetadataPath.forProjectRoot(projectRoot);
+			if (!isProjectMetadataRoot(metadataPath.projectRoot())) {
+				return null;
+			}
+			if (!isRegisteredProjectRoot(metadataPath.projectRoot()) && JLSFsUtils.isExcluded(projectRoot)) {
+				return null;
+			}
+			return ensureInitialized(metadataPath);
+		} catch (IOException e) {
+			throw new IllegalStateException("Unable to preserve project metadata for " + projectRoot, e);
+		}
+	}
+
+	static boolean isPreservationEnabled() {
+		return InstanceScope.INSTANCE.getNode(CORE_PLUGIN_ID).getBoolean(PRESERVE_PROJECT_METADATA, false);
+	}
+
+	private static boolean isInMetadataArea(IPath location) {
+		return JLSFsUtils.METADATA_FOLDER_PATH.isPrefixOf(location);
+	}
+
+	private static boolean isProjectMetadataRoot(IPath projectRoot) {
+		java.nio.file.Path projectDescription = projectRoot.append(IProjectDescription.DESCRIPTION_FILE_NAME).toFile().toPath();
+		return Files.exists(projectDescription, LinkOption.NOFOLLOW_LINKS) || isRegisteredProjectRoot(projectRoot);
+	}
+
+	private static boolean isRegisteredProjectRoot(IPath projectRoot) {
+		return JLSFsUtils.getProjectNameIfLocationIsProjectRoot(projectRoot) != null;
+	}
+
+	private static IPath ensureInitialized(MetadataPath metadataPath) throws IOException {
+		synchronized (INITIALIZATION_LOCK) {
+			java.nio.file.Path shadowRoot = metadataPath.shadowRoot().toFile().toPath();
+			java.nio.file.Path completeMarker = shadowRoot.resolve(COMPLETE_MARKER);
+			if (Files.isRegularFile(completeMarker, LinkOption.NOFOLLOW_LINKS)) {
+				return metadataPath.shadowRoot();
+			}
+			if (Files.exists(shadowRoot, LinkOption.NOFOLLOW_LINKS)) {
+				deleteRecursively(shadowRoot);
+			}
+			Files.createDirectories(shadowRoot);
+			try {
+				java.nio.file.Path projectRoot = metadataPath.projectRoot().toFile().toPath();
+				for (String metadataName : PROTECTED_METADATA_NAMES) {
+					java.nio.file.Path source = projectRoot.resolve(metadataName);
+					if (Files.exists(source, LinkOption.NOFOLLOW_LINKS)) {
+						copyRecursively(source, shadowRoot.resolve(metadataName));
+					}
+				}
+				Files.createFile(completeMarker);
+			} catch (IOException e) {
+				try {
+					deleteRecursively(shadowRoot);
+				} catch (IOException cleanupException) {
+					e.addSuppressed(cleanupException);
+				}
+				throw e;
+			}
+			return metadataPath.shadowRoot();
+		}
+	}
+
+	private static void copyRecursively(java.nio.file.Path source, java.nio.file.Path target) throws IOException {
+		if (Files.isSymbolicLink(source)) {
+			throw new IOException("Symbolic links are not supported in preserved project metadata: " + source);
+		}
+		if (!Files.isDirectory(source, LinkOption.NOFOLLOW_LINKS)) {
+			Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
+			return;
+		}
+
+		Files.walkFileTree(source, new SimpleFileVisitor<>() {
+			@Override
+			public FileVisitResult preVisitDirectory(java.nio.file.Path directory, BasicFileAttributes attributes) throws IOException {
+				if (attributes.isSymbolicLink()) {
+					throw new IOException("Symbolic links are not supported in preserved project metadata: " + directory);
+				}
+				Files.createDirectories(target.resolve(source.relativize(directory)));
+				return FileVisitResult.CONTINUE;
+			}
+
+			@Override
+			public FileVisitResult visitFile(java.nio.file.Path file, BasicFileAttributes attributes) throws IOException {
+				if (attributes.isSymbolicLink() || !attributes.isRegularFile()) {
+					throw new IOException("Unsupported file type in preserved project metadata: " + file);
+				}
+				java.nio.file.Path destination = target.resolve(source.relativize(file));
+				Files.createDirectories(destination.getParent());
+				Files.copy(file, destination, StandardCopyOption.REPLACE_EXISTING);
+				return FileVisitResult.CONTINUE;
+			}
+		});
+	}
+
+	private static void deleteRecursively(java.nio.file.Path root) throws IOException {
+		Files.walkFileTree(root, new SimpleFileVisitor<>() {
+			@Override
+			public FileVisitResult visitFile(java.nio.file.Path file, BasicFileAttributes attributes) throws IOException {
+				Files.delete(file);
+				return FileVisitResult.CONTINUE;
+			}
+
+			@Override
+			public FileVisitResult postVisitDirectory(java.nio.file.Path directory, IOException exception) throws IOException {
+				if (exception != null) {
+					throw exception;
+				}
+				Files.delete(directory);
+				return FileVisitResult.CONTINUE;
+			}
+		});
+	}
+
+	private record MetadataPath(IPath projectRoot, IPath relativePath, IPath shadowRoot) {
+
+		static MetadataPath from(IPath location) throws IOException {
+			for (int i = location.segmentCount() - 1; i >= 0; i--) {
+				if (!".settings".equals(location.segment(i)) || i == 0) {
+					continue;
+				}
+				IPath projectRoot = location.removeLastSegments(location.segmentCount() - i);
+				MetadataPath candidate = create(projectRoot, location.removeFirstSegments(i));
+				if (ProjectMetadataStore.isProjectMetadataRoot(candidate.projectRoot())) {
+					return candidate;
+				}
+			}
+
+			if (location.segmentCount() >= 2 && PROTECTED_METADATA_NAMES.contains(location.lastSegment())) {
+				return create(location.removeLastSegments(1), new Path(location.lastSegment()));
+			}
+			return null;
+		}
+
+		static MetadataPath forProjectRoot(IPath projectRoot) throws IOException {
+			return create(projectRoot, Path.EMPTY);
+		}
+
+		private static MetadataPath create(IPath projectRoot, IPath relativePath) throws IOException {
+			java.nio.file.Path canonicalRoot = projectRoot.toFile().getCanonicalFile().toPath();
+			IPath canonicalProjectRoot = Path.fromOSString(canonicalRoot.toString());
+			String projectIdentity = canonicalRoot.toUri().normalize().toString();
+			String projectKey = UUID.nameUUIDFromBytes(projectIdentity.getBytes(StandardCharsets.UTF_8)).toString();
+			IPath shadowRoot = JLSFsUtils.METADATA_FOLDER_PATH.append(SHADOW_FOLDER).append(projectKey);
+			return new MetadataPath(canonicalProjectRoot, relativePath, shadowRoot);
+		}
+	}
+}

--- a/org.eclipse.jdt.ls.tests/projects/maven/metadata-preservation/.classpath
+++ b/org.eclipse.jdt.ls.tests/projects/maven/metadata-preservation/.classpath
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- User-managed formatting and attributes in this file must remain byte-identical. -->
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="metadata.preservation.fixture" value="keep"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/org.eclipse.jdt.ls.tests/projects/maven/metadata-preservation/.project
+++ b/org.eclipse.jdt.ls.tests/projects/maven/metadata-preservation/.project
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This project description is deliberately user-managed and non-default. -->
+<projectDescription>
+	<name>metadata-preservation</name>
+	<comment>Keep this user-authored comment and formatting.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+	<filteredResources>
+		<filter>
+			<id>1723456789000</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>user-owned-output</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
+</projectDescription>

--- a/org.eclipse.jdt.ls.tests/projects/maven/metadata-preservation/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.jdt.ls.tests/projects/maven/metadata-preservation/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+# User-managed ordering and comments must be preserved.
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.problem.unusedPrivateMember=warning
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=17

--- a/org.eclipse.jdt.ls.tests/projects/maven/metadata-preservation/.settings/org.eclipse.m2e.core.prefs
+++ b/org.eclipse.jdt.ls.tests/projects/maven/metadata-preservation/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,5 @@
+# This file is intentionally not in m2e's canonical ordering.
+resolveWorkspaceProjects=true
+eclipse.preferences.version=1
+activeProfiles=
+version=1

--- a/org.eclipse.jdt.ls.tests/projects/maven/metadata-preservation/pom.xml
+++ b/org.eclipse.jdt.ls.tests/projects/maven/metadata-preservation/pom.xml
@@ -1,0 +1,25 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.sample</groupId>
+	<artifactId>metadata-preservation</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.15.0</version>
+				<configuration>
+					<release>17</release>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.18.0</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/org.eclipse.jdt.ls.tests/projects/maven/metadata-preservation/src/main/java/org/sample/DependencyUser.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/metadata-preservation/src/main/java/org/sample/DependencyUser.java
@@ -1,0 +1,12 @@
+package org.sample;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class DependencyUser {
+
+	private int unused;
+
+	public boolean accepts(String value) {
+		return StringUtils.isNotBlank(value);
+	}
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/filesystem/JLSFileSystemTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/filesystem/JLSFileSystemTest.java
@@ -1,0 +1,259 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.filesystem;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.apache.commons.io.FileUtils;
+import org.eclipse.core.filesystem.EFS;
+import org.eclipse.core.filesystem.IFileStore;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.jdt.ls.core.internal.IConstants;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class JLSFileSystemTest {
+
+	private static final String PRESERVE_PROJECT_METADATA = "java.import.preserveProjectMetadata";
+
+	private Path tempDirectory;
+	private IProject workspaceProject;
+	private final Set<Path> shadowRoots = new HashSet<>();
+	private String previousPreservationSetting;
+	private String previousRootMetadataMode;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		tempDirectory = Files.createTempDirectory("jls-metadata-preservation-");
+		IEclipsePreferences preferences = InstanceScope.INSTANCE.getNode(IConstants.PLUGIN_ID);
+		previousPreservationSetting = preferences.get(PRESERVE_PROJECT_METADATA, null);
+		preferences.remove(PRESERVE_PROJECT_METADATA);
+		previousRootMetadataMode = System.getProperty(JLSFsUtils.GENERATES_METADATA_FILES_AT_PROJECT_ROOT);
+	}
+
+	@Test
+	void preservesTheCompleteMetadataSnapshotBeforeTheFirstWrite() throws Exception {
+		Path projectRoot = tempDirectory.resolve("project");
+		Path projectFile = projectRoot.resolve(".project");
+		Path classpathFile = projectRoot.resolve(".classpath");
+		Path settingsFile = projectRoot.resolve(".settings/nested/custom.options");
+		byte[] projectBytes = "user project bytes\n".getBytes(StandardCharsets.UTF_8);
+		byte[] classpathBytes = "user classpath bytes\n".getBytes(StandardCharsets.UTF_8);
+		byte[] settingsBytes = "user settings bytes\n".getBytes(StandardCharsets.UTF_8);
+		Files.createDirectories(settingsFile.getParent());
+		Files.write(projectFile, projectBytes);
+		Files.write(classpathFile, classpathBytes);
+		Files.write(settingsFile, settingsBytes);
+		enablePreservation();
+
+		IFileStore projectStore = getStore(projectFile);
+		Files.writeString(classpathFile, "changed after the snapshot\n");
+		Files.writeString(settingsFile, "changed after the snapshot\n");
+
+		assertNotEquals(projectFile, localPath(projectStore));
+		assertArrayEquals(projectBytes, Files.readAllBytes(localPath(projectStore)));
+		assertArrayEquals(classpathBytes, Files.readAllBytes(localPath(getStore(classpathFile))));
+		assertArrayEquals(settingsBytes, Files.readAllBytes(localPath(getStore(settingsFile))));
+	}
+
+	@Test
+	void routesMissingMetadataToTheShadowWithoutCreatingItAtTheProjectRoot() throws Exception {
+		Path projectRoot = tempDirectory.resolve("project");
+		Path projectFile = projectRoot.resolve(".project");
+		Path classpathFile = projectRoot.resolve(".classpath");
+		Files.createDirectories(projectRoot);
+		Files.writeString(projectFile, "project bytes\n");
+		enablePreservation();
+
+		IFileStore classpathStore = getStore(classpathFile);
+		byte[] generatedBytes = "generated classpath\n".getBytes(StandardCharsets.UTF_8);
+		try (OutputStream output = classpathStore.openOutputStream(EFS.NONE, null)) {
+			output.write(generatedBytes);
+		}
+
+		assertFalse(Files.exists(classpathFile));
+		assertArrayEquals(generatedBytes, Files.readAllBytes(localPath(getStore(classpathFile))));
+	}
+
+	@Test
+	void protectsEverySettingsDescendant() throws Exception {
+		Path projectRoot = tempDirectory.resolve("project");
+		Path settingsDirectory = projectRoot.resolve(".settings");
+		Path nestedFile = settingsDirectory.resolve("nested/.settings/custom.options");
+		Path siblingFile = settingsDirectory.resolve("org.eclipse.jdt.core.prefs");
+		byte[] nestedBytes = "nested=true\n".getBytes(StandardCharsets.UTF_8);
+		byte[] siblingBytes = "sibling=true\n".getBytes(StandardCharsets.UTF_8);
+		Files.createDirectories(nestedFile.getParent());
+		Files.writeString(projectRoot.resolve(".project"), "project bytes\n");
+		Files.write(nestedFile, nestedBytes);
+		Files.write(siblingFile, siblingBytes);
+		enablePreservation();
+
+		IFileStore nestedStore = getStore(nestedFile);
+		byte[] updatedBytes = "nested=false\n".getBytes(StandardCharsets.UTF_8);
+		try (OutputStream output = nestedStore.openOutputStream(EFS.NONE, null)) {
+			output.write(updatedBytes);
+		}
+
+		assertArrayEquals(nestedBytes, Files.readAllBytes(nestedFile));
+		assertArrayEquals(updatedBytes, Files.readAllBytes(localPath(nestedStore)));
+		Path shadowSettings = localPath(getStore(settingsDirectory));
+		assertArrayEquals(siblingBytes, Files.readAllBytes(shadowSettings.resolve(siblingFile.getFileName())));
+	}
+
+	@Test
+	void routesEveryFileStoreEntryPointToTheSameShadow() throws Exception {
+		Path projectRoot = tempDirectory.resolve("project");
+		Path projectFile = projectRoot.resolve(".project");
+		Path classpathFile = projectRoot.resolve(".classpath");
+		Files.createDirectories(projectRoot);
+		Files.writeString(projectFile, "project bytes\n");
+		Files.writeString(classpathFile, "classpath bytes\n");
+		enablePreservation();
+
+		org.eclipse.core.runtime.IPath classpathPath = org.eclipse.core.runtime.Path.fromOSString(classpathFile.toString());
+		Path expected = localPath(new JLSFileSystem().getStore(classpathPath));
+		JLSFile projectStore = new JLSFile(projectRoot.toFile());
+
+		assertNotEquals(classpathFile, expected);
+		assertEquals(expected, localPath(projectStore.getChild(".classpath")));
+		assertEquals(expected, localPath(projectStore.getFileStore(new org.eclipse.core.runtime.Path(".classpath"))));
+	}
+
+	@Test
+	void routesTheFirstProjectDescriptionForARegisteredWorkspaceProject() throws Exception {
+		Path projectRoot = tempDirectory.resolve("project");
+		Files.createDirectories(projectRoot);
+		projectRoot = projectRoot.toRealPath();
+		Path projectFile = projectRoot.resolve(".project");
+		enablePreservation();
+
+		String projectName = "preserved-project-" + Long.toUnsignedString(System.nanoTime());
+		IProjectDescription description = ResourcesPlugin.getWorkspace().newProjectDescription(projectName);
+		description.setLocation(org.eclipse.core.runtime.Path.fromOSString(projectRoot.toString()));
+		workspaceProject = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
+		workspaceProject.create(description, new NullProgressMonitor());
+		workspaceProject.open(new NullProgressMonitor());
+
+		Path shadowProject = localPath(getStore(projectFile));
+		assertFalse(Files.exists(projectFile));
+		assertNotEquals(projectFile, shadowProject);
+		assertTrue(Files.readString(shadowProject).contains("<name>" + projectName + "</name>"));
+	}
+
+	@Test
+	void hidesAProtectedRootEntryAfterItIsDeletedFromTheShadow() throws Exception {
+		Path projectRoot = tempDirectory.resolve("project");
+		Path projectFile = projectRoot.resolve(".project");
+		Path classpathFile = projectRoot.resolve(".classpath");
+		Files.createDirectories(projectRoot);
+		Files.writeString(projectFile, "project bytes\n");
+		Files.writeString(classpathFile, "classpath bytes\n");
+		enablePreservation();
+
+		Files.delete(localPath(getStore(classpathFile)));
+		JLSFile projectStore = new JLSFile(projectRoot.toFile());
+
+		assertTrue(Files.exists(classpathFile));
+		assertFalse(Stream.of(projectStore.childNames(EFS.NONE, null)).anyMatch(".classpath"::equals));
+		assertFalse(Stream.of(projectStore.childInfos(EFS.NONE, null)).anyMatch(info -> ".classpath".equals(info.getName())));
+	}
+
+	@Test
+	void isolatesSameNamedProjectsByTheirRootLocation() throws Exception {
+		Path firstProject = tempDirectory.resolve("first/project");
+		Path secondProject = tempDirectory.resolve("second/project");
+		Path firstProjectFile = firstProject.resolve(".project");
+		Path secondProjectFile = secondProject.resolve(".project");
+		Files.createDirectories(firstProject);
+		Files.createDirectories(secondProject);
+		Files.writeString(firstProjectFile, "first project\n");
+		Files.writeString(secondProjectFile, "second project\n");
+		enablePreservation();
+
+		Path firstShadow = localPath(getStore(firstProjectFile));
+		Path secondShadow = localPath(getStore(secondProjectFile));
+
+		assertNotEquals(firstProjectFile, firstShadow);
+		assertNotEquals(secondProjectFile, secondShadow);
+		assertNotEquals(firstShadow, secondShadow);
+		assertArrayEquals("first project\n".getBytes(StandardCharsets.UTF_8), Files.readAllBytes(firstShadow));
+		assertArrayEquals("second project\n".getBytes(StandardCharsets.UTF_8), Files.readAllBytes(secondShadow));
+	}
+
+	private static void enablePreservation() {
+		System.setProperty(JLSFsUtils.GENERATES_METADATA_FILES_AT_PROJECT_ROOT, "true");
+		InstanceScope.INSTANCE.getNode(IConstants.PLUGIN_ID).putBoolean(PRESERVE_PROJECT_METADATA, true);
+	}
+
+	private IFileStore getStore(Path path) throws Exception {
+		IFileStore store = new JLSFileSystem().getStore(org.eclipse.core.runtime.Path.fromOSString(path.toString()));
+		Path redirectedPath = localPath(store);
+		if (!path.equals(redirectedPath)) {
+			Path shadowRoot = redirectedPath;
+			while (shadowRoot != null && !Files.isRegularFile(shadowRoot.resolve(".complete"))) {
+				shadowRoot = shadowRoot.getParent();
+			}
+			if (shadowRoot != null) {
+				shadowRoots.add(shadowRoot);
+			}
+		}
+		return store;
+	}
+
+	private static Path localPath(IFileStore store) throws Exception {
+		File file = store.toLocalFile(EFS.NONE, null);
+		assertNotNull(file);
+		return file.toPath();
+	}
+
+	@AfterEach
+	void cleanUp() throws Exception {
+		if (workspaceProject != null && workspaceProject.exists()) {
+			workspaceProject.delete(false, true, new NullProgressMonitor());
+		}
+		for (Path shadowRoot : shadowRoots) {
+			FileUtils.deleteDirectory(shadowRoot.toFile());
+		}
+		if (previousRootMetadataMode == null) {
+			System.clearProperty(JLSFsUtils.GENERATES_METADATA_FILES_AT_PROJECT_ROOT);
+		} else {
+			System.setProperty(JLSFsUtils.GENERATES_METADATA_FILES_AT_PROJECT_ROOT, previousRootMetadataMode);
+		}
+		IEclipsePreferences preferences = InstanceScope.INSTANCE.getNode(IConstants.PLUGIN_ID);
+		if (previousPreservationSetting == null) {
+			preferences.remove(PRESERVE_PROJECT_METADATA);
+		} else {
+			preferences.put(PRESERVE_PROJECT_METADATA, previousPreservationSetting);
+		}
+		FileUtils.deleteDirectory(tempDirectory.toFile());
+	}
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/filesystem/ProjectMetadataPreservationLifecycleTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/filesystem/ProjectMetadataPreservationLifecycleTest.java
@@ -1,0 +1,181 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.filesystem;
+
+import static org.eclipse.jdt.ls.core.internal.testing.ProjectMetadataAssertions.assertProjectMetadataEquals;
+import static org.eclipse.jdt.ls.core.internal.testing.ProjectMetadataAssertions.snapshotProjectMetadata;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.FileUtils;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.ls.core.internal.IConstants;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.JobHelpers;
+import org.eclipse.jdt.ls.core.internal.ResourceUtils;
+import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
+import org.eclipse.jdt.ls.core.internal.handlers.InitHandler;
+import org.eclipse.jdt.ls.core.internal.handlers.JDTLanguageServer;
+import org.eclipse.jdt.ls.core.internal.handlers.MapFlattener;
+import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+import org.eclipse.jdt.ls.core.internal.managers.StandardProjectsManager;
+import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
+import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
+import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.InitializedParams;
+import org.junit.jupiter.api.Test;
+
+public class ProjectMetadataPreservationLifecycleTest extends AbstractProjectsManagerBasedTest {
+
+	private static final String PROJECT_PATH = "maven/metadata-preservation";
+	private static final String PROJECT_NAME = "metadata-preservation";
+
+	private JDTLanguageServer server;
+
+	@Test
+	void preservesProjectMetadataAcrossImportUpdateAndRestart() throws Exception {
+		String previousMetadataAtProjectRoot = System.getProperty(JLSFsUtils.GENERATES_METADATA_FILES_AT_PROJECT_ROOT);
+		System.setProperty(JLSFsUtils.GENERATES_METADATA_FILES_AT_PROJECT_ROOT, "true");
+		PreferenceManager originalPreferenceManager = preferenceManager;
+		StandardProjectsManager originalProjectsManager = projectsManager;
+		IEclipsePreferences instancePreferences = InstanceScope.INSTANCE.getNode(IConstants.PLUGIN_ID);
+		String previousPreservationSetting = instancePreferences.get(Preferences.PRESERVE_PROJECT_METADATA, null);
+		String previousWorkspaceInitialized = instancePreferences.get(IConstants.WORKSPACE_INITIALIZED, null);
+		File projectDirectory = copyFiles(PROJECT_PATH, true);
+		Path projectRoot = projectDirectory.toPath();
+		Map<Path, byte[]> metadataBeforeImport = snapshotProjectMetadata(projectRoot);
+		Path shadowRoot = null;
+
+		try {
+			startServer(new PreferenceManager());
+			initialize(projectDirectory);
+			shadowRoot = Path.of(new JLSFileSystem().getStore(org.eclipse.core.runtime.Path.fromOSString(projectRoot.resolve(".project").toString())).toURI()).getParent();
+			assertFalse(projectRoot.toRealPath().equals(shadowRoot.toRealPath()));
+
+			IProject project = WorkspaceHelper.getProject(PROJECT_NAME);
+			assertNotNull(project);
+			IJavaProject javaProject = JavaCore.create(project);
+			assertNotNull(javaProject.findType("org.apache.commons.lang3.StringUtils"));
+			assertProjectMetadataEquals(metadataBeforeImport, projectRoot);
+
+			IFile pom = project.getFile("pom.xml");
+			String updatedPom = ResourceUtils.getContent(pom)
+					.replace("<groupId>org.apache.commons</groupId>", "<groupId>commons-codec</groupId>")
+					.replace("<artifactId>commons-lang3</artifactId>", "<artifactId>commons-codec</artifactId>")
+					.replace("<version>3.18.0</version>", "<version>1.20.0</version>");
+			ResourceUtils.setContent(pom, updatedPom);
+			projectsManager.updateProject(project, false);
+			waitForBackgroundJobs();
+
+			assertNull(javaProject.findType("org.apache.commons.lang3.StringUtils"));
+			assertNotNull(javaProject.findType("org.apache.commons.codec.binary.Base64"));
+			assertProjectMetadataEquals(metadataBeforeImport, projectRoot);
+
+			stopServer();
+			project.delete(IProject.FORCE | IProject.NEVER_DELETE_PROJECT_CONTENT, new NullProgressMonitor());
+			waitForBackgroundJobs();
+
+			startServer(new PreferenceManager());
+			initialize(projectDirectory);
+			project = WorkspaceHelper.getProject(PROJECT_NAME);
+			assertNotNull(project);
+			assertNotNull(JavaCore.create(project).findType("org.apache.commons.codec.binary.Base64"));
+			assertProjectMetadataEquals(metadataBeforeImport, projectRoot);
+		} finally {
+			try {
+				stopServer();
+			} finally {
+				try {
+					if (shadowRoot != null) {
+						FileUtils.deleteDirectory(shadowRoot.toFile());
+					}
+				} finally {
+					restore(instancePreferences, Preferences.PRESERVE_PROJECT_METADATA, previousPreservationSetting);
+					restore(instancePreferences, IConstants.WORKSPACE_INITIALIZED, previousWorkspaceInitialized);
+					restoreSystemProperty(JLSFsUtils.GENERATES_METADATA_FILES_AT_PROJECT_ROOT, previousMetadataAtProjectRoot);
+					preferenceManager = originalPreferenceManager;
+					JavaLanguageServerPlugin.setPreferencesManager(preferenceManager);
+					projectsManager = originalProjectsManager;
+				}
+			}
+		}
+	}
+
+	private void startServer(PreferenceManager manager) {
+		preferenceManager = manager;
+		JavaLanguageServerPlugin.setPreferencesManager(manager);
+		projectsManager = new StandardProjectsManager(manager);
+		server = new JDTLanguageServer(projectsManager, manager);
+		server.connectClient(client);
+		JavaLanguageServerPlugin.getInstance().setProtocol(server);
+	}
+
+	private void initialize(File projectDirectory) throws Exception {
+		InitializeParams params = new InitializeParams();
+		params.setCapabilities(new ClientCapabilities());
+		params.setRootUri(projectDirectory.toURI().toString());
+		params.setInitializationOptions(Map.of(InitHandler.SETTINGS_KEY, preservationConfiguration()));
+		server.initialize(params).get(60, TimeUnit.SECONDS);
+		server.initialized(new InitializedParams());
+		JobHelpers.waitForJobs(JDTLanguageServer.JAVA_LSP_INITIALIZE_WORKSPACE, monitor);
+		waitForBackgroundJobs();
+		assertTrue(preferenceManager.getPreferences().isPreserveProjectMetadata());
+	}
+
+	private static Map<String, Object> preservationConfiguration() {
+		Map<String, Object> configuration = new HashMap<>();
+		MapFlattener.setValue(configuration, Preferences.PRESERVE_PROJECT_METADATA, true);
+		return configuration;
+	}
+
+	private void stopServer() throws Exception {
+		if (server == null) {
+			return;
+		}
+		server.shutdown().get(60, TimeUnit.SECONDS);
+		server.disconnectClient();
+		projectsManager.unregisterListeners();
+		waitForBackgroundJobs();
+		server = null;
+		JavaLanguageServerPlugin.getInstance().setProtocol(null);
+	}
+
+	private static void restore(IEclipsePreferences preferences, String key, String value) {
+		if (value == null) {
+			preferences.remove(key);
+		} else {
+			preferences.put(key, value);
+		}
+	}
+
+	private static void restoreSystemProperty(String key, String value) {
+		if (value == null) {
+			System.clearProperty(key);
+		} else {
+			System.setProperty(key, value);
+		}
+	}
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServerTest.java
@@ -30,6 +30,9 @@ import org.eclipse.core.resources.IWorkspaceDescription;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.jdt.ls.core.internal.IConstants;
 import org.eclipse.jdt.ls.core.internal.JavaClientConnection.JavaLanguageClient;
 import org.eclipse.jdt.ls.core.internal.JobHelpers;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
@@ -103,6 +106,30 @@ public class JDTLanguageServerTest {
 			assertFalse(isAutoBuilding(), "Autobuilding is on");
 		} finally {
 			ProjectsManager.setAutoBuilding(enabled);
+		}
+	}
+
+	@Test
+	public void testPreserveProjectMetadataConfiguration() {
+		IEclipsePreferences store = InstanceScope.INSTANCE.getNode(IConstants.PLUGIN_ID);
+		String previousValue = store.get(Preferences.PRESERVE_PROJECT_METADATA, null);
+		try {
+			Map<String, Object> configuration = new HashMap<>();
+			configuration.put(Preferences.PRESERVE_PROJECT_METADATA, true);
+			server.didChangeConfiguration(new DidChangeConfigurationParams(configuration));
+			assertTrue(prefManager.getPreferences().isPreserveProjectMetadata());
+			assertTrue(store.getBoolean(Preferences.PRESERVE_PROJECT_METADATA, false));
+
+			configuration.put(Preferences.PRESERVE_PROJECT_METADATA, false);
+			server.didChangeConfiguration(new DidChangeConfigurationParams(configuration));
+			assertFalse(prefManager.getPreferences().isPreserveProjectMetadata());
+			assertFalse(store.getBoolean(Preferences.PRESERVE_PROJECT_METADATA, true));
+		} finally {
+			if (previousValue == null) {
+				store.remove(Preferences.PRESERVE_PROJECT_METADATA);
+			} else {
+				store.put(Preferences.PRESERVE_PROJECT_METADATA, previousValue);
+			}
 		}
 	}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/PreferencesTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/PreferencesTest.java
@@ -90,6 +90,20 @@ public class PreferencesTest {
 	}
 
 	@Test
+	public void testPreserveProjectMetadataPreference() {
+		assertFalse(new Preferences().isPreserveProjectMetadata());
+
+		Map<String, Object> configuration = new HashMap<>();
+		MapFlattener.setValue(configuration, Preferences.PRESERVE_PROJECT_METADATA, true);
+		Preferences configured = Preferences.createFrom(configuration);
+		assertTrue(configured.isPreserveProjectMetadata());
+
+		Preferences partiallyUpdated = Preferences.updateFrom(configured, Map.of());
+		assertTrue(partiallyUpdated.isPreserveProjectMetadata());
+		assertTrue(configured.clone().isPreserveProjectMetadata());
+	}
+
+	@Test
 	public void testPartialUpdatePreservesExistingValues() {
 		// Create initial preferences with full configuration
 		Map<String, Object> initialConfig = new HashMap<>();

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/testing/ProjectMetadataAssertions.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/testing/ProjectMetadataAssertions.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.testing;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.jdt.core.IJavaProject;
+
+public final class ProjectMetadataAssertions {
+
+	private ProjectMetadataAssertions() {
+	}
+
+	public static Map<Path, byte[]> snapshotProjectMetadata(Path projectRoot) throws IOException {
+		Map<Path, byte[]> snapshot = new LinkedHashMap<>();
+		try (Stream<Path> paths = Files.walk(projectRoot)) {
+			for (Path path : paths.filter(Files::isRegularFile).sorted().collect(Collectors.toList())) {
+				Path relativePath = projectRoot.relativize(path);
+				if (isProtectedMetadataPath(relativePath)) {
+					snapshot.put(relativePath, Files.readAllBytes(path));
+				}
+			}
+		}
+		return snapshot;
+	}
+
+	public static void assertProjectMetadataEquals(Map<Path, byte[]> expected, Path projectRoot) throws IOException {
+		Map<Path, byte[]> actual = snapshotProjectMetadata(projectRoot);
+		assertEquals(expected.keySet(), actual.keySet(), "Project-root metadata inventory changed");
+		for (Path path : expected.keySet()) {
+			assertArrayEquals(expected.get(path), actual.get(path), path + " changed");
+		}
+	}
+
+	private static boolean isProtectedMetadataPath(Path relativePath) {
+		if (relativePath.getNameCount() == 0) {
+			return false;
+		}
+		String topLevelName = relativePath.getName(0).toString();
+		if (".settings".equals(topLevelName)) {
+			return true;
+		}
+		return relativePath.getNameCount() == 1 && (IProjectDescription.DESCRIPTION_FILE_NAME.equals(topLevelName)
+				|| IJavaProject.CLASSPATH_FILE_NAME.equals(topLevelName));
+	}
+}


### PR DESCRIPTION
## Summary

- add the opt-in `java.import.preserveProjectMetadata` setting
- preserve existing `.project`, `.classpath`, and `.settings/**` files by routing language-server writes to a private overlay keyed by canonical project location
- keep the private overlay stable across server restarts while leaving root metadata byte-for-byte unchanged across import and project updates
- cover preference propagation, filesystem routing/enumeration, and the import/update/restart lifecycle with focused tests

## Testing

- `JAVA_HOME=<jdk-21> ./mvnw clean test-compile -Declipse.jdt.ls.skipGradleChecksums=true -DskipTests`
  - passed across all eight reactor modules, including compilation of all 233 test sources
- focused Tycho verification on JDK 21, using `-P=-macosx-jvm-flags -Dos.testArgs=-XstartOnFirstThread` as the local workaround until #3869 lands
  - `JLSFileSystemTest`: 7 passed
  - `PreferencesTest`: 18 passed
  - `JDTLanguageServerTest`: 4 passed (using the Mockito agent because runtime self-attachment is unavailable locally)
  - `ProjectMetadataPreservationLifecycleTest`: 1 passed
  - total: 30 tests, 0 failures or errors
- `git diff --check upstream/main...HEAD`
  - passed
