### PR TITLE
Remove obsolete macOS launching test dependency

### DIFF
--- a/org.eclipse.jdt.ls.tests/pom.xml
+++ b/org.eclipse.jdt.ls.tests/pom.xml
@@ -123,26 +123,6 @@
 			<properties>
 				<os.testArgs>-XstartOnFirstThread</os.testArgs>
 			</properties>
-			<build>
-				<pluginManagement>
-					<plugins>
-						<plugin>
-							<groupId>org.eclipse.tycho</groupId>
-							<artifactId>tycho-surefire-plugin</artifactId>
-							<version>${tycho-version}</version>
-							<configuration>
-								<dependencies>
-									<dependency>
-										<artifactId>org.eclipse.jdt.launching.macosx</artifactId>
-										<version>0.0.0</version>
-										<type>eclipse-plugin</type>
-									</dependency>
-								</dependencies>
-							</configuration>
-						</plugin>
-					</plugins>
-				</pluginManagement>
-			</build>
 		</profile>
 	</profiles>
 </project>


### PR DESCRIPTION
## Summary

- remove the obsolete `org.eclipse.jdt.launching.macosx` Tycho test dependency on macOS
- keep `-XstartOnFirstThread` for macOS test launches
- rely on `org.eclipse.jdt.launching`, which the test bundle already requires

Eclipse JDT Debug [inlined the standalone macOS bundle into `org.eclipse.jdt.launching`](https://github.com/eclipse-jdt/eclipse.jdt.debug/commit/39cd9acaa9f9e7ffa42085f38687b153262b03d6). The old installable unit is no longer published in the Eclipse 4.41 target, so explicitly requesting it prevents the test runtime from resolving.

## Testing

- `JAVA_HOME=<JDK 21> ./mvnw -pl '!org.eclipse.jdt.ls.product,!org.eclipse.jdt.ls.tests.syntaxserver' verify -Dtest=org.eclipse.jdt.ls.core.internal.preferences.PreferencesTest -Declipse.jdt.ls.skipGradleChecksums=true`
- 17 tests run, 0 failures, 0 errors
