### PR TITLE
Add enum type declaration snippet completion

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetCompletionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetCompletionProposal.java
@@ -85,9 +85,11 @@ public class SnippetCompletionProposal extends CompletionProposal {
 	private static final String CLASS_SNIPPET_LABEL = "class";
 	private static final String INTERFACE_SNIPPET_LABEL = "interface";
 	private static final String RECORD_SNIPPET_LABEL = "record";
+	private static final String ENUM_SNIPPET_LABEL = "enum";
 	private static final String CLASS_KEYWORD = "class";
 	private static final String INTERFACE_KEYWORD = "interface";
 	private static final String RECORD_KEYWORD = "record";
+	private static final String ENUM_KEYWORD = "enum";
 	private static final String INTERFACE_METHOD_SNIPPET = "$${1|public,private|} $${2:void} $${3:name}($${4});";
 
 	private static String PACKAGEHEADER = "package_header";
@@ -472,13 +474,15 @@ public class SnippetCompletionProposal extends CompletionProposal {
 		boolean isInterfacePrefix = true;
 		boolean isClassPrefix = true;
 		boolean isRecordPrefix = true;
+		boolean isEnumPrefix = true;
 		if (completionToken != null && completionToken.length > 0) {
 			String prefix = new String(completionToken);
 			isInterfacePrefix = INTERFACE_KEYWORD.startsWith(prefix);
 			isClassPrefix = CLASS_KEYWORD.startsWith(prefix);
 			isRecordPrefix = RECORD_KEYWORD.startsWith(prefix);
+			isEnumPrefix = ENUM_KEYWORD.startsWith(prefix);
 		}
-		if (!isInterfacePrefix && !isClassPrefix && !isRecordPrefix) {
+		if (!isInterfacePrefix && !isClassPrefix && !isRecordPrefix && !isEnumPrefix) {
 			return Collections.emptyList();
 		}
 		if (monitor == null) {
@@ -510,6 +514,12 @@ public class SnippetCompletionProposal extends CompletionProposal {
 			CompletionItem recordSnippet = getRecordSnippet(scc, monitor);
 			if (recordSnippet != null) {
 				res.add(recordSnippet);
+			}
+		}
+		if (isEnumPrefix) {
+			CompletionItem enumSnippet = getEnumSnippet(scc, monitor);
+			if (enumSnippet != null) {
+				res.add(enumSnippet);
 			}
 		}
 
@@ -633,6 +643,32 @@ public class SnippetCompletionProposal extends CompletionProposal {
 			return null;
 		}
 		return recordSnippet;
+	}
+
+	private static CompletionItem getEnumSnippet(SnippetCompletionContext scc, IProgressMonitor monitor) {
+		ICompilationUnit cu = scc.getCompilationUnit();
+		if (!accept(cu, scc.getCompletionContext(), false)) {
+			return null;
+		}
+		if (monitor.isCanceled()) {
+			return null;
+		}
+		final CompletionItem enumSnippet = new CompletionItem();
+		enumSnippet.setFilterText(ENUM_SNIPPET_LABEL);
+		enumSnippet.setLabel(ENUM_SNIPPET_LABEL);
+		enumSnippet.setSortText(SortTextHelper.convertRelevance(0));
+
+		try {
+			CodeGenerationTemplate template = (scc.needsPublic(monitor)) ? CodeGenerationTemplate.ENUMSNIPPET_PUBLIC : CodeGenerationTemplate.ENUMSNIPPET_DEFAULT;
+			enumSnippet.setInsertText(getSnippetContent(scc, template, true));
+			if (isCompletionListItemDefaultsSupport()) {
+				enumSnippet.setTextEditText(getSnippetContent(scc, template, true));
+			}
+		} catch (CoreException e) {
+			JavaLanguageServerPlugin.log(e.getStatus());
+			return null;
+		}
+		return enumSnippet;
 	}
 
 	private static void setFields(CompletionItem ci, ICompilationUnit cu, CompletionItemDefaults completionItemDefaults) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/CodeGenerationTemplate.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/CodeGenerationTemplate.java
@@ -232,7 +232,23 @@ public enum CodeGenerationTemplate {
 	RECORDSNIPPET_DEFAULT(
 			CodeTemplatePreferences.CODETEMPLATE_CODESNIPPET,
 			CodeTemplatePreferences.RECORDSNIPPET_CONTEXTTYPE,
-			CodeTemplatePreferences.CODETEMPLATE_RECORDSNIPPET_DEFAULT);
+			CodeTemplatePreferences.CODETEMPLATE_RECORDSNIPPET_DEFAULT),
+
+	/**
+	 * Snippet `public enum` content template
+	 */
+	ENUMSNIPPET_PUBLIC(
+			CodeTemplatePreferences.CODETEMPLATE_CODESNIPPET,
+			CodeTemplatePreferences.ENUMSNIPPET_CONTEXTTYPE,
+			CodeTemplatePreferences.CODETEMPLATE_ENUMSNIPPET_PUBLIC),
+
+	/**
+	 * Snippet `enum` content template
+	 */
+	ENUMSNIPPET_DEFAULT(
+			CodeTemplatePreferences.CODETEMPLATE_CODESNIPPET,
+			CodeTemplatePreferences.ENUMSNIPPET_CONTEXTTYPE,
+			CodeTemplatePreferences.CODETEMPLATE_ENUMSNIPPET_DEFAULT);
 
 
 	private final String preferenceId;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/CodeTemplatePreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/CodeTemplatePreferences.java
@@ -161,6 +161,8 @@ public class CodeTemplatePreferences {
 
 	public static final String RECORDSNIPPET_CONTEXTTYPE = "recordsnippet_context"; //$NON-NLS-1$
 
+	public static final String ENUMSNIPPET_CONTEXTTYPE = "enumsnippet_context"; //$NON-NLS-1$
+
 	/**
 	 * Default value for new type
 	 */
@@ -300,6 +302,14 @@ public class CodeTemplatePreferences {
 	 * Default value for public record snippet body content
 	 */
 	public static final String CODETEMPLATE_RECORDSNIPPET_PUBLIC = "${filecomment}${package_header}${typecomment}public record ${type_name}(${cursor}) {\n}";
+	/**
+	 * Default value for enum snippet body content
+	 */
+	public static final String CODETEMPLATE_ENUMSNIPPET_DEFAULT = "${filecomment}${package_header}enum ${type_name} {\n\n\t${cursor}\n}";
+	/**
+	 * Default value for public enum snippet body content
+	 */
+	public static final String CODETEMPLATE_ENUMSNIPPET_PUBLIC = "${filecomment}${package_header}${typecomment}public enum ${type_name} {\n\n\t${cursor}\n}";
 
 	public static class Month extends SimpleTemplateVariableResolver {
 		public Month() {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
@@ -129,7 +129,8 @@ public class PreferenceManager {
 		for (String contextTypeId : List.of(
 				CodeTemplatePreferences.CLASSSNIPPET_CONTEXTTYPE,
 				CodeTemplatePreferences.INTERFACESNIPPET_CONTEXTTYPE,
-				CodeTemplatePreferences.RECORDSNIPPET_CONTEXTTYPE)) {
+				CodeTemplatePreferences.RECORDSNIPPET_CONTEXTTYPE,
+				CodeTemplatePreferences.ENUMSNIPPET_CONTEXTTYPE)) {
 			CodeTemplateContextType contextType = new CodeTemplateContextType(contextTypeId);
 			contextType.addResolver(new CodeTemplateVariableResolver(CodeTemplateContextType.FILE_COMMENT, JavaManipulationMessages.CodeTemplateContextType_variable_description_filecomment));
 			registry.addContextType(contextType);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -1545,6 +1545,21 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 	}
 
 	@Test
+	public void testSnippet_enum_with_package_packagePrivate() throws JavaModelException {
+		preferences.setPreferPackagePrivateVisibility(true);
+		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java", "package org.sample;\n");
+		CompletionList list = requestCompletions(unit, "package org.sample;\n");
+
+		assertNotNull(list);
+		CompletionItem item = list.getItems().stream()
+				.filter(i -> "enum".equals(i.getLabel()) && i.getKind() == CompletionItemKind.Snippet)
+				.findFirst().orElse(null);
+		assertNotNull(item);
+		String te = item.getInsertText();
+		assertEquals("enum Test {\n\n\t${0}\n}", te);
+	}
+
+	@Test
 	public void testSnippet_inner_class_itemDefaults_enabled_type_definition() throws JavaModelException {
 		mockClientPreferences(true, true, true);
 		when(preferenceManager.getClientPreferences().getCompletionItemInsertTextModeDefault()).thenReturn(InsertTextMode.AsIs);
@@ -1677,6 +1692,37 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertEquals("record", item.getLabel());
 		String te = item.getInsertText();
 		assertEquals("/**\n * Test\n */\npublic record Test(${0}) {\n}", te);
+	}
+
+	@Test
+	public void testSnippet_enum() throws JavaModelException {
+		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java", "");
+		CompletionList list = requestCompletions(unit, "");
+
+		assertNotNull(list);
+		CompletionItem item = list.getItems().stream()
+				.filter(i -> "enum".equals(i.getLabel()) && i.getKind() == CompletionItemKind.Snippet)
+				.findFirst().orElse(null);
+		assertNotNull(item);
+		String te = item.getInsertText();
+		assertEquals("package org.sample;\n\n/**\n * Test\n */\npublic enum Test {\n\n\t${0}\n}", ResourceUtils.dos2Unix(te));
+
+		//check resolution doesn't blow up (https://github.com/eclipse/eclipse.jdt.ls/issues/675)
+		assertSame(item, server.resolveCompletionItem(item).join());
+	}
+
+	@Test
+	public void testSnippet_enum_with_package() throws JavaModelException {
+		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java", "package org.sample;\n");
+		CompletionList list = requestCompletions(unit, "package org.sample;\n");
+
+		assertNotNull(list);
+		CompletionItem item = list.getItems().stream()
+				.filter(i -> "enum".equals(i.getLabel()) && i.getKind() == CompletionItemKind.Snippet)
+				.findFirst().orElse(null);
+		assertNotNull(item);
+		String te = item.getInsertText();
+		assertEquals("/**\n * Test\n */\npublic enum Test {\n\n\t${0}\n}", te);
 	}
 
 	@Disabled("When running tests, in SnippetCompletionProposal.getSnippetContent(), cu.getAllTypes() returns en empty array, so inner record name is not computed")


### PR DESCRIPTION
## Summary
- add enum to type declaration snippet completions alongside class, interface, and record
- register enum snippet templates for public and package-private visibility
- add completion handler tests for enum snippets with and without package declarations

## Testing
- ./mvnw -pl org.eclipse.jdt.ls.filesystem,org.eclipse.jdt.ls.core,org.eclipse.jdt.ls.tests -am '-Dtest=CompletionHandlerTest#testSnippet_enum+testSnippet_enum_with_package+testSnippet_enum_with_package_packagePrivate' test