### PR TITLE
Add the ability to set JDT Classpath variables

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2021 Red Hat Inc. and others.
+ * Copyright (c) 2016-2026 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -36,6 +36,8 @@ import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.ls.core.internal.JavaClientConnection;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.JobHelpers;
@@ -261,6 +263,9 @@ final public class InitHandler extends BaseInitHandler {
 				if (preferences.isImportGradleEnabled()) {
 					WrapperValidator.putSha256(preferences.getGradleWrapperList());
 				}
+				if (!preferences.getClasspathVariables().isEmpty()) {
+					initializeClasspathVariables(preferences);
+				}
 				Runnable resetBuildState = () -> {
 				};
 				try {
@@ -307,4 +312,13 @@ final public class InitHandler extends BaseInitHandler {
 		job.schedule();
 	}
 
+	private void initializeClasspathVariables(Preferences prefs) {
+		for (Map.Entry<String, IPath> entry : prefs.getClasspathVariables().entrySet()) {
+			try {
+				JavaCore.setClasspathVariable(entry.getKey(), entry.getValue(), new NullProgressMonitor());
+			} catch (JavaModelException e) {
+				JavaLanguageServerPlugin.logException(e);
+			}
+		}
+	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectsManager.java
@@ -32,6 +32,7 @@ import java.util.Hashtable;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
@@ -402,6 +403,23 @@ public class StandardProjectsManager extends ProjectsManager {
 		}
 	}
 
+	public void configureClasspathVariables(Preferences oldPrefs, Preferences newPrefs, IProgressMonitor monitor) throws CoreException {
+		Map<String, IPath> oldClasspathVariables = oldPrefs.getClasspathVariables();
+		Map<String, IPath> newClasspathVariables = newPrefs.getClasspathVariables();
+		for (Entry<String, IPath> entry : newClasspathVariables.entrySet()) {
+			IPath prefValue = entry.getValue();
+			IPath oldPrefValue = oldClasspathVariables.get(entry.getKey());
+			if (!prefValue.equals(oldPrefValue)) {
+				JavaCore.setClasspathVariable(entry.getKey(), prefValue, monitor);
+			}
+		}
+		for (String key : oldClasspathVariables.keySet()) {
+			if (!newClasspathVariables.containsKey(key)) {
+				JavaCore.removeClasspathVariable(key, monitor);
+			}
+		}
+	}
+
 	private static void initializeDefaultOptions(Preferences preferences) {
 		Hashtable<String, String> defaultOptions = JavaCore.getDefaultOptions();
 		IVMInstall defaultVM = JavaRuntime.getDefaultVMInstall();
@@ -649,6 +667,13 @@ public class StandardProjectsManager extends ProjectsManager {
 					if (!Objects.equals(oldPreferences.getResourceFilters(), newPreferences.getResourceFilters())) {
 						try {
 							configureFilters(new NullProgressMonitor());
+						} catch (CoreException e) {
+							JavaLanguageServerPlugin.logException(e.getMessage(), e);
+						}
+					}
+					if (!Objects.equals(oldPreferences.getClasspathVariables(), newPreferences.getClasspathVariables())) {
+						try {
+							configureClasspathVariables(oldPreferences, newPreferences, new NullProgressMonitor());
 						} catch (CoreException e) {
 							JavaLanguageServerPlugin.logException(e.getMessage(), e);
 						}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectsManager.java
@@ -391,6 +391,18 @@ public class StandardProjectsManager extends ProjectsManager {
 		if (!Objects.equals(javaOptions, JavaCore.getOptions())) {
 			JavaCore.setOptions(javaOptions);
 		}
+		if (preferences.getClasspathVariables() != null && !preferences.getClasspathVariables().isEmpty()) {
+			for (Entry<String, IPath> entry : preferences.getClasspathVariables().entrySet()) {
+				IPath corePath = JavaCore.getClasspathVariable(entry.getKey());
+				if (!entry.getValue().equals(corePath)) {
+					try {
+						JavaCore.setClasspathVariable(entry.getKey(), entry.getValue(), new NullProgressMonitor());
+					} catch (JavaModelException e) {
+						JavaLanguageServerPlugin.logException(e.getMessage(), e);
+					}
+				}
+			}
+		}
 		if (cleanWorkspace && preferences.isAutobuildEnabled()) {
 			new WorkspaceJob("Clean workspace...") {
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectsManager.java
@@ -391,18 +391,6 @@ public class StandardProjectsManager extends ProjectsManager {
 		if (!Objects.equals(javaOptions, JavaCore.getOptions())) {
 			JavaCore.setOptions(javaOptions);
 		}
-		if (preferences.getClasspathVariables() != null && !preferences.getClasspathVariables().isEmpty()) {
-			for (Entry<String, IPath> entry : preferences.getClasspathVariables().entrySet()) {
-				IPath corePath = JavaCore.getClasspathVariable(entry.getKey());
-				if (!entry.getValue().equals(corePath)) {
-					try {
-						JavaCore.setClasspathVariable(entry.getKey(), entry.getValue(), new NullProgressMonitor());
-					} catch (JavaModelException e) {
-						JavaLanguageServerPlugin.logException(e.getMessage(), e);
-					}
-				}
-			}
-		}
 		if (cleanWorkspace && preferences.isAutobuildEnabled()) {
 			new WorkspaceJob("Clean workspace...") {
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -162,6 +162,12 @@ public class Preferences {
 	 */
 	public static final String JAVA_RESOURCE_FILTERS = "java.project.resourceFilters";
 	public static final List<String> JAVA_RESOURCE_FILTERS_DEFAULT;
+
+	/**
+	 * Specifies classpath variables to use in resolving the classpath
+	 */
+	public static final String JAVA_CLASSPATH_VARIABLES = "java.classpath.variables";
+
 	/**
 	 * Preference key for Show quickfixes at the problem or line level.
 	 */
@@ -740,6 +746,8 @@ public class Preferences {
 	private int staticImportOnDemandThreshold;
 	private Set<RuntimeEnvironment> runtimes = new HashSet<>();
 	private List<String> resourceFilters;
+	private List<String> classpathVarList;
+	private Map<String, IPath> classpathVariables;
 
 	private List<String> fileHeaderTemplate = new LinkedList<>();
 	private List<String> typeCommentTemplate = new LinkedList<>();
@@ -1014,6 +1022,8 @@ public class Preferences {
 		staticImportOnDemandThreshold = IMPORTS_STATIC_ONDEMANDTHRESHOLD_DEFAULT;
 		referencedLibraries = JAVA_PROJECT_REFERENCED_LIBRARIES_DEFAULT;
 		resourceFilters = JAVA_RESOURCE_FILTERS_DEFAULT;
+		classpathVarList = Collections.emptyList();
+		classpathVariables = Collections.emptyMap();
 		includeAccessors = true;
 		smartSemicolonDetection = false;
 		includeDecompiledSources = true;
@@ -1669,6 +1679,11 @@ public class Preferences {
 			prefs.setResourceFilters(resourceFilters);
 		}
 
+		if (containsKey(configuration, JAVA_CLASSPATH_VARIABLES)) {
+			List<String> classPaths = getList(configuration, JAVA_CLASSPATH_VARIABLES, existing.classpathVarList);
+			prefs.setClasspathVariables(classPaths);
+		}
+
 		if (containsKey(configuration, JAVA_FORMATTER_PROFILE_NAME)) {
 			String formatterProfileName = getString(configuration, JAVA_FORMATTER_PROFILE_NAME);
 			prefs.setFormatterProfileName(formatterProfileName);
@@ -2086,6 +2101,33 @@ public class Preferences {
 		return this;
 	}
 
+	public Preferences setClasspathVariables(List<String> classpathVariables) {
+		if (classpathVariables != null) {
+			this.classpathVarList = classpathVariables;
+			this.classpathVariables = classpathVariables.stream().filter((resource) -> {
+				// ensure we have at least name= and there is only one equal sign and that value is valid IPath
+				if (resource.length() > 0) {
+					int index = resource.indexOf('=');
+					if (index > 0) {
+						int index2 = resource.indexOf('=', index + 1);
+						if (index2 < 0) {
+							IPath path = IPath.fromOSString(resource.substring(index + 1));
+							if (path.isValidPath(path.toOSString())) {
+								return true;
+							}
+						}
+					}
+				}
+				JavaLanguageServerPlugin.logInfo("Invalid preference: " + Preferences.JAVA_CLASSPATH_VARIABLES + "=" + resource);
+				return false;
+			}).collect(Collectors.toMap(value -> value.substring(0, value.indexOf('=')), value -> IPath.fromOSString(value.substring(value.indexOf('=') + 1))));
+		} else {
+			this.classpathVariables = Collections.emptyMap();
+			this.classpathVarList = Collections.emptyList();
+		}
+		return this;
+	}
+
 	public Preferences setJavaFormatComments(boolean javaFormatComments) {
 		this.javaFormatComments = javaFormatComments;
 		return this;
@@ -2479,6 +2521,10 @@ public class Preferences {
 
 	public List<String> getResourceFilters() {
 		return resourceFilters;
+	}
+
+	public Map<String, IPath> getClasspathVariables() {
+		return classpathVariables;
 	}
 
 	public String getFormatterProfileName() {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManagerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManagerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2022 Red Hat Inc. and others.
+ * Copyright (c) 2016-2026 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -34,6 +34,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.core.internal.resources.Resource;
@@ -228,6 +229,30 @@ public class ProjectsManagerTest extends AbstractProjectsManagerBasedTest {
 		IProject project = getProject(name);
 		assertIsJavaProject(project);
 		assertNoErrors(project);
+	}
+
+	@Test
+	public void testClasspathVariables() throws Exception {
+		Map<String, IPath> classpathVariables = preferenceManager.getPreferences().getClasspathVariables();
+		assertTrue(classpathVariables.isEmpty());
+		try {
+			String name = "salut";
+			importProjects("maven/" + name);
+			IProject project = getProject(name);
+			assertIsJavaProject(project);
+			preferenceManager.getPreferences().setClasspathVariables(Arrays.asList("var1=/home/user1", "var2=/home/user2"));
+			Map<String, IPath> classpathVariables2 = preferenceManager.getPreferences().getClasspathVariables();
+			assertEquals(classpathVariables2.get("var1"), IPath.fromOSString("/home/user1"));
+			assertEquals(classpathVariables2.get("var2"), IPath.fromOSString("/home/user2"));
+			assertEquals(classpathVariables2.get("var3"), null);
+			preferenceManager.getPreferences().setClasspathVariables(null);
+			classpathVariables2 = preferenceManager.getPreferences().getClasspathVariables();
+			assertEquals(classpathVariables2.get("var1"), null);
+			assertEquals(classpathVariables2.get("var2"), null);
+			assertEquals(classpathVariables2.get("var3"), null);
+		} finally {
+			preferenceManager.getPreferences().setClasspathVariables(null);
+		}
 	}
 
 	@Test


### PR DESCRIPTION
- add new JAVA_CLASS_PATH_VARIABLES preference to Preferences class which is entered by the user in name=value strings
- add new Preferences.setClasspathVariables() method which takes an array of name=value strings and creates a Map<String, IPath>
- add check in StandardProjectsManager preference change listener to look for changes in the classpath preferences and call the configureClasspathVariables method to set and remove JavaCore classpath variables
- add new test to ProjectsManagerTest
- for #3860