### PR TITLE
Fix early log messages not being filtered (#3541)

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/LogReader.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/LogReader.java
@@ -440,6 +440,22 @@ public class LogReader {
 			children.add(child);
 		}
 
+		public void setSeverity(int severity) {
+			this.severity = severity;
+		}
+
+		public void setDate(Date date) {
+			this.fDate = date;
+		}
+
+		public void setPluginId(String pluginId) {
+			this.pluginId = pluginId;
+		}
+
+		public String getPluginId() {
+			return pluginId;
+		}
+
 		public Date getDate() {
 			return fDate;
 		}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DefaultLogFilter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DefaultLogFilter.java
@@ -14,8 +14,8 @@ package org.eclipse.jdt.ls.core.internal.handlers;
 
 import java.util.function.Predicate;
 
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jdt.core.manipulation.JavaManipulation;
+import org.eclipse.jdt.ls.core.internal.LogReader.LogEntry;
 
 /**
  * Default Log filter. Excludes the following messages from being logged to the
@@ -27,31 +27,31 @@ import org.eclipse.jdt.core.manipulation.JavaManipulation;
  * @author Fred Bricon
  *
  */
-public class DefaultLogFilter implements Predicate<IStatus> {
+public class DefaultLogFilter implements Predicate<LogEntry> {
 
 	private static final String MISSING_RESOURCE_FILTER_TYPE = "Missing resource filter type";
-	
+
 	private static final String AST_CREATION_ERROR = "Exception occurred during compilation unit conversion";
 
 	@Override
-	public boolean test(IStatus status) {
+	public boolean test(LogEntry entry) {
 
-		String message = getMessage(status);
+		String message = getMessage(entry);
 		// Checking for status messages is a bit weak, since it could still change in theory (although highly unlikely)
 		// and might fail in case of I18n'ed messages
-		if (message == null || message.startsWith(MISSING_RESOURCE_FILTER_TYPE) 
+		if (message == null || message.startsWith(MISSING_RESOURCE_FILTER_TYPE)
 				// Hack to silence errors logged in CoreASTProvider.getAST()
 				// See https://github.com/eclipse/eclipse.jdt.ls/issues/2608
 				// See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/317
 				|| message.startsWith(AST_CREATION_ERROR)
-				|| JavaManipulation.ID_PLUGIN.equals(status.getPlugin())) {
+				|| JavaManipulation.ID_PLUGIN.equals(entry.getPluginId())) {
 			return false;
 		}
 		return true;
 	}
 
-	private String getMessage(IStatus status) {
-		return status == null ? null : status.getMessage();
+	private String getMessage(LogEntry entry) {
+		return entry == null ? null : entry.getMessage();
 	}
 
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/LogHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/LogHandler.java
@@ -51,14 +51,14 @@ public class LogHandler {
 	 * <p>Clients who load the LS in same process can override the default log handler.
 	 * This usually needs to be done very early, before the language server starts.</p>
 	 */
-	public static Predicate<IStatus> defaultLogFilter = new DefaultLogFilter();
+	public static Predicate<LogEntry> defaultLogFilter = new DefaultLogFilter();
 	private static final String JAVA_ERROR_LOG = "java.ls.error";
 
 	private ILogListener logListener;
 	private DateFormat dateFormat;
 	private int logLevelMask;
 	private JavaClientConnection connection;
-	private Predicate<IStatus> filter;
+	private Predicate<LogEntry> filter;
 
 	private String firstRecordedEntryDateString;
 
@@ -75,7 +75,7 @@ public class LogHandler {
 		this(defaultLogFilter);
 	}
 
-	public LogHandler(Predicate<IStatus> filter) {
+	public LogHandler(Predicate<LogEntry> filter) {
 		this.filter = filter;
 	}
 
@@ -135,12 +135,19 @@ public class LogHandler {
 	}
 
 	private void processLogMessage(LogEntry entry) {
+		if ((filter != null && !filter.test(entry)) || (entry.getSeverity() & logLevelMask) == 0) {
+			//no op;
+			return;
+		}
 		// Skip sending to client if current thread is interrupted as that would close the LSP connection to the client !!!
 		if (Thread.currentThread().isInterrupted() || connection == null) {
 			return;
 		}
 		String dateString = this.dateFormat.format(entry.getDate());
-		String message = entry.getMessage() + '\n' + entry.getStack();
+		String message = entry.getMessage();
+		if (entry.getStack() != null) {
+			message = message + '\n' + entry.getStack();
+		}
 
 		connection.logMessage(getMessageTypeFromSeverity(entry.getSeverity()), dateString + ' ' + message);
 		final boolean hasWorkspaceExitedUnsaved = entry.getSeverity() == IStatus.WARNING
@@ -159,44 +166,21 @@ public class LogHandler {
 			}
 		}
 	}
+
 	private void processLogMessage(IStatus status) {
-		if ((filter != null && !filter.test(status)) || !status.matches(this.logLevelMask)) {
-			//no op;
-			return;
-		}
-		// Skip sending to client if current thread is interrupted as that would close the LSP connection to the client !!!
-		if (Thread.currentThread().isInterrupted() || connection == null) {
-			return;
-		}
-		String dateString = this.dateFormat.format(new Date());
-		String message = status.getMessage();
-		String exceptionAsString = null;
+		LogEntry entry = new LogEntry();
+		entry.setMessage(status.getMessage());
+		entry.setSeverity(status.getSeverity());
+		entry.setDate(new Date());
+		entry.setPluginId(status.getPlugin());
 		if (status.getException() != null) {
 			StringWriter sw = new StringWriter();
 			status.getException().printStackTrace(new PrintWriter(sw));
-			exceptionAsString = sw.toString();
-			message = message + '\n' + exceptionAsString;
-		} else if (message.startsWith(BUILD_ERROR_MSG_DETAILS)) {
-			exceptionAsString = message.substring(BUILD_ERROR_MSG_DETAILS_LENGTH).trim();
+			entry.setStack(sw.toString());
+		} else if (status.getMessage() != null && status.getMessage().startsWith(BUILD_ERROR_MSG_DETAILS)) {
+			entry.setStack(status.getMessage().substring(BUILD_ERROR_MSG_DETAILS_LENGTH).trim());
 		}
-
-		connection.logMessage(getMessageTypeFromSeverity(status.getSeverity()), dateString + ' ' + message);
-
-		final boolean hasWorkspaceExitedUnsaved = status.getSeverity() == IStatus.WARNING
-				&& status.getMessage().contains("workspace exited with unsaved changes in the previous session");
-		// Send a trace event to client
-		if (status.getSeverity() == IStatus.ERROR || hasWorkspaceExitedUnsaved) {
-			JsonObject properties = new JsonObject();
-			properties.addProperty("message", redact(status.getMessage()));
-			if (exceptionAsString != null) {
-				properties.addProperty("exception", exceptionAsString);
-			}
-			int hashCode = properties.hashCode();
-			if (!knownErrors.contains(hashCode)) {
-				knownErrors.add(hashCode);
-				connection.telemetryEvent(new TelemetryEvent(JAVA_ERROR_LOG, properties));
-			}
-		}
+		processLogMessage(entry);
 	}
 
 	private String redact(String message) {


### PR DESCRIPTION
Live log messages went through a filter before being sent to the client, but messages replayed from disk (from before the listener was registered) skipped the filter entirely, letting messages the filter was meant to hide leak through.

This converts live messages into a LogEntry before processing, so both paths now go through the same filter and log-level check.

Fixes #3541