### PR TITLE
Update lombok to the latest version

### DIFF
--- a/org.eclipse.jdt.ls.tests/pom.xml
+++ b/org.eclipse.jdt.ls.tests/pom.xml
@@ -93,7 +93,7 @@
 				</property>
 			</activation>
 			<properties>
-				<lombokArgs>-javaagent:${basedir}/lib/lombok-1.18.36.jar</lombokArgs>
+				<lombokArgs>-javaagent:${basedir}/lib/lombok-1.18.48.jar</lombokArgs>
 			</properties>
 			<build>
 				<plugins>
@@ -105,7 +105,7 @@
 								<artifactItem>
 									<groupId>org.projectlombok</groupId>
 									<artifactId>lombok</artifactId>
-									<version>1.18.36</version>
+									<version>1.18.48</version>
 								</artifactItem>
 							</artifactItems>
 						</configuration>

--- a/org.eclipse.jdt.ls.tests/projects/maven/mavenlombok/pom.xml
+++ b/org.eclipse.jdt.ls.tests/projects/maven/mavenlombok/pom.xml
@@ -12,7 +12,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.32</version>
+            <version>1.18.48</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- Update the version used in the test project
- Update the copy of the agent that's downloaded for use during tests
- Blocked on https://github.com/projectlombok/lombok/issues/4080 (we'll likely need to update to 1.18.49)